### PR TITLE
Do not set Helm chart version in test deployment

### DIFF
--- a/.github/workflows/deploy-test.yaml
+++ b/.github/workflows/deploy-test.yaml
@@ -144,7 +144,7 @@ jobs:
       - name: Set the current version in the Helm chart
         uses: mikefarah/yq@master
         with:
-          cmd: yq -i '.version="${{ needs.rust.outputs.tag }}" | .appVersion="${{ needs.rust.outputs.tag }}"' deploy/e-ks/Chart.yaml
+          cmd: yq -i '.appVersion="${{ needs.rust.outputs.tag }}"' deploy/e-ks/Chart.yaml
       - name: Create namespace
         shell: bash
         run: |


### PR DESCRIPTION
Setting the `chartVersion` to a non-SemVer string will fail the deployment, as seen in https://github.com/kiesraad/e-ks/actions/runs/20914325935/job/60084309353