### PR TITLE
Configure Dependabot for GitHub Actions and Cargo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 5
+    groups:
+      github-actions:
+        patterns: ["*"]
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 5
+      semver-major-days: 21
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      cargo:
+        patterns: ["*"]
+    allow:
+      - dependency-type: all
+    ignore:
+      # New axum major and minor versions usually have breaking changes, see #790 for axum 0.8
+      - dependency-name: "axum"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "axum-extra"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]


### PR DESCRIPTION
Dependabot is going to make a PR with version updates on a weekly basis. Based on the configuration in Abacus.

Fixes #8 