### PR TITLE
Add contributor and security policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Bijdragen
+
+Dank je wel voor je interesse in e-KS! We ontwikkelen e-KS open source omdat dit de transparantie bevordert. We zijn altijd nieuwsgierig naar nieuwe perspectieven of invalshoeken, dus alle bijdragen zijn welkom.
+
+Voor de duidelijkheid: de Kiesraad heeft concrete plannen en doelstellingen met e-KS, en die zijn leidend. Hierdoor is het goed mogelijk dat een waardevolle bijdrage uit de community toch niet kan worden meegenomen, omdat we anders beloofde dingen niet op tijd waar kunnen maken.
+
+# Status
+
+⚠️  Op dit moment is dit project in de opstart fase 🚧
+
+Hierdoor is het te vroeg voor concrete bijdragen aan de broncode. Op enig moment zullen we wel bijdragen accepteren; hiervoor zullen we je dan vragen om een Contributor Licence Agreement (CLA) te tekenen, met name om het gebruiksrecht op je bijdrage eenduidig te regelen. Dit hoef je dan maar één keer te doen.
+
+## Hoe kun je bijdragen?
+
+- Je kunt een [issue aanmaken](https://github.com/kiesraad/e-KS/issues) op deze repository. Klik rechtsboven op **New issue** en kies dan **Blank issue**. Vervolgens geef je het issue een heldere titel en een duidelijke beschrijving. Selecteer bij **Label** ook het type issue, vooral bij een bug is dit handig. Klik tot slot op **Create**.
+- Als je naar een specifieke pull request of issue kijkt, kun je vragen of opmerkingen daar toevoegen in een comment.
+
+## Beveiliging
+
+Op dit moment is deze repository volop in ontwikkeling en nog **niet** bedoeld voor actief gebruik. Het kan zijn dat bepaalde beveiligingsmaatregelen in de programmatuur nog niet zijn aangebracht. Als je iets tegenkomt wat niet in orde lijkt, mag dit op de gebruikelijke manier gemeld worden via de [issue tracker](https://github.com/kiesraad/e-KS/issues).
+
+Beveiligingsmeldingen die niet te maken hebben met de content van deze repository, vragen we je te melden conform ons [beveiligingsbeleid](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Beveiliging
+
+Bij de Kiesraad vinden we beveiliging belangrijk. Alle meldingen met betrekking tot beveiliging zijn daarom uiteraard welkom.
+ 
+## Status van het project
+
+⚠️  Op dit moment is dit project in de opstart fase, en niet bedoeld voor actief gebruik. 🚧
+
+## Vragen of opmerkingen
+
+Als je een vraag of opmerking over security hebt, kun je het team bereiken via e-ks[@]tweedegolf.nl. Je ontvangt dan tijdig antwoord en het kan zijn dat we om extra informatie vragen.
+
+## Een beveiligingsprobleem melden
+
+We waarderen het als je (ernstige) beveiligingsproblemen op een verantwoorde manier (dus niet openbaar) meldt volgens het *responsible disclosure*-principe. Voor het melden van een beveiligingsprobleem kun je direct contact opnemen met onze CISO via security[@]kiesraad.nl.


### PR DESCRIPTION
Boilerplate documentation; taken from the Abacus project but with some content removed that is not applicable at the moment.