### PR TITLE
Add security headers

### DIFF
--- a/deploy/e-ks/templates/httpRoute.yaml
+++ b/deploy/e-ks/templates/httpRoute.yaml
@@ -57,7 +57,14 @@ spec:
           extensionRef:
             group: traefik.io
             kind: Middleware
+            name: security-headers
+  {{- if .Values.requireLogin }}
+        - type: ExtensionRef
+          extensionRef:
+            group: traefik.io
+            kind: Middleware
             name: auth
+  {{- end }}
 
       backendRefs:
         - name: eks
@@ -75,3 +82,20 @@ spec:
         namespace: ingress
       - name: test-auth
         namespace: ingress
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: security-headers
+  namespace: {{ .Release.Namespace }}
+spec:
+  headers:
+    frameDeny: true
+    contentTypeNosniff: true
+    contentSecurityPolicy: "default-src 'none'; base-uri 'none'; form-action 'self'; script-src 'self'; style-src 'self'; font-src 'self'; img-src 'self'; frame-ancestors 'none';"
+    referrerPolicy: same-origin
+
+    forceSTSHeader: true
+    stsIncludeSubdomains: true
+    stsSeconds: 31536000
+    stsPreload: false # in production, we should consider setting this to true

--- a/deploy/e-ks/values.yaml
+++ b/deploy/e-ks/values.yaml
@@ -1,5 +1,6 @@
 hostname: "eks-test.nl"
 subdomain: "<branchname>"
+requireLogin: true
 
 db:
   setup: false


### PR DESCRIPTION
Additionally, I've added CAA entries to our DNS:

```shell
max@max-xps:~$ dig +short CAA eks-test.nl.
128 issuemail ";"
128 issuewild "letsencrypt.org;validationmethods=dns-01"
128 issue "letsencrypt.org;validationmethods=dns-01"
0 iodef "mailto:security@tweedegolf.com"
128 issuevmc ";"

```