### PR TITLE
Do not fail compilation on missing translation during development

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,28 +12,26 @@ documentation = "https://kiesraad.github.io/e-KS/e_ks/"
 repository = "https://github.com/kiesraad/e-KS"
 
 [features]
-default = ["dotenv", "livereload", "dev-features", "anyhow", "http-logging"]
+default = ["livereload", "dev-features", "http-logging"]
 memory-serve = ["dep:memory-serve"]
-dotenv = ["dep:dotenvy"]
 fixtures = []
 livereload = []
-dev-features = []
+dev-features = ["dep:anyhow", "dep:dotenvy"]
 http-logging = ["dep:tower-http"]
-anyhow = ["dep:anyhow"]
 
 [[bin]]
 name = "fixtures"
-required-features = ["fixtures", "anyhow"]
+required-features = ["fixtures", "dev-features"]
 test = false
 
 [[bin]]
 name = "development"
-required-features = ["anyhow"]
+required-features = ["dev-features"]
 test = false
 
 [[bin]]
 name = "setup"
-required-features = ["anyhow"]
+required-features = ["dev-features"]
 test = false
 
 [dependencies]

--- a/build.rs
+++ b/build.rs
@@ -58,11 +58,23 @@ fn load_locales() {
 
         flatten_yaml("", &docs[0], &mut file);
 
+        #[cfg(feature = "dev-features")]
         writeln!(
             file,
             "($other:literal) => {{
-            ::core::compile_error!(concat!(\"unknown translation key: \", $other));
-        }};\n}}\npub use inner_t_{} as t_{};\n",
+                concat!(\"[\", $other, \"]\")
+            }};\n}}\npub use inner_t_{} as t_{};\n",
+            lang.to_lowercase(),
+            lang.to_lowercase()
+        )
+        .unwrap();
+
+        #[cfg(not(feature = "dev-features"))]
+        writeln!(
+            file,
+            "($other:literal) => {{
+                ::core::compile_error!(concat!(\"unknown translation key: \", $other))
+            }};\n}}\npub use inner_t_{} as t_{};\n",
             lang.to_lowercase(),
             lang.to_lowercase()
         )

--- a/src/bin/eks.rs
+++ b/src/bin/eks.rs
@@ -3,7 +3,7 @@ use eks::{AppError, AppState, logging, router, server};
 #[tokio::main]
 async fn main() -> Result<(), AppError> {
     // Load environment variables from a .env file if present
-    #[cfg(feature = "dotenv")]
+    #[cfg(feature = "dev-features")]
     dotenvy::dotenv().ok();
 
     // Initialize tracing subscriber (logging)

--- a/src/bin/fixtures.rs
+++ b/src/bin/fixtures.rs
@@ -4,7 +4,7 @@ use eks::{AppState, fixtures, logging};
 #[tokio::main]
 async fn main() -> Result<()> {
     // Load environment variables from a .env file if present
-    #[cfg(feature = "dotenv")]
+    #[cfg(feature = "dev-features")]
     dotenvy::dotenv().ok();
 
     // Initialize tracing subscriber (logging)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 
-{% block page_title %}Overzicht{% endblock %}
+{% block page_title %}{{ t!("common.general_information")|trans }}{% endblock %}
 {% block overview_nav_class %}active{% endblock %}
 
 {% block content %}


### PR DESCRIPTION
- Simplify cargo features
- Do not panic on missing translation when `dev-features` is enabled