### PR TITLE
Write PW report to disk in GH action

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -155,8 +155,9 @@ jobs:
 
       - name: Run playwright tests
         run: bin/test
+
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         if: ${{ !cancelled() }}
         with:
           name: playwright-report

--- a/playwright/compose.yml
+++ b/playwright/compose.yml
@@ -4,6 +4,7 @@ services:
       dockerfile: docker/playwright.Dockerfile
     volumes:
       - ./tests:/app/tests
+      - ./playwright-report:/app/playwright-report
       - ../frontend:/frontend:ro
     environment:
       PLAYWRIGHT_TEST_BASE_URL: http://application:3000


### PR DESCRIPTION
Mount `playwright/playwright-report/` directory when running playwright using docker compose. This allows us to access the report when running in Github actions.