### PR TITLE
Fix: Add cargo install for sqlx cli to setup script

### DIFF
--- a/src/bin/setup.rs
+++ b/src/bin/setup.rs
@@ -48,6 +48,9 @@ async fn main() -> Result<()> {
     println!("📚 Installing cargo-watch (if it is not yet installed)...");
     config.commands.install_cargo_watch.run().await?;
 
+    println!("📚 Installing cargo-sqlx (if it is not yet installed)...");
+    config.commands.install_cargo_sqlx.run().await?;
+
     wait_for_postgres().await?;
 
     println!("🚚 Running sqlx migrations and loading fixtures...");
@@ -77,6 +80,7 @@ struct CommandsConfig {
     docker_compose_rm: CommandConfig,
     docker_compose_up: CommandConfig,
     install_cargo_watch: CommandConfig,
+    install_cargo_sqlx: CommandConfig,
     esbuild_bundle: CommandConfig,
     load_fixtures: CommandConfig,
 }

--- a/src/dev/setup.yml
+++ b/src/dev/setup.yml
@@ -47,3 +47,8 @@ commands:
     args:
       - install
       - cargo-watch
+  install_cargo_sqlx:
+    command: cargo
+    args:
+      - install
+      - sqlx-cli


### PR DESCRIPTION
The sqlx cargo binary is neccesary to run migrations and prepare queries. 

This PR includes the installation of the sqlx cli in the setup script such that it is not assumed to be installed on a development machine.