### PR TITLE
Exclude TS from codecoverage in sonarqube

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Filter changes for non-Markdown files
         id: filter
         run: | 
-          if [[ $(git diff --name-only "origin/${{ github.base_ref }}" HEAD | grep -v "\.md$") ]]  ; then 
+          if [[ "${{ github.ref_name }}" == "main" ]] || [[ $(git diff --name-only "origin/${{ github.base_ref }}" HEAD | grep -v "\.md$") ]]  ; then 
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -130,7 +130,6 @@ jobs:
     timeout-minutes: 60
     env:
       CARGO_TERM_COLOR: always
-      PLAYWRIGHT_BROWSERS_PATH: .cache/playwright
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,3 +5,4 @@ sonar.test.inclusions=playwright/tests/**/*.ts
 sonar.exclusions=target/**,frontend/static/**,**/node_modules/**,**/playwright-report/**,**/playwright/test-results/**
 sonar.sources=./
 sonar.plsql.file.suffixes=tab,pkb
+sonar.coverage.exclusions=**/*.ts


### PR DESCRIPTION
After a lot of back-and-forth, I think, the best is to exclude the TS files from the code coverage calculation for now. It seems that the tooling around TS coverage, especially in combination with Playwright, is not really existent right now. Our best bet would be <https://istanbul.js.org/>, but that's designed for unit tests, which we currently don't have for our TS files. It might be usable in combination with the [coverage API](https://playwright.dev/docs/api/class-coverage) in playwright, but I did not succeed within a reasonable timeframe.