### PR TITLE
Implement redesign candidate list cards

### DIFF
--- a/src/persons/pages/list.rs
+++ b/src/persons/pages/list.rs
@@ -3,7 +3,7 @@ use axum::response::IntoResponse;
 
 use crate::{
     AppError, Context, HtmlTemplate, filters,
-    persons::{PersonPagination, PersonSort, pages::PersonsPath},
+    persons::{Person, PersonPagination, PersonSort, pages::PersonsPath},
     t,
 };
 

--- a/templates/persons/list.html
+++ b/templates/persons/list.html
@@ -4,6 +4,18 @@
 {% block persons_nav_class %}active{% endblock %}
 
 {% block content %}
+<nav class="sticky-nav">
+  <div class="sticky-nav-bar">
+    <div></div>
+    <div>
+      <div class="buttons">
+        <a href="{{ Person::new_path() }}" class="button secondary icon-plus" type="button">
+          {{ t!("person.actions.add")|trans }}
+        </a>
+      </div>
+    </div>
+  </div>
+</nav>
 {% if person_pagination.persons.is_empty() %}
 <section>
   <p>{{ t!("person.list.empty")|trans }}</p>


### PR DESCRIPTION
Fix #156 

- Clickable cards
- Optimise SVG icons (sorry)
- Grid layout
- Other icons
- Automatic list names ("Groningen, Friesland")
- Column list view of electoral districts

<img width="1445" height="896" alt="Screenshot From 2026-01-22 15-37-17" src="https://github.com/user-attachments/assets/02f1a456-98da-4e82-b585-4647c9ca31de" />

<img width="1835" height="923" alt="Screenshot From 2026-01-22 15-36-56" src="https://github.com/user-attachments/assets/b6da2c7d-785e-4895-b205-1812154a9e00" />
