### PR TITLE
Fix security headers for OAuthLogin

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -11,6 +11,8 @@ set -euo pipefail
     --loader:.svg=file \
     --public-path=/static/
 
+cp frontend/favicon.svg frontend/static/favicon.svg
+
 cargo build \
     --features memory-serve \
     --no-default-features \

--- a/deploy/e-ks/templates/httpRoute.yaml
+++ b/deploy/e-ks/templates/httpRoute.yaml
@@ -92,7 +92,7 @@ spec:
   headers:
     frameDeny: true
     contentTypeNosniff: true
-    contentSecurityPolicy: "default-src 'none'; base-uri 'none'; form-action 'self'; script-src 'self'; style-src 'self'; font-src 'self'; img-src 'self'; frame-ancestors 'none';"
+    contentSecurityPolicy: "default-src 'none'; base-uri 'none'; form-action 'self' https://github.com/login/oauth/authorize; script-src 'self'; style-src 'self' 'unsafe-hashes' 'sha256-f5JbnZ2wnky3B/YgIC+GaLDK8cBvQj7OEOASYhBjUYA=' 'sha256-be2laphxFXcKr/3rNHrcGPm2jpf+OrcryYe8Gxt//J8='; font-src 'self'; img-src 'self'; frame-ancestors 'none';"
     referrerPolicy: same-origin
 
     forceSTSHeader: true

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Kiesraad - Kandidaatstelling</title>
-  <link rel="icon" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI3NSIgaGVpZ2h0PSI3NSIgdmlld0JveD0iMCAwIDc1IDc1IiBmaWxsPSJub25lIj4KICA8cGF0aCBkPSJNMzcuNSAwTDY5Ljk3NiAxOC43NVY1Ni4yNUwzNy41IDc1TDUuMDI0MDUgNTYuMjVWMTguNzVMMzcuNSAwWiIgZmlsbD0iIzExMzA1MSIvPgogIDxwYXRoIGQ9Ik0zNy45MTEzIDM3LjVMNTYuMjQ5NCAyMC4zNjUxTDUwLjIxNTYgMTYuOTM4MUwzMS41MjI1IDMzLjgzNjdIMzAuNDU3N1YyMi4yNTU4VjE3Ljg4MzRMMjYuNzkwMSAxNS43NTYzTDIzLjAwNDIgMTcuODgzNFYxOC40NzQzVjIyLjI1NThWNTkuMjQzN0gzMC40NTc3VjQxLjM5OTdIMzEuNTIyNUw1MC4zMzM5IDU5LjI0MzdMNTYuNzIyNiA1NS41ODA0TDM3LjkxMTMgMzcuNVoiIGZpbGw9IndoaXRlIi8+Cjwvc3ZnPg==" />
+  <link rel="icon" href="/static/favicon.svg" />
   <link rel="stylesheet" href="/static/index.css?{{ filters::cache_buster() }}" />
   {% if Context::livereload_enabled() %}<script src="/livereload/poll.js"></script>{% endif %}
   <script src="/static/index.js?{{ filters::cache_buster() }}" defer></script>


### PR DESCRIPTION
This PR fixes some issues with the CSP:

- GitHub OAuth did not work on Chrome, while working fine on Firefox, because Chrome interprets the redirect to GitHub as a form submission,n which wasn't allowed.
- Fix styling of the login page. This uses 'unsafe-hashes' to allow the inline style of the login page. This must be removed for the production deployment. Alternatively, we could ignore styling and remove the `unsafe-hashes` already.
- Fetches the favicon from the server instead of including it in the HTML as `data` as this is not allowed by the CSP