### PR TITLE
Explicitly add whole directory as src for sonarqube

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,3 +3,4 @@ sonar.organization=kiesraad
 sonar.tests=playwright/tests
 sonar.test.inclusions=playwright/tests/**/*.spec.ts
 sonar.exclusions=target/**,frontend/static/**,**/node_modules/**,**/playwright-report/**,**/playwright/test-results/**
+sonar.sources=./


### PR DESCRIPTION
After merging cdcd3e68, apparently SonarQube does not analyze most of the code anymore. I hope explicitly adding the whole directory as sources fixes that.