### PR TITLE
Fix saving a political group with empty long list checkbox

### DIFF
--- a/src/core/political_groups/structs/political_group_form.rs
+++ b/src/core/political_groups/structs/political_group_form.rs
@@ -9,6 +9,7 @@ use crate::{
 #[validate(target = "PoliticalGroup")]
 pub struct PoliticalGroupForm {
     #[validate(parse = "bool", optional)]
+    #[serde(default)]
     pub long_list_allowed: String,
     #[validate(parse = "LegalName", optional)]
     pub legal_name: String,


### PR DESCRIPTION
Fix error page when submitting political group without a "long list" radio button selection.