### PR TITLE
Prefer struct methods over direct store updates + cleanup

### DIFF
--- a/src/core/authorised_agents/extractors/authorised_agent.rs
+++ b/src/core/authorised_agents/extractors/authorised_agent.rs
@@ -43,7 +43,7 @@ mod tests {
     use tower::ServiceExt;
 
     use crate::{
-        AppEvent, AppState,
+        AppState,
         test_utils::{response_body_string, sample_authorised_agent},
     };
 
@@ -52,11 +52,10 @@ mod tests {
         let authorised_agent = sample_authorised_agent(AuthorisedAgentId::new());
 
         let app_state = AppState::new_for_tests().await;
-        app_state
-            .store
-            .update(AppEvent::CreateAuthorisedAgent(authorised_agent.clone()))
+        authorised_agent
+            .create(&app_state.store)
             .await
-            .unwrap();
+            .expect("create authorised agent");
 
         let app = Router::new()
             .route(

--- a/src/core/authorised_agents/structs/authorised_agent.rs
+++ b/src/core/authorised_agents/structs/authorised_agent.rs
@@ -19,10 +19,6 @@ impl AuthorisedAgent {
         self.name.is_complete()
     }
 
-    pub fn last_name_with_prefix(&self) -> String {
-        self.name.last_name_with_prefix()
-    }
-
     pub async fn create(&self, store: &AppStore) -> Result<(), AppError> {
         store
             .update(AppEvent::CreateAuthorisedAgent(self.clone()))

--- a/src/core/candidate_lists/extractors/candidate_list.rs
+++ b/src/core/candidate_lists/extractors/candidate_list.rs
@@ -42,7 +42,7 @@ mod tests {
     use tower::ServiceExt;
 
     use crate::{
-        AppEvent, AppState, Locale,
+        AppState, Locale,
         candidate_lists::CandidateListId,
         render_error_pages,
         test_utils::{response_body_string, sample_candidate_list},
@@ -54,11 +54,9 @@ mod tests {
         let list = sample_candidate_list(CandidateListId::new());
 
         let app_state = AppState::new_for_tests().await;
-        app_state
-            .store
-            .update(AppEvent::CreateCandidateList(list.clone()))
+        list.create(&app_state.store)
             .await
-            .unwrap();
+            .expect("create candidate list");
 
         let app = Router::new()
             .route(

--- a/src/core/candidate_lists/extractors/full_candidate_list.rs
+++ b/src/core/candidate_lists/extractors/full_candidate_list.rs
@@ -42,8 +42,8 @@ mod tests {
     use tower::ServiceExt;
 
     use crate::{
-        AppEvent, AppState, Locale,
-        candidate_lists::{CandidateList, CandidateListId},
+        AppState, Locale,
+        candidate_lists::CandidateListId,
         persons::PersonId,
         render_error_pages,
         test_utils::{response_body_string, sample_candidate_list, sample_person},
@@ -56,20 +56,17 @@ mod tests {
         let person = sample_person(PersonId::new());
 
         let app_state = AppState::new_for_tests().await;
-        app_state
-            .store
-            .update(AppEvent::CreateCandidateList(list.clone()))
+        list.create(&app_state.store)
             .await
-            .unwrap();
-        app_state
-            .store
-            .update(AppEvent::CreatePerson(person.clone()))
+            .expect("create candidate list");
+        person
+            .create(&app_state.store)
             .await
-            .unwrap();
-
-        CandidateList::update_order(&app_state.store, list_id, &[person.id])
+            .expect("create person");
+        list.clone()
+            .update_order(&app_state.store, &[person.id])
             .await
-            .unwrap();
+            .expect("update candidate list order");
 
         let app = Router::new()
             .route(

--- a/src/core/candidate_lists/pages/create.rs
+++ b/src/core/candidate_lists/pages/create.rs
@@ -52,15 +52,7 @@ pub async fn create_candidate_list_submit(
     State(store): State<AppStore>,
     Form(form): Form<CandidateListCreateForm>,
 ) -> Result<Response, AppError> {
-    let previous_candidates = if form.copy_candidates {
-        store
-            .get_candidate_lists()?
-            .last()
-            .map(|list| list.candidates.clone())
-    } else {
-        None
-    };
-
+    let should_copy_candidates = form.copy_candidates;
     match form.validate_create(&context.csrf_tokens) {
         Err(form_data) => Ok(HtmlTemplate(
             CandidateListCreateTemplate {
@@ -70,14 +62,16 @@ pub async fn create_candidate_list_submit(
             context,
         )
         .into_response()),
-        Ok(candidate_list) => {
-            candidate_list.create(&store).await?;
-
-            if let Some(candidates) = previous_candidates
-                && !candidates.is_empty()
-            {
-                CandidateList::update_order(&store, candidate_list.id, &candidates).await?;
+        Ok(mut candidate_list) => {
+            if should_copy_candidates {
+                candidate_list.candidates = store
+                    .get_candidate_lists()?
+                    .last()
+                    .map(|list| list.candidates.clone())
+                    .unwrap_or_default();
             }
+
+            candidate_list.create(&store).await?;
 
             Ok(Redirect::to(&candidate_list.after_create_path()).into_response())
         }
@@ -187,18 +181,14 @@ mod test {
         let context = Context::new_test_without_db();
         let csrf_token = context.csrf_tokens.issue().value;
         let list_id = CandidateListId::new();
-        let list = sample_candidate_list(list_id);
+        let mut list = sample_candidate_list(list_id);
         let person_a = sample_person(PersonId::new());
         let person_b = sample_person(PersonId::new());
 
+        person_a.create(&store).await?;
+        person_b.create(&store).await?;
+        list.candidates = vec![person_a.id, person_b.id];
         list.create(&store).await?;
-        store
-            .update(crate::AppEvent::CreatePerson(person_a.clone()))
-            .await?;
-        store
-            .update(crate::AppEvent::CreatePerson(person_b.clone()))
-            .await?;
-        CandidateList::update_order(&store, list_id, &[person_a.id, person_b.id]).await?;
 
         let form = CandidateListCreateForm {
             electoral_districts: vec![ElectoralDistrict::DR],

--- a/src/core/candidate_lists/pages/delete.rs
+++ b/src/core/candidate_lists/pages/delete.rs
@@ -20,7 +20,8 @@ pub async fn delete_candidate_list(
     match form.validate_create(&context.csrf_tokens) {
         Err(_) => Ok(Redirect::to(&candidate_list.update_path()).into_response()),
         Ok(_) => {
-            CandidateList::delete_by_id(&store, candidate_list.id).await?;
+            candidate_list.delete(&store).await?;
+
             Ok(Redirect::to(&CandidateList::list_path()).into_response())
         }
     }

--- a/src/core/candidate_lists/pages/list_submitter.rs
+++ b/src/core/candidate_lists/pages/list_submitter.rs
@@ -7,10 +7,7 @@ use axum_extra::extract::Form;
 
 use crate::{
     AppError, AppStore, Context, HtmlTemplate, InitialQuery,
-    candidate_lists::{
-        CandidateList, ListSubmitterForm,
-        pages::{UpdateListSubmitterPath, UpdateSubstituteListSubmittersPath},
-    },
+    candidate_lists::{CandidateList, ListSubmitterForm, pages::UpdateListSubmitterPath},
     filters,
     form::FormData,
     list_submitters::ListSubmitter,
@@ -76,29 +73,6 @@ pub async fn update_list_submitter(
     )
 }
 
-pub async fn update_substitute_list_submitters(
-    _: UpdateSubstituteListSubmittersPath,
-    context: Context,
-    candidate_list: CandidateList,
-    State(store): State<AppStore>,
-    Query(query): Query<InitialQuery>,
-) -> Result<Response, AppError> {
-    let form = FormData::new_with_data(
-        ListSubmitterForm::from(candidate_list.clone()),
-        &context.csrf_tokens,
-    );
-    let form_action = candidate_list.update_substitute_list_submitters_path();
-
-    render_submitter_form(
-        context,
-        candidate_list,
-        &store,
-        query.should_warn(),
-        form,
-        form_action,
-    )
-}
-
 pub async fn update_list_submitter_submit(
     _: UpdateListSubmitterPath,
     context: Context,
@@ -120,32 +94,7 @@ pub async fn update_list_submitter_submit(
         ),
         Ok(candidate_list) => {
             candidate_list.update(&store).await?;
-            Ok(Redirect::to(&candidate_list.view_path()).into_response())
-        }
-    }
-}
 
-pub async fn update_substitute_list_submitters_submit(
-    _: UpdateSubstituteListSubmittersPath,
-    context: Context,
-    candidate_list: CandidateList,
-    State(store): State<AppStore>,
-    Query(query): Query<InitialQuery>,
-    Form(form): Form<ListSubmitterForm>,
-) -> Result<Response, AppError> {
-    let form_action = candidate_list.update_substitute_list_submitters_path();
-
-    match form.validate_update(&candidate_list, &context.csrf_tokens) {
-        Err(form_data) => render_submitter_form(
-            context,
-            candidate_list,
-            &store,
-            query.should_warn(),
-            form_data,
-            form_action,
-        ),
-        Ok(candidate_list) => {
-            candidate_list.update(&store).await?;
             Ok(Redirect::to(&candidate_list.view_path()).into_response())
         }
     }
@@ -210,91 +159,6 @@ mod tests {
         assert!(body.contains(list_submitter.name.initials.as_str()));
         assert!(body.contains(substitute_submitter.name.last_name.as_str()));
         assert!(body.contains(substitute_submitter.name.initials.as_str()));
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn update_substitute_list_submitters_renders_submitter_form() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let candidate_list = sample_candidate_list(CandidateListId::new());
-        let list_submitter = sample_list_submitter(ListSubmitterId::new());
-        let substitute_submitter = sample_substitute_submitter(SubstituteSubmitterId::new());
-        let political_group = sample_political_group(PoliticalGroupId::new());
-
-        candidate_list.create(&store).await?;
-        political_group.create(&store).await?;
-        list_submitter.create(&store).await?;
-        substitute_submitter.create(&store).await?;
-
-        let context = Context::new(political_group.clone(), Locale::En, CsrfTokens::default());
-
-        let response = update_substitute_list_submitters(
-            UpdateSubstituteListSubmittersPath {
-                list_id: candidate_list.id,
-            },
-            context,
-            candidate_list.clone(),
-            State(store),
-            Query(InitialQuery::default()),
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(response.status(), StatusCode::OK);
-        let body = response_body_string(response).await;
-        assert!(body.contains("Submitter of the list"));
-        assert!(body.contains("Substitute list submitters"));
-        assert!(body.contains("csrf_token"));
-        assert!(body.contains(&candidate_list.update_substitute_list_submitters_path()));
-        assert!(body.contains(list_submitter.name.last_name.as_str()));
-        assert!(body.contains(list_submitter.name.initials.as_str()));
-        assert!(body.contains(substitute_submitter.name.last_name.as_str()));
-        assert!(body.contains(substitute_submitter.name.initials.as_str()));
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn update_substitute_list_submitters_shows_warnings_when_not_initial()
-    -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let candidate_list = sample_candidate_list(CandidateListId::new());
-        let list_submitter = sample_list_submitter(ListSubmitterId::new());
-        let substitute_submitter = sample_substitute_submitter(SubstituteSubmitterId::new());
-        let political_group = sample_political_group(PoliticalGroupId::new());
-
-        candidate_list.create(&store).await?;
-        political_group.create(&store).await?;
-        list_submitter.create(&store).await?;
-        substitute_submitter.create(&store).await?;
-
-        let context = Context::new(political_group.clone(), Locale::En, CsrfTokens::default());
-        let query: InitialQuery =
-            serde_urlencoded::from_str("initial=false").expect("initial query");
-
-        let response = update_substitute_list_submitters(
-            UpdateSubstituteListSubmittersPath {
-                list_id: candidate_list.id,
-            },
-            context,
-            candidate_list.clone(),
-            State(store),
-            Query(query),
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(response.status(), StatusCode::OK);
-        let body = response_body_string(response).await;
-        assert!(body.contains(&format!(
-            "href=\"{}\" class=\"ok\"",
-            candidate_list.update_path()
-        )));
-        assert!(body.contains(&format!(
-            "href=\"{}\" class=\"warning\"",
-            candidate_list.update_list_submitter_path()
-        )));
 
         Ok(())
     }
@@ -372,74 +236,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn update_substitute_list_submitters_persists_and_redirects() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let political_group = sample_political_group(PoliticalGroupId::new());
-        political_group.create(&store).await?;
-        let context = Context::new(political_group.clone(), Locale::En, CsrfTokens::default());
-        let csrf_token = context.csrf_tokens.issue().value;
-        let creation_date = UtcDateTime::now();
-        let candidate_list = CandidateList {
-            electoral_districts: vec![ElectoralDistrict::UT],
-            created_at: creation_date,
-            updated_at: creation_date,
-            ..Default::default()
-        };
-        let list_submitter = sample_list_submitter(ListSubmitterId::new());
-        let substitute_submitter_a = sample_substitute_submitter(SubstituteSubmitterId::new());
-        let substitute_submitter_b = sample_substitute_submitter(SubstituteSubmitterId::new());
-
-        candidate_list.create(&store).await?;
-        list_submitter.create(&store).await?;
-        substitute_submitter_a.create(&store).await?;
-        substitute_submitter_b.create(&store).await?;
-
-        let form = ListSubmitterForm {
-            list_submitter_id: list_submitter.id.to_string(),
-            substitute_list_submitter_ids: vec![
-                substitute_submitter_a.id,
-                substitute_submitter_b.id,
-            ],
-            csrf_token,
-        };
-        let response = update_substitute_list_submitters_submit(
-            UpdateSubstituteListSubmittersPath {
-                list_id: candidate_list.id,
-            },
-            context,
-            candidate_list.clone(),
-            State(store.clone()),
-            Query(InitialQuery::default()),
-            Form(form),
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(response.status(), StatusCode::SEE_OTHER);
-        let location = response
-            .headers()
-            .get(header::LOCATION)
-            .expect("location header")
-            .to_str()
-            .expect("location header value");
-
-        let lists = CandidateListSummary::list(&store)?;
-        assert_eq!(lists.len(), 1);
-
-        let updated_list = &lists[0].list;
-
-        assert_eq!(updated_list.view_path(), location);
-        assert_eq!(candidate_list.id, updated_list.id);
-        assert_eq!(list_submitter.id, updated_list.list_submitter_id.unwrap());
-        assert_eq!(
-            vec![substitute_submitter_a.id, substitute_submitter_b.id],
-            updated_list.substitute_list_submitter_ids
-        );
-
-        Ok(())
-    }
-
-    #[tokio::test]
     async fn update_list_submitters_invalid_form_renders_template() -> Result<(), AppError> {
         let store = AppStore::new_for_test().await;
         let political_group = sample_political_group(PoliticalGroupId::new());
@@ -475,57 +271,6 @@ mod tests {
         let body = response_body_string(response).await;
         assert!(body.contains("Submitter of the list"));
         assert!(body.contains("Substitute list submitters"));
-
-        let lists = CandidateListSummary::list(&store)?;
-        assert_eq!(lists.len(), 1);
-
-        let updated_list = &lists[0].list;
-
-        // verify candidate list didn't update in database
-        assert!(updated_list.list_submitter_id.is_none());
-        assert!(updated_list.substitute_list_submitter_ids.is_empty());
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn update_substitute_list_submitters_invalid_form_renders_template()
-    -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let political_group = sample_political_group(PoliticalGroupId::new());
-        political_group.create(&store).await?;
-        let context = Context::new(political_group.clone(), Locale::En, CsrfTokens::default());
-        let candidate_list = sample_candidate_list(CandidateListId::new());
-        let list_submitter = sample_list_submitter(ListSubmitterId::new());
-        let substitute_submitter = sample_substitute_submitter(SubstituteSubmitterId::new());
-
-        candidate_list.create(&store).await?;
-        list_submitter.create(&store).await?;
-        substitute_submitter.create(&store).await?;
-
-        let form = ListSubmitterForm {
-            list_submitter_id: list_submitter.id.to_string(),
-            substitute_list_submitter_ids: vec![substitute_submitter.id],
-            csrf_token: TokenValue("invalid".to_string()),
-        };
-        let response = update_substitute_list_submitters_submit(
-            UpdateSubstituteListSubmittersPath {
-                list_id: candidate_list.id,
-            },
-            context,
-            candidate_list.clone(),
-            State(store.clone()),
-            Query(InitialQuery::default()),
-            Form(form),
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(StatusCode::OK, response.status());
-        let body = response_body_string(response).await;
-        assert!(body.contains("Submitter of the list"));
-        assert!(body.contains("Substitute list submitters"));
-        assert!(body.contains(&candidate_list.update_substitute_list_submitters_path()));
 
         let lists = CandidateListSummary::list(&store)?;
         assert_eq!(lists.len(), 1);

--- a/src/core/candidate_lists/pages/mod.rs
+++ b/src/core/candidate_lists/pages/mod.rs
@@ -123,8 +123,6 @@ pub fn router() -> Router<AppState> {
         .typed_post(update::update_candidate_list_submit)
         .typed_get(list_submitter::update_list_submitter)
         .typed_post(list_submitter::update_list_submitter_submit)
-        .typed_get(list_submitter::update_substitute_list_submitters)
-        .typed_post(list_submitter::update_substitute_list_submitters_submit)
         .typed_post(delete::delete_candidate_list)
         .typed_post(reorder::reorder_candidate_list)
 }

--- a/src/core/candidate_lists/pages/reorder.rs
+++ b/src/core/candidate_lists/pages/reorder.rs
@@ -13,11 +13,13 @@ pub struct CandidateListReorderPayload {
 
 pub async fn reorder_candidate_list(
     _: CandidateListReorderPath,
-    candidate_list: CandidateList,
+    mut candidate_list: CandidateList,
     State(store): State<AppStore>,
     Json(payload): Json<CandidateListReorderPayload>,
 ) -> Result<impl IntoResponse, AppError> {
-    CandidateList::update_order(&store, candidate_list.id, &payload.person_ids).await?;
+    candidate_list
+        .update_order(&store, &payload.person_ids)
+        .await?;
 
     Ok(StatusCode::NO_CONTENT)
 }
@@ -26,7 +28,7 @@ pub async fn reorder_candidate_list(
 mod tests {
     use super::*;
     use crate::{
-        AppEvent, AppStore,
+        AppStore,
         candidate_lists::{CandidateListId, FullCandidateList},
         persons::PersonId,
         test_utils::{sample_candidate_list, sample_person_with_last_name},
@@ -41,13 +43,11 @@ mod tests {
         let person_b = sample_person_with_last_name(PersonId::new(), "Bakker");
 
         list.create(&store).await?;
-        store
-            .update(AppEvent::CreatePerson(person_a.clone()))
+        person_a.create(&store).await?;
+        person_b.create(&store).await?;
+        list.clone()
+            .update_order(&store, &[person_a.id, person_b.id])
             .await?;
-        store
-            .update(AppEvent::CreatePerson(person_b.clone()))
-            .await?;
-        CandidateList::update_order(&store, list_id, &[person_a.id, person_b.id]).await?;
 
         let response = reorder_candidate_list(
             CandidateListReorderPath { list_id },

--- a/src/core/candidate_lists/pages/update.rs
+++ b/src/core/candidate_lists/pages/update.rs
@@ -60,6 +60,7 @@ pub async fn update_candidate_list_submit(
         .into_response()),
         Ok(candidate_list) => {
             candidate_list.update(&store).await?;
+
             Ok(Redirect::to(&candidate_list.view_path()).into_response())
         }
     }

--- a/src/core/candidate_lists/pages/view.rs
+++ b/src/core/candidate_lists/pages/view.rs
@@ -28,7 +28,7 @@ pub async fn view_candidate_list(
 mod tests {
     use super::*;
     use crate::{
-        AppEvent, AppStore, Context,
+        AppStore, Context,
         candidate_lists::CandidateListId,
         persons::PersonId,
         test_utils::{response_body_string, sample_candidate_list, sample_person},
@@ -43,8 +43,8 @@ mod tests {
         let person = sample_person(PersonId::new());
 
         list.create(&store).await?;
-        store.update(AppEvent::CreatePerson(person.clone())).await?;
-        CandidateList::update_order(&store, list_id, &[person.id]).await?;
+        person.create(&store).await?;
+        list.clone().update_order(&store, &[person.id]).await?;
 
         let full_list = FullCandidateList::get(&store, list_id).expect("candidate list");
 

--- a/src/core/candidate_lists/structs/candidate_list.rs
+++ b/src/core/candidate_lists/structs/candidate_list.rs
@@ -58,68 +58,93 @@ impl CandidateList {
     }
 
     pub async fn update_order(
+        &mut self,
         store: &AppStore,
-        list_id: CandidateListId,
         person_ids: &[PersonId],
-    ) -> Result<FullCandidateList, AppError> {
-        let mut list = store.get_candidate_list(list_id)?;
+    ) -> Result<(), AppError> {
+        let existing_person_ids = store
+            .get_persons()?
+            .iter()
+            .map(|p| p.id)
+            .collect::<BTreeSet<_>>();
 
-        CandidateList::ensure_persons_exist(store, person_ids)?;
+        // check all new ids exist
+        if !person_ids.iter().all(|id| existing_person_ids.contains(id)) {
+            return Err(AppError::GenericNotFound);
+        }
 
-        list.candidates = person_ids.to_vec();
-        list.updated_at = UtcDateTime::now();
+        let mut updated = store.get_candidate_list(self.id)?;
+
+        updated.candidates = person_ids.to_vec();
+        updated.updated_at = UtcDateTime::now();
 
         store
-            .update(AppEvent::UpdateCandidateList(list.clone()))
+            .update(AppEvent::UpdateCandidateList(updated.clone()))
             .await?;
 
-        CandidateList::build_full_candidate_list(store, list)
+        *self = updated;
+
+        Ok(())
+    }
+
+    pub async fn update_position(
+        &mut self,
+        store: &AppStore,
+        id: PersonId,
+        position: usize,
+    ) -> Result<(), AppError> {
+        let Some(current_index) = self.candidates.iter().position(|&pid| pid == id) else {
+            return Ok(());
+        };
+
+        let moved = self.candidates.remove(current_index);
+
+        // convert the position (1, 2, 3...) to an index (0, 1, 2,..) and clamp it to the valid range
+        let target_index = position.saturating_sub(1).min(self.candidates.len());
+
+        self.candidates.insert(target_index, moved);
+
+        self.update_order(store, &self.candidates.clone()).await?;
+
+        Ok(())
     }
 
     pub async fn append_candidate(
+        &mut self,
         store: &AppStore,
-        list_id: CandidateListId,
         person_id: PersonId,
     ) -> Result<(), AppError> {
-        let mut list = store.get_candidate_list(list_id)?;
+        let person = store.get_person(person_id)?;
 
-        CandidateList::ensure_persons_exist(store, &[person_id])?;
-
-        if !list.candidates.contains(&person_id) {
-            list.candidates.push(person_id);
-            list.updated_at = UtcDateTime::now();
-            store.update(AppEvent::UpdateCandidateList(list)).await?;
+        if !self.candidates.contains(&person.id) {
+            self.candidates.push(person.id);
+            self.updated_at = UtcDateTime::now();
+            self.update(store).await?;
         }
 
         Ok(())
     }
 
-    pub async fn remove_candidate_from_list(
+    pub async fn remove_candidate(
+        &mut self,
         store: &AppStore,
-        list_id: CandidateListId,
         person_id: PersonId,
     ) -> Result<(), AppError> {
-        let mut list = store.get_candidate_list(list_id)?;
-
-        if !list.candidates.contains(&person_id) {
-            return Err(AppError::NotFound(
-                "candidate not found on list".to_string(),
-            ));
+        if self.candidates.contains(&person_id) {
+            self.candidates.retain(|id| *id != person_id);
+            self.updated_at = UtcDateTime::now();
+            self.update(store).await?;
         }
-
-        list.candidates.retain(|id| *id != person_id);
-        list.updated_at = UtcDateTime::now();
-        store.update(AppEvent::UpdateCandidateList(list)).await?;
 
         Ok(())
     }
 
     pub async fn get_candidate(
+        &self,
         store: &AppStore,
-        list_id: CandidateListId,
         person_id: PersonId,
     ) -> Result<Candidate, AppError> {
-        let list = store.get_candidate_list(list_id)?;
+        let list = store.get_candidate_list(self.id)?;
 
         let position = list
             .candidates
@@ -131,18 +156,14 @@ impl CandidateList {
         let person = store.get_person(person_id)?;
 
         Ok(Candidate {
-            list_id,
+            list_id: self.id,
             position,
             person,
         })
     }
 
-    pub fn persons_not_on_list(
-        store: &AppStore,
-        list_id: CandidateListId,
-    ) -> Result<Vec<Person>, AppError> {
-        let list = store.get_candidate_list(list_id)?;
-
+    pub fn persons_not_on_list(&self, store: &AppStore) -> Result<Vec<Person>, AppError> {
+        let list = store.get_candidate_list(self.id)?;
         let existing: BTreeMap<PersonId, ()> =
             list.candidates.into_iter().map(|id| (id, ())).collect();
 
@@ -165,8 +186,8 @@ impl CandidateList {
             .await
     }
 
-    pub async fn delete_by_id(store: &AppStore, list_id: CandidateListId) -> Result<(), AppError> {
-        store.update(AppEvent::DeleteCandidateList(list_id)).await
+    pub async fn delete(&self, store: &AppStore) -> Result<(), AppError> {
+        store.update(AppEvent::DeleteCandidateList(self.id)).await
     }
 
     pub(crate) fn build_full_candidate_list(
@@ -189,27 +210,13 @@ impl CandidateList {
 
         Ok(FullCandidateList { list, candidates })
     }
-
-    fn ensure_persons_exist(store: &AppStore, person_ids: &[PersonId]) -> Result<(), AppError> {
-        let existing: BTreeMap<PersonId, ()> = store
-            .get_persons()?
-            .into_iter()
-            .map(|person| (person.id, ()))
-            .collect();
-
-        if person_ids.iter().any(|id| !existing.contains_key(id)) {
-            return Err(AppError::GenericNotFound);
-        }
-
-        Ok(())
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
-        AppEvent, AppStore,
+        AppStore,
         candidate_lists::CandidateListSummary,
         persons::PersonId,
         test_utils::{sample_candidate_list, sample_person_with_last_name},
@@ -481,31 +488,22 @@ mod tests {
         let person_b = sample_person_with_last_name(PersonId::new(), "Bakker");
 
         list_a.create(&store).await?;
-        store
-            .update(AppEvent::CreatePerson(person_a.clone()))
-            .await?;
-        CandidateList::update_order(&store, list_a.id, &[person_a.id]).await?;
+        person_a.create(&store).await?;
+        list_a.clone().update_order(&store, &[person_a.id]).await?;
 
         list_b.create(&store).await?;
-        store
-            .update(AppEvent::CreatePerson(person_b.clone()))
-            .await?;
-        CandidateList::update_order(&store, list_b.id, &[person_b.id]).await?;
+        person_b.create(&store).await?;
+        list_b.clone().update_order(&store, &[person_b.id]).await?;
 
-        // test
-        CandidateList::delete_by_id(&store, list_a.id).await?;
+        list_a.delete(&store).await?;
 
-        // verify
         let lists = CandidateListSummary::list(&store)?;
         let list_b_from_db = FullCandidateList::get(&store, list_b.id).unwrap();
-        // one list remains
+
         assert_eq!(1, lists.len());
-        // the correct list got deleted
         assert_eq!(list_b.id, lists[0].list.id);
-        // and only persons got removed associated with the deleted list
         assert_eq!(1, lists[0].person_count);
         assert_eq!(person_b.id, list_b_from_db.candidates[0].person.id);
-        // no duplicate districts
         assert_eq!(0, lists[0].duplicate_districts.len());
 
         Ok(())
@@ -520,13 +518,11 @@ mod tests {
         let person_b = sample_person_with_last_name(PersonId::new(), "Bakker");
 
         list.create(&store).await?;
-        store
-            .update(AppEvent::CreatePerson(person_a.clone()))
+        person_a.create(&store).await?;
+        person_b.create(&store).await?;
+        list.clone()
+            .update_order(&store, &[person_a.id, person_b.id])
             .await?;
-        store
-            .update(AppEvent::CreatePerson(person_b.clone()))
-            .await?;
-        CandidateList::update_order(&store, list_id, &[person_a.id, person_b.id]).await?;
 
         let detail = FullCandidateList::get(&store, list_id).expect("candidate list");
         assert_eq!(2, detail.candidates.len());
@@ -539,9 +535,8 @@ mod tests {
     #[tokio::test]
     async fn update_candidate_list_order_returns_not_found() -> Result<(), AppError> {
         let store = AppStore::new_for_test().await;
-        let err = CandidateList::update_order(&store, CandidateListId::new(), &[])
-            .await
-            .unwrap_err();
+        let mut missing_list = sample_candidate_list(CandidateListId::new());
+        let err = missing_list.update_order(&store, &[]).await.unwrap_err();
         assert!(matches!(err, AppError::GenericNotFound));
 
         Ok(())
@@ -560,20 +555,16 @@ mod tests {
     async fn test_append_candidate_to_list() -> Result<(), AppError> {
         let store = AppStore::new_for_test().await;
         let list_id = CandidateListId::new();
-        let list = sample_candidate_list(list_id);
+        let mut list = sample_candidate_list(list_id);
         let person_a = sample_person_with_last_name(PersonId::new(), "Jansen");
         let person_b = sample_person_with_last_name(PersonId::new(), "Bakker");
 
         list.create(&store).await?;
-        store
-            .update(AppEvent::CreatePerson(person_a.clone()))
-            .await?;
-        store
-            .update(AppEvent::CreatePerson(person_b.clone()))
-            .await?;
+        person_a.create(&store).await?;
+        person_b.create(&store).await?;
 
-        CandidateList::append_candidate(&store, list_id, person_a.id).await?;
-        CandidateList::append_candidate(&store, list_id, person_b.id).await?;
+        list.append_candidate(&store, person_a.id).await?;
+        list.append_candidate(&store, person_b.id).await?;
 
         let detail = FullCandidateList::get(&store, list_id).expect("candidate list");
 
@@ -589,7 +580,9 @@ mod tests {
     #[tokio::test]
     async fn append_candidate_to_list_returns_not_found() -> Result<(), AppError> {
         let store = AppStore::new_for_test().await;
-        let err = CandidateList::append_candidate(&store, CandidateListId::new(), PersonId::new())
+        let mut missing_list = sample_candidate_list(CandidateListId::new());
+        let err = missing_list
+            .append_candidate(&store, PersonId::new())
             .await
             .unwrap_err();
         assert!(matches!(err, AppError::GenericNotFound));
@@ -608,8 +601,9 @@ mod tests {
         list.create(&store).await?;
         person_a.create(&store).await?;
         person_b.create(&store).await?;
-        CandidateList::append_candidate(&store, list_id, person_a.id).await?;
-        CandidateList::append_candidate(&store, list_id, person_b.id).await?;
+        let mut list = store.get_candidate_list(list_id)?;
+        list.append_candidate(&store, person_a.id).await?;
+        list.append_candidate(&store, person_b.id).await?;
 
         person_a.delete(&store).await?;
 
@@ -624,14 +618,18 @@ mod tests {
     async fn get_candidate_returns_candidate() -> Result<(), AppError> {
         let store = AppStore::new_for_test().await;
         let list_id = CandidateListId::new();
-        let list = sample_candidate_list(list_id);
+        let mut list = sample_candidate_list(list_id);
         let person = sample_person_with_last_name(PersonId::new(), "Jansen");
 
         list.create(&store).await?;
-        store.update(AppEvent::CreatePerson(person.clone())).await?;
-        CandidateList::append_candidate(&store, list_id, person.id).await?;
+        person.create(&store).await?;
+        list.append_candidate(&store, person.id).await?;
 
-        let candidate = CandidateList::get_candidate(&store, list_id, person.id).await?;
+        let candidate = store
+            .get_candidate_list(list_id)?
+            .get_candidate(&store, person.id)
+            .await?;
+
         assert_eq!(candidate.list_id, list_id);
         assert_eq!(candidate.position, 1);
         assert_eq!(candidate.person.id, person.id);

--- a/src/core/candidate_lists/structs/full_candidate_list.rs
+++ b/src/core/candidate_lists/structs/full_candidate_list.rs
@@ -39,18 +39,4 @@ impl FullCandidateList {
     pub fn id(&self) -> CandidateListId {
         self.list.id
     }
-
-    pub fn update_position(&mut self, id: PersonId, position: usize) {
-        let Some(current_index) = self.get_index(id) else {
-            return;
-        };
-
-        let mut moved = self.candidates.remove(current_index);
-
-        // convert the position (1, 2, 3...) to an index (0, 1, 2,..) and clamp it to the valid range
-        let target_index = position.saturating_sub(1).min(self.candidates.len());
-
-        moved.position = position;
-        self.candidates.insert(target_index, moved);
-    }
 }

--- a/src/core/candidates/extractors/candidate.rs
+++ b/src/core/candidates/extractors/candidate.rs
@@ -1,9 +1,6 @@
 use axum::extract::{FromRef, FromRequestParts, Path};
 
-use crate::{
-    AppError, AppStore, Context, CsrfTokens, candidate_lists::CandidateList, candidates::Candidate,
-    trans,
-};
+use crate::{AppError, AppStore, Context, CsrfTokens, candidates::Candidate, trans};
 
 use super::CandidateListAndPersonPathParams;
 
@@ -24,7 +21,14 @@ where
         let Path(CandidateListAndPersonPathParams { list_id, person_id }) =
             Path::<CandidateListAndPersonPathParams>::from_request_parts(parts, state).await?;
 
-        let candidate = CandidateList::get_candidate(&store, list_id, person_id)
+        let candidate_list = store.get_candidate_list(list_id).map_err(|err| match err {
+            AppError::NotFound(_) => AppError::NotFound(
+                trans!("person.not_found_in_candidate_list", context.locale).to_string(),
+            ),
+            _ => err,
+        })?;
+        let candidate = candidate_list
+            .get_candidate(&store, person_id)
             .await
             .map_err(|err| match err {
                 AppError::NotFound(_) => AppError::NotFound(
@@ -50,7 +54,7 @@ mod tests {
     use tower::ServiceExt;
 
     use crate::{
-        AppEvent, AppState,
+        AppState,
         candidate_lists::CandidateListId,
         persons::PersonId,
         render_error_pages,
@@ -64,17 +68,10 @@ mod tests {
         let person = sample_person(PersonId::new());
 
         let app_state = AppState::new_for_tests().await;
-        app_state
-            .store
-            .update(AppEvent::CreateCandidateList(list.clone()))
-            .await
-            .unwrap();
-        app_state
-            .store
-            .update(AppEvent::CreatePerson(person.clone()))
-            .await
-            .unwrap();
-        CandidateList::update_order(&app_state.store, list_id, &[person.id])
+        list.create(&app_state.store).await.unwrap();
+        person.create(&app_state.store).await.unwrap();
+        list.clone()
+            .update_order(&app_state.store, &[person.id])
             .await
             .unwrap();
 
@@ -110,16 +107,8 @@ mod tests {
         let list = sample_candidate_list(list_id);
         let person = sample_person(PersonId::new());
 
-        state
-            .store
-            .update(AppEvent::CreateCandidateList(list.clone()))
-            .await
-            .unwrap();
-        state
-            .store
-            .update(AppEvent::CreatePerson(person.clone()))
-            .await
-            .unwrap();
+        list.create(&state.store).await.unwrap();
+        person.create(&state.store).await.unwrap();
 
         let app =
             Router::new()

--- a/src/core/candidates/pages/add.rs
+++ b/src/core/candidates/pages/add.rs
@@ -27,7 +27,7 @@ pub async fn add_existing_person(
     full_list: FullCandidateList,
     State(store): State<AppStore>,
 ) -> Result<impl IntoResponse, AppError> {
-    let persons = CandidateList::persons_not_on_list(&store, full_list.id())?;
+    let persons = full_list.list.persons_not_on_list(&store)?;
 
     Ok(HtmlTemplate(
         AddExistingPersonTemplate { full_list, persons },
@@ -42,21 +42,21 @@ pub struct AddPersonForm {
 
 pub async fn add_person_to_candidate_list(
     _: AddCandidatePath,
-    full_list: FullCandidateList,
+    mut list: CandidateList,
     State(store): State<AppStore>,
     Form(form): Form<AddPersonForm>,
 ) -> Result<Response, AppError> {
-    let redirect = Redirect::to(&full_list.list.view_path()).into_response();
+    let redirect = Redirect::to(&list.view_path()).into_response();
     let person_exists = store
         .get_persons()?
         .iter()
         .any(|person| person.id == form.person_id);
 
-    if full_list.contains(form.person_id) || !person_exists {
+    if list.candidates.contains(&form.person_id) || !person_exists {
         return Ok(redirect);
     }
 
-    CandidateList::append_candidate(&store, full_list.id(), form.person_id).await?;
+    list.append_candidate(&store, form.person_id).await?;
 
     Ok(redirect)
 }
@@ -65,7 +65,7 @@ pub async fn add_person_to_candidate_list(
 mod tests {
     use super::*;
     use crate::{
-        AppEvent, AppStore, Context,
+        AppStore, Context,
         candidate_lists::CandidateListId,
         persons::PersonId,
         test_utils::{
@@ -87,7 +87,7 @@ mod tests {
         let person = sample_person(PersonId::new());
 
         list.create(&store).await?;
-        store.update(AppEvent::CreatePerson(person.clone())).await?;
+        person.create(&store).await?;
 
         let full_list = FullCandidateList::get(&store, list_id).expect("candidate list");
 
@@ -116,13 +116,11 @@ mod tests {
         let person = sample_person_with_last_name(PersonId::new(), "Bakker");
 
         list.create(&store).await?;
-        store.update(AppEvent::CreatePerson(person.clone())).await?;
-
-        let full_list = FullCandidateList::get(&store, list_id).expect("candidate list");
+        person.create(&store).await?;
 
         let response = add_person_to_candidate_list(
             AddCandidatePath { list_id },
-            full_list,
+            list.clone(),
             State(store.clone()),
             Form(AddPersonForm {
                 person_id: person.id,
@@ -151,24 +149,18 @@ mod tests {
     {
         let store = AppStore::new_for_test().await;
         let list_id = CandidateListId::new();
-        let list = sample_candidate_list(list_id);
+        let mut list = sample_candidate_list(list_id);
         let existing_person = sample_person_with_last_name(PersonId::new(), "Jansen");
         let new_person = sample_person_with_last_name(PersonId::new(), "Bakker");
 
+        existing_person.create(&store).await?;
+        list.candidates = vec![existing_person.id];
         list.create(&store).await?;
-        store
-            .update(AppEvent::CreatePerson(existing_person.clone()))
-            .await?;
-        store
-            .update(AppEvent::CreatePerson(new_person.clone()))
-            .await?;
-        CandidateList::update_order(&store, list_id, &[existing_person.id]).await?;
-
-        let full_list = FullCandidateList::get(&store, list_id).expect("candidate list");
+        new_person.create(&store).await?;
 
         let response = add_person_to_candidate_list(
             AddCandidatePath { list_id },
-            full_list,
+            list.clone(),
             State(store.clone()),
             Form(AddPersonForm {
                 person_id: new_person.id,

--- a/src/core/candidates/pages/create.rs
+++ b/src/core/candidates/pages/create.rs
@@ -6,11 +6,8 @@ use axum::{
 use axum_extra::extract::Form;
 
 use crate::{
-    AppError, AppEvent, AppStore, Context, HtmlTemplate, UtcDateTime,
-    candidate_lists::{CandidateList, FullCandidateList},
-    filters,
-    form::FormData,
-    persons::{COUNTRY_CODES, PersonForm},
+    AppError, AppStore, Context, HtmlTemplate, candidate_lists::FullCandidateList, filters,
+    form::FormData, persons::PersonForm,
 };
 
 use super::CreateCandidatePath;
@@ -19,7 +16,6 @@ use super::CreateCandidatePath;
 struct PersonCreateTemplate {
     full_list: FullCandidateList,
     form: FormData<PersonForm>,
-    countries: &'static [&'static str],
 }
 
 pub async fn create_person_candidate_list(
@@ -31,7 +27,6 @@ pub async fn create_person_candidate_list(
         PersonCreateTemplate {
             full_list,
             form: FormData::new(&context.csrf_tokens),
-            countries: &COUNTRY_CODES,
         },
         context,
     )
@@ -50,20 +45,16 @@ pub async fn create_person_candidate_list_submit(
             PersonCreateTemplate {
                 full_list,
                 form: form_data,
-                countries: &COUNTRY_CODES,
             },
             context,
         )
         .into_response()),
-        Ok(mut person) => {
-            let now = UtcDateTime::now();
-            person.created_at = now;
-            person.updated_at = now;
-            store.update(AppEvent::CreatePerson(person.clone())).await?;
+        Ok(person) => {
+            person.create(&store).await?;
 
-            CandidateList::append_candidate(&store, full_list.id(), person.id).await?;
-
-            let candidate = CandidateList::get_candidate(&store, full_list.id(), person.id).await?;
+            let mut list = full_list.list;
+            list.append_candidate(&store, person.id).await?;
+            let candidate = list.get_candidate(&store, person.id).await?;
 
             Ok(Redirect::to(&candidate.after_create_path()).into_response())
         }

--- a/src/core/candidates/pages/delete.rs
+++ b/src/core/candidates/pages/delete.rs
@@ -35,7 +35,7 @@ pub async fn delete_person(
 mod tests {
     use super::*;
     use crate::{
-        AppEvent, AppStore,
+        AppStore,
         candidate_lists::{CandidateListId, FullCandidateList},
         persons::PersonId,
         test_utils::{sample_candidate_list, sample_person, sample_person_with_last_name},
@@ -47,17 +47,19 @@ mod tests {
     async fn delete_person_removes_from_list_and_redirects() -> Result<(), AppError> {
         let store = AppStore::new_for_test().await;
         let list_id = CandidateListId::new();
-        let list = sample_candidate_list(list_id);
+        let mut list = sample_candidate_list(list_id);
         let person = sample_person(PersonId::new());
         let other_person = sample_person_with_last_name(PersonId::new(), "Other");
 
+        person.create(&store).await?;
+        other_person.create(&store).await?;
+        list.candidates = vec![person.id, other_person.id];
         list.create(&store).await?;
-        store.update(AppEvent::CreatePerson(person.clone())).await?;
-        store
-            .update(AppEvent::CreatePerson(other_person.clone()))
+
+        let candidate = store
+            .get_candidate_list(list_id)?
+            .get_candidate(&store, person.id)
             .await?;
-        CandidateList::update_order(&store, list_id, &[person.id, other_person.id]).await?;
-        let candidate = CandidateList::get_candidate(&store, list_id, person.id).await?;
 
         let context = Context::new_test_without_db();
         let csrf_token = context.csrf_tokens.issue().value;

--- a/src/core/candidates/pages/update.rs
+++ b/src/core/candidates/pages/update.rs
@@ -6,12 +6,8 @@ use axum::{
 use axum_extra::extract::Form;
 
 use crate::{
-    AppError, AppEvent, AppResponse, AppStore, Context, HtmlTemplate, UtcDateTime,
-    candidate_lists::FullCandidateList,
-    candidates::Candidate,
-    filters,
-    form::FormData,
-    persons::{COUNTRY_CODES, PersonForm},
+    AppError, AppResponse, AppStore, Context, HtmlTemplate, candidate_lists::FullCandidateList,
+    candidates::Candidate, filters, form::FormData, persons::PersonForm,
 };
 
 use super::CandidateListUpdatePersonPath;
@@ -21,7 +17,6 @@ struct PersonUpdateTemplate {
     full_list: FullCandidateList,
     candidate: Candidate,
     form: FormData<PersonForm>,
-    countries: &'static [&'static str],
 }
 
 pub async fn update_person(
@@ -38,7 +33,6 @@ pub async fn update_person(
             ),
             candidate,
             full_list,
-            countries: &COUNTRY_CODES,
         },
         context,
     ))
@@ -58,14 +52,12 @@ pub async fn update_person_submit(
                 candidate,
                 full_list,
                 form: form_data,
-                countries: &COUNTRY_CODES,
             },
             context,
         )
         .into_response()),
-        Ok(mut person) => {
-            person.updated_at = UtcDateTime::now();
-            store.update(AppEvent::UpdatePerson(person)).await?;
+        Ok(person) => {
+            person.update(&store).await?;
 
             Ok(Redirect::to(&full_list.list.view_path()).into_response())
         }
@@ -76,8 +68,8 @@ pub async fn update_person_submit(
 mod tests {
     use super::*;
     use crate::{
-        AppEvent, AppStore, Context,
-        candidate_lists::{CandidateList, CandidateListId},
+        AppStore, Context,
+        candidate_lists::CandidateListId,
         persons::PersonId,
         test_utils::{
             response_body_string, sample_candidate_list, sample_person, sample_person_form,
@@ -97,11 +89,14 @@ mod tests {
         let person = sample_person(PersonId::new());
 
         list.create(&store).await?;
-        store.update(AppEvent::CreatePerson(person.clone())).await?;
-        CandidateList::update_order(&store, list_id, &[person.id]).await?;
+        person.create(&store).await?;
+        list.clone().update_order(&store, &[person.id]).await?;
 
         let full_list = FullCandidateList::get(&store, list_id).expect("candidate list");
-        let candidate = CandidateList::get_candidate(&store, list_id, person.id).await?;
+        let candidate = store
+            .get_candidate_list(list_id)?
+            .get_candidate(&store, person.id)
+            .await?;
 
         let response = update_person(
             CandidateListUpdatePersonPath {
@@ -130,11 +125,14 @@ mod tests {
         let person = sample_person(PersonId::new());
 
         list.create(&store).await?;
-        store.update(AppEvent::CreatePerson(person.clone())).await?;
-        CandidateList::update_order(&store, list_id, &[person.id]).await?;
+        person.create(&store).await?;
+        list.clone().update_order(&store, &[person.id]).await?;
 
         let full_list = FullCandidateList::get(&store, list_id).expect("candidate list");
-        let candidate = CandidateList::get_candidate(&store, list_id, person.id).await?;
+        let candidate = store
+            .get_candidate_list(list_id)?
+            .get_candidate(&store, person.id)
+            .await?;
 
         let context = Context::new_test_without_db();
         let csrf_token = context.csrf_tokens.issue().value;
@@ -181,11 +179,14 @@ mod tests {
         let person = sample_person(PersonId::new());
 
         list.create(&store).await?;
-        store.update(AppEvent::CreatePerson(person.clone())).await?;
-        CandidateList::update_order(&store, list_id, &[person.id]).await?;
+        person.create(&store).await?;
+        list.clone().update_order(&store, &[person.id]).await?;
 
         let full_list = FullCandidateList::get(&store, list_id).expect("candidate list");
-        let candidate = CandidateList::get_candidate(&store, list_id, person.id).await?;
+        let candidate = store
+            .get_candidate_list(list_id)?
+            .get_candidate(&store, person.id)
+            .await?;
 
         let context = Context::new_test_without_db();
         let csrf_token = context.csrf_tokens.issue().value;

--- a/src/core/candidates/pages/update_address.rs
+++ b/src/core/candidates/pages/update_address.rs
@@ -6,7 +6,7 @@ use axum::{
 use axum_extra::extract::Form;
 
 use crate::{
-    AppError, AppEvent, AppResponse, AppStore, Context, HtmlTemplate, UtcDateTime,
+    AppError, AppResponse, AppStore, Context, HtmlTemplate,
     candidate_lists::FullCandidateList,
     candidates::Candidate,
     filters,
@@ -67,9 +67,10 @@ pub async fn update_person_address_submit(
             context,
         )
         .into_response()),
-        Ok(mut person) => {
-            person.updated_at = UtcDateTime::now();
-            store.update(AppEvent::UpdatePerson(person)).await?;
+        Ok(person) => {
+            person
+                .update_address(&store, person.address.clone())
+                .await?;
 
             Ok(Redirect::to(&full_list.list.view_path()).into_response())
         }
@@ -80,8 +81,8 @@ pub async fn update_person_address_submit(
 mod tests {
     use super::*;
     use crate::{
-        AppEvent, AppStore, Context,
-        candidate_lists::{CandidateList, CandidateListId},
+        AppStore, Context,
+        candidate_lists::CandidateListId,
         persons::PersonId,
         test_utils::{
             response_body_string, sample_address_form, sample_candidate_list,
@@ -103,11 +104,14 @@ mod tests {
         let person = sample_person_with_last_name(PersonId::new(), "Jansen");
 
         list.create(&store).await?;
-        store.update(AppEvent::CreatePerson(person.clone())).await?;
-        CandidateList::update_order(&store, list_id, &[person.id]).await?;
+        person.create(&store).await?;
+        list.clone().update_order(&store, &[person.id]).await?;
 
         let full_list = FullCandidateList::get(&store, list_id).expect("candidate list");
-        let candidate = CandidateList::get_candidate(&store, list_id, person.id).await?;
+        let candidate = store
+            .get_candidate_list(list_id)?
+            .get_candidate(&store, person.id)
+            .await?;
 
         let response = update_person_address(
             CandidateListUpdateAddressPath {
@@ -133,15 +137,18 @@ mod tests {
     async fn update_person_address_persists_and_redirects() -> Result<(), AppError> {
         let store = AppStore::new_for_test().await;
         let list_id = CandidateListId::new();
-        let list = sample_candidate_list(list_id);
+        let mut list = sample_candidate_list(list_id);
         let person = sample_person_with_last_name(PersonId::new(), "Jansen");
 
+        person.create(&store).await?;
+        list.candidates = vec![person.id];
         list.create(&store).await?;
-        store.update(AppEvent::CreatePerson(person.clone())).await?;
-        CandidateList::update_order(&store, list_id, &[person.id]).await?;
 
         let full_list = FullCandidateList::get(&store, list_id).expect("candidate list");
-        let candidate = CandidateList::get_candidate(&store, list_id, person.id).await?;
+        let candidate = store
+            .get_candidate_list(list_id)?
+            .get_candidate(&store, person.id)
+            .await?;
 
         let context = Context::new_test_without_db();
         let csrf_token = context.csrf_tokens.issue().value;
@@ -188,15 +195,18 @@ mod tests {
     async fn update_person_address_invalid_form_renders_template() -> Result<(), AppError> {
         let store = AppStore::new_for_test().await;
         let list_id = CandidateListId::new();
-        let list = sample_candidate_list(list_id);
+        let mut list = sample_candidate_list(list_id);
         let person = sample_person_with_last_name(PersonId::new(), "Jansen");
 
+        person.create(&store).await?;
+        list.candidates = vec![person.id];
         list.create(&store).await?;
-        store.update(AppEvent::CreatePerson(person.clone())).await?;
-        CandidateList::update_order(&store, list_id, &[person.id]).await?;
 
         let full_list = FullCandidateList::get(&store, list_id).expect("candidate list");
-        let candidate = CandidateList::get_candidate(&store, list_id, person.id).await?;
+        let candidate = store
+            .get_candidate_list(list_id)?
+            .get_candidate(&store, person.id)
+            .await?;
 
         let context = Context::new_test_without_db();
         let csrf_token = context.csrf_tokens.issue().value;

--- a/src/core/candidates/pages/update_position.rs
+++ b/src/core/candidates/pages/update_position.rs
@@ -7,7 +7,7 @@ use axum_extra::extract::Form;
 
 use crate::{
     AppError, AppStore, Context, HtmlTemplate,
-    candidate_lists::{CandidateList, FullCandidateList},
+    candidate_lists::FullCandidateList,
     candidates::{Candidate, CandidatePosition, CandidatePositionAction, CandidatePositionForm},
     filters,
     form::FormData,
@@ -80,17 +80,12 @@ pub async fn update_candidate_position_submit(
 
             match position_form.action {
                 CandidatePositionAction::Remove => {
-                    CandidateList::remove_candidate_from_list(
-                        &store,
-                        candidate.list_id,
-                        candidate.person.id,
-                    )
-                    .await?;
+                    let mut list = full_list.list;
+                    list.remove_candidate(&store, candidate.person.id).await?;
                 }
                 CandidatePositionAction::Move => {
-                    let mut full_list = full_list;
-                    full_list.update_position(candidate.person.id, position_form.position);
-                    CandidateList::update_order(&store, candidate.list_id, &full_list.get_ids())
+                    let mut list = full_list.list;
+                    list.update_position(&store, candidate.person.id, position_form.position)
                         .await?;
                 }
             }
@@ -104,7 +99,7 @@ pub async fn update_candidate_position_submit(
 mod tests {
     use super::*;
     use crate::{
-        AppEvent, AppStore, Context, TokenValue,
+        AppStore, Context, TokenValue,
         candidate_lists::CandidateListId,
         persons::PersonId,
         test_utils::{
@@ -131,15 +126,15 @@ mod tests {
     async fn update_candidate_position_renders_form() -> Result<(), AppError> {
         let store = AppStore::new_for_test().await;
         let list_id = CandidateListId::new();
-        let list = sample_candidate_list(list_id);
+        let mut list = sample_candidate_list(list_id);
         let person = sample_person(PersonId::new());
 
+        person.create(&store).await?;
+        list.candidates = vec![person.id];
         list.create(&store).await?;
-        store.update(AppEvent::CreatePerson(person.clone())).await?;
-        CandidateList::update_order(&store, list_id, &[person.id]).await?;
 
         let full_list = FullCandidateList::get(&store, list_id).expect("candidate list");
-        let candidate = CandidateList::get_candidate(&store, list_id, person.id).await?;
+        let candidate = list.get_candidate(&store, person.id).await?;
 
         let response = update_candidate_position(
             UpdateCandidatePositionPath {
@@ -170,16 +165,17 @@ mod tests {
         let person_b = sample_person_with_last_name(PersonId::new(), "Bakker");
 
         list.create(&store).await?;
-        store
-            .update(AppEvent::CreatePerson(person_a.clone()))
+        person_a.create(&store).await?;
+        person_b.create(&store).await?;
+        list.clone()
+            .update_order(&store, &[person_a.id, person_b.id])
             .await?;
-        store
-            .update(AppEvent::CreatePerson(person_b.clone()))
-            .await?;
-        CandidateList::update_order(&store, list_id, &[person_a.id, person_b.id]).await?;
 
         let full_list = FullCandidateList::get(&store, list_id).expect("candidate list");
-        let candidate = CandidateList::get_candidate(&store, list_id, person_a.id).await?;
+        let candidate = store
+            .get_candidate_list(list_id)?
+            .get_candidate(&store, person_a.id)
+            .await?;
 
         let context = Context::new_test_without_db();
         let csrf_token = context.csrf_tokens.issue().value;
@@ -218,16 +214,17 @@ mod tests {
         let person_b = sample_person_with_last_name(PersonId::new(), "Bakker");
 
         list.create(&store).await?;
-        store
-            .update(AppEvent::CreatePerson(person_a.clone()))
+        person_a.create(&store).await?;
+        person_b.create(&store).await?;
+        list.clone()
+            .update_order(&store, &[person_a.id, person_b.id])
             .await?;
-        store
-            .update(AppEvent::CreatePerson(person_b.clone()))
-            .await?;
-        CandidateList::update_order(&store, list_id, &[person_a.id, person_b.id]).await?;
 
         let full_list = FullCandidateList::get(&store, list_id).expect("candidate list");
-        let candidate = CandidateList::get_candidate(&store, list_id, person_a.id).await?;
+        let candidate = store
+            .get_candidate_list(list_id)?
+            .get_candidate(&store, person_a.id)
+            .await?;
 
         let context = Context::new_test_without_db();
         let csrf_token = context.csrf_tokens.issue().value;
@@ -265,16 +262,17 @@ mod tests {
         let person_b = sample_person_with_last_name(PersonId::new(), "Bakker");
 
         list.create(&store).await?;
-        store
-            .update(AppEvent::CreatePerson(person_a.clone()))
+        person_a.create(&store).await?;
+        person_b.create(&store).await?;
+        list.clone()
+            .update_order(&store, &[person_a.id, person_b.id])
             .await?;
-        store
-            .update(AppEvent::CreatePerson(person_b.clone()))
-            .await?;
-        CandidateList::update_order(&store, list_id, &[person_a.id, person_b.id]).await?;
 
         let full_list = FullCandidateList::get(&store, list_id).expect("candidate list");
-        let candidate = CandidateList::get_candidate(&store, list_id, person_a.id).await?;
+        let candidate = store
+            .get_candidate_list(list_id)?
+            .get_candidate(&store, person_a.id)
+            .await?;
 
         let context = Context::new_test_without_db();
         let csrf_token = TokenValue("invalid".to_string());

--- a/src/core/candidates/pages/update_representative.rs
+++ b/src/core/candidates/pages/update_representative.rs
@@ -83,7 +83,7 @@ mod tests {
     use super::*;
     use crate::{
         AppError, AppStore, Context,
-        candidate_lists::{CandidateList, CandidateListId},
+        candidate_lists::CandidateListId,
         persons::PersonId,
         test_utils::{
             extract_csrf_token, response_body_string, sample_candidate_list, sample_person,
@@ -106,10 +106,13 @@ mod tests {
 
         list.create(&store).await?;
         person.create(&store).await?;
-        CandidateList::update_order(&store, list_id, &[person.id]).await?;
+        list.clone().update_order(&store, &[person.id]).await?;
 
         let full_list = FullCandidateList::get(&store, list_id).expect("candidate list");
-        let candidate = CandidateList::get_candidate(&store, list_id, person.id).await?;
+        let candidate = store
+            .get_candidate_list(list_id)?
+            .get_candidate(&store, person.id)
+            .await?;
 
         let response = update_representative(
             UpdateRepresentativePath {
@@ -141,10 +144,13 @@ mod tests {
 
         list.create(&store).await?;
         person.create(&store).await?;
-        CandidateList::update_order(&store, list_id, &[person.id]).await?;
+        list.clone().update_order(&store, &[person.id]).await?;
 
         let full_list = FullCandidateList::get(&store, list_id).expect("candidate list");
-        let candidate = CandidateList::get_candidate(&store, list_id, person.id).await?;
+        let candidate = store
+            .get_candidate_list(list_id)?
+            .get_candidate(&store, person.id)
+            .await?;
 
         let context = Context::new_test_without_db();
         let csrf_tokens = context.csrf_tokens.clone();
@@ -180,10 +186,13 @@ mod tests {
 
         list.create(&store).await?;
         person.create(&store).await?;
-        CandidateList::update_order(&store, list_id, &[person.id]).await?;
+        list.clone().update_order(&store, &[person.id]).await?;
 
         let full_list = FullCandidateList::get(&store, list_id).expect("candidate list");
-        let candidate = CandidateList::get_candidate(&store, list_id, person.id).await?;
+        let candidate = store
+            .get_candidate_list(list_id)?
+            .get_candidate(&store, person.id)
+            .await?;
 
         let context = Context::new_test_without_db();
         let csrf_token = context.csrf_tokens.issue().value;
@@ -229,10 +238,13 @@ mod tests {
 
         list.create(&store).await?;
         person.create(&store).await?;
-        CandidateList::update_order(&store, list_id, &[person.id]).await?;
+        list.clone().update_order(&store, &[person.id]).await?;
 
         let full_list = FullCandidateList::get(&store, list_id).expect("candidate list");
-        let candidate = CandidateList::get_candidate(&store, list_id, person.id).await?;
+        let candidate = store
+            .get_candidate_list(list_id)?
+            .get_candidate(&store, person.id)
+            .await?;
 
         let context = Context::new_test_without_db();
         let csrf_token = context.csrf_tokens.issue().value;

--- a/src/core/list_submitters/extractors/list_submitter.rs
+++ b/src/core/list_submitters/extractors/list_submitter.rs
@@ -43,7 +43,7 @@ mod tests {
     use tower::ServiceExt;
 
     use crate::{
-        AppEvent, AppState,
+        AppState,
         test_utils::{response_body_string, sample_list_submitter},
     };
 
@@ -52,11 +52,7 @@ mod tests {
         let list_submitter = sample_list_submitter(ListSubmitterId::new());
 
         let app_state = AppState::new_for_tests().await;
-        app_state
-            .store
-            .update(AppEvent::CreateListSubmitter(list_submitter.clone()))
-            .await
-            .unwrap();
+        list_submitter.create(&app_state.store).await.unwrap();
 
         let app = Router::new()
             .route(

--- a/src/core/list_submitters/pages/list_submitter_delete.rs
+++ b/src/core/list_submitters/pages/list_submitter_delete.rs
@@ -6,20 +6,19 @@ use axum_extra::extract::Form;
 
 use crate::{AppError, AppStore, Context, form::EmptyForm, list_submitters::ListSubmitter};
 
-use super::{ListSubmitterDeletePath, ListSubmitterUpdatePath};
+use super::ListSubmitterDeletePath;
 
 pub async fn delete_list_submitter(
-    ListSubmitterDeletePath { submitter_id }: ListSubmitterDeletePath,
+    _: ListSubmitterDeletePath,
     context: Context,
+    submitter: ListSubmitter,
     State(store): State<AppStore>,
     Form(form): Form<EmptyForm>,
 ) -> Result<Response, AppError> {
     match form.validate_create(&context.csrf_tokens) {
-        Err(_) => {
-            Ok(Redirect::to(&ListSubmitterUpdatePath { submitter_id }.to_string()).into_response())
-        }
+        Err(_) => Ok(Redirect::to(&submitter.update_path()).into_response()),
         Ok(_) => {
-            ListSubmitter::delete_by_id(&store, submitter_id).await?;
+            submitter.delete(&store).await?;
 
             Ok(Redirect::to(&ListSubmitter::list_path()).into_response())
         }
@@ -43,8 +42,10 @@ mod tests {
         let group_id = PoliticalGroupId::new();
         let political_group = sample_political_group(group_id);
         let submitter_id = ListSubmitterId::new();
+        let submitter = sample_list_submitter(submitter_id);
 
         political_group.create(&store).await?;
+        submitter.create(&store).await?;
 
         let context = Context::new_test_without_db();
         let csrf_token = context.csrf_tokens.issue().value;
@@ -52,6 +53,7 @@ mod tests {
         let response = delete_list_submitter(
             ListSubmitterDeletePath { submitter_id },
             context,
+            submitter,
             State(store.clone()),
             Form(EmptyForm::new(csrf_token)),
         )
@@ -89,6 +91,7 @@ mod tests {
         let response = delete_list_submitter(
             ListSubmitterDeletePath { submitter_id },
             context,
+            list_submitter.clone(),
             State(store.clone()),
             Form(EmptyForm::new(TokenValue("invalid".to_string()))),
         )
@@ -102,10 +105,8 @@ mod tests {
             .expect("location header")
             .to_str()
             .expect("location header value");
-        assert_eq!(
-            location,
-            ListSubmitterUpdatePath { submitter_id }.to_string()
-        );
+
+        assert_eq!(location, list_submitter.update_path());
 
         let submitters = store.get_list_submitters()?;
         assert_eq!(submitters.len(), 1);

--- a/src/core/list_submitters/structs/list_submitter.rs
+++ b/src/core/list_submitters/structs/list_submitter.rs
@@ -17,15 +17,7 @@ pub struct ListSubmitter {
 
 impl ListSubmitter {
     pub fn is_complete(&self) -> bool {
-        self.name.is_complete() && self.is_address_complete()
-    }
-
-    pub fn is_address_complete(&self) -> bool {
-        self.address.is_complete()
-    }
-
-    pub fn last_name_with_prefix(&self) -> String {
-        self.name.last_name_with_prefix()
+        self.name.is_complete() && self.address.is_complete()
     }
 
     pub async fn create(&self, store: &AppStore) -> Result<(), AppError> {
@@ -44,17 +36,12 @@ impl ListSubmitter {
             .await
     }
 
-    pub async fn delete_by_id(
-        store: &AppStore,
-        list_submitter_id: ListSubmitterId,
-    ) -> Result<(), AppError> {
+    pub async fn delete(&self, store: &AppStore) -> Result<(), AppError> {
         store
             .update(AppEvent::DeleteListSubmitter {
-                list_submitter_id,
+                list_submitter_id: self.id,
                 updated_at: UtcDateTime::now(),
             })
-            .await?;
-
-        Ok(())
+            .await
     }
 }

--- a/src/core/persons/extractors/person.rs
+++ b/src/core/persons/extractors/person.rs
@@ -50,7 +50,7 @@ mod tests {
     use tower::ServiceExt;
 
     use crate::{
-        AppEvent, AppState, Locale, render_error_pages,
+        AppState, Locale, render_error_pages,
         test_utils::{response_body_string, sample_person},
     };
 
@@ -59,11 +59,7 @@ mod tests {
         let person = sample_person(PersonId::new());
 
         let app_state = AppState::new_for_tests().await;
-        app_state
-            .store
-            .update(AppEvent::CreatePerson(person.clone()))
-            .await
-            .unwrap();
+        person.create(&app_state.store).await.unwrap();
 
         let app = Router::new()
             .route(

--- a/src/core/persons/extractors/person_pagination.rs
+++ b/src/core/persons/extractors/person_pagination.rs
@@ -51,7 +51,7 @@ mod tests {
     use tower::ServiceExt;
 
     use crate::{
-        AppEvent, AppState,
+        AppState,
         persons::PersonId,
         test_utils::{response_body_string, sample_person_with_last_name},
     };
@@ -59,20 +59,12 @@ mod tests {
     #[tokio::test]
     async fn person_pagination_extractor_slices_and_orders() {
         let app_state = AppState::new_for_tests().await;
-        app_state
-            .store
-            .update(AppEvent::CreatePerson(sample_person_with_last_name(
-                PersonId::new(),
-                "Bakker",
-            )))
+        sample_person_with_last_name(PersonId::new(), "Bakker")
+            .create(&app_state.store)
             .await
             .unwrap();
-        app_state
-            .store
-            .update(AppEvent::CreatePerson(sample_person_with_last_name(
-                PersonId::new(),
-                "Jansen",
-            )))
+        sample_person_with_last_name(PersonId::new(), "Jansen")
+            .create(&app_state.store)
             .await
             .unwrap();
 

--- a/src/core/persons/pages/address.rs
+++ b/src/core/persons/pages/address.rs
@@ -54,7 +54,9 @@ pub async fn update_person_address_submit(
         )
         .into_response()),
         Ok(person) => {
-            person.update_address(&store).await?;
+            person
+                .update_address(&store, person.address.clone())
+                .await?;
 
             Ok(Redirect::to(&Person::list_path()).into_response())
         }

--- a/src/core/persons/pages/create.rs
+++ b/src/core/persons/pages/create.rs
@@ -8,14 +8,13 @@ use axum_extra::extract::Form;
 use crate::{
     AppError, AppStore, Context, HtmlTemplate, filters,
     form::FormData,
-    persons::{COUNTRY_CODES, Person, PersonForm, pages::PersonsCreatePath},
+    persons::{Person, PersonForm, pages::PersonsCreatePath},
 };
 
 #[derive(Template)]
 #[template(path = "persons/create.html")]
 struct PersonCreateTemplate {
     form: FormData<PersonForm>,
-    countries: &'static [&'static str],
 }
 
 pub async fn create_person(
@@ -25,7 +24,6 @@ pub async fn create_person(
     Ok(HtmlTemplate(
         PersonCreateTemplate {
             form: FormData::new(&context.csrf_tokens),
-            countries: &COUNTRY_CODES,
         },
         context,
     ))
@@ -38,14 +36,9 @@ pub async fn create_person_submit(
     Form(form): Form<PersonForm>,
 ) -> Result<Response, AppError> {
     match form.validate_create(&context.csrf_tokens) {
-        Err(form_data) => Ok(HtmlTemplate(
-            PersonCreateTemplate {
-                form: form_data,
-                countries: &COUNTRY_CODES,
-            },
-            context,
-        )
-        .into_response()),
+        Err(form_data) => {
+            Ok(HtmlTemplate(PersonCreateTemplate { form: form_data }, context).into_response())
+        }
         Ok(person) => {
             person.create(&store).await?;
 

--- a/src/core/persons/pages/delete.rs
+++ b/src/core/persons/pages/delete.rs
@@ -11,8 +11,9 @@ use crate::{
 };
 
 pub async fn delete_person(
-    DeletePersonPath { person_id }: DeletePersonPath,
+    _: DeletePersonPath,
     context: Context,
+    person: Person,
     State(store): State<AppStore>,
     Form(form): Form<EmptyForm>,
 ) -> Result<Response, AppError> {
@@ -22,7 +23,7 @@ pub async fn delete_person(
             Ok(Redirect::to(&Person::list_path()).into_response())
         }
         Ok(_) => {
-            Person::delete_by_id(&store, person_id).await?;
+            person.delete(&store).await?;
             // TODO: set success flash message
             Ok(Redirect::to(&Person::list_path()).into_response())
         }
@@ -49,6 +50,7 @@ mod tests {
         let response = delete_person(
             DeletePersonPath { person_id },
             context,
+            person,
             State(store.clone()),
             Form(EmptyForm::new(csrf_token)),
         )

--- a/src/core/persons/pages/update.rs
+++ b/src/core/persons/pages/update.rs
@@ -8,7 +8,7 @@ use axum_extra::extract::Form;
 use crate::{
     AppError, AppResponse, AppStore, Context, HtmlTemplate, filters,
     form::FormData,
-    persons::{COUNTRY_CODES, Person, PersonForm, pages::UpdatePersonPath},
+    persons::{Person, PersonForm, pages::UpdatePersonPath},
 };
 
 #[derive(Template)]
@@ -16,7 +16,6 @@ use crate::{
 struct PersonUpdateTemplate {
     person: Person,
     form: FormData<PersonForm>,
-    countries: &'static [&'static str],
 }
 
 pub async fn update_person(
@@ -28,7 +27,6 @@ pub async fn update_person(
         PersonUpdateTemplate {
             form: FormData::new_with_data(PersonForm::from(person.clone()), &context.csrf_tokens),
             person,
-            countries: &COUNTRY_CODES,
         },
         context,
     ))
@@ -46,7 +44,6 @@ pub async fn update_person_submit(
             PersonUpdateTemplate {
                 person,
                 form: form_data,
-                countries: &COUNTRY_CODES,
             },
             context,
         )

--- a/src/core/persons/structs/person.rs
+++ b/src/core/persons/structs/person.rs
@@ -96,10 +96,6 @@ impl Person {
             && self.country_of_residence.is_some()
     }
 
-    pub fn is_address_complete(&self) -> bool {
-        self.address.is_complete()
-    }
-
     pub fn is_representative_complete(&self) -> bool {
         if self.is_dutch() {
             return true;
@@ -110,7 +106,7 @@ impl Person {
 
     pub fn is_complete(&self) -> bool {
         self.is_personal_info_complete()
-            && self.is_address_complete()
+            && self.address.is_complete()
             && self.is_representative_complete()
     }
 
@@ -136,31 +132,24 @@ impl Person {
             .await
     }
 
-    pub async fn update_address(&self, store: &AppStore) -> Result<(), AppError> {
-        let existing = store.get_person(self.id)?;
-
-        let updated = Person {
-            address: self.address.clone(),
-            updated_at: UtcDateTime::now(),
-            ..existing
-        };
-
-        store.update(AppEvent::UpdatePerson(updated.clone())).await
+    pub async fn update_address(
+        &self,
+        store: &AppStore,
+        address: DutchAddress,
+    ) -> Result<(), AppError> {
+        store
+            .update(AppEvent::UpdatePersonAddress {
+                person_id: self.id,
+                address,
+                updated_at: UtcDateTime::now(),
+            })
+            .await
     }
 
     pub async fn delete(&self, store: &AppStore) -> Result<(), AppError> {
         store
             .update(AppEvent::DeletePerson {
                 person_id: self.id,
-                updated_at: UtcDateTime::now(),
-            })
-            .await
-    }
-
-    pub async fn delete_by_id(store: &AppStore, person_id: PersonId) -> Result<(), AppError> {
-        store
-            .update(AppEvent::DeletePerson {
-                person_id,
                 updated_at: UtcDateTime::now(),
             })
             .await
@@ -271,7 +260,9 @@ mod tests {
         person.address.house_number_addition = None;
         person.address.street_name = Some("Nieuweweg".parse().expect("street name"));
 
-        person.update_address(&store).await?;
+        person
+            .update_address(&store, person.address.clone())
+            .await?;
 
         let updated = store.get_person(id)?;
         assert_eq!(

--- a/src/core/persons/structs/person_sort.rs
+++ b/src/core/persons/structs/person_sort.rs
@@ -21,10 +21,18 @@ pub fn compare_persons(a: &Person, b: &Person, sort_field: &PersonSort) -> std::
             .name
             .last_name
             .cmp(&b.name.last_name)
-            .then_with(|| cmp_option_string(&a.name.last_name_prefix, &b.name.last_name_prefix))
+            .then_with(|| {
+                a.name
+                    .last_name_prefix
+                    .as_str_or_empty()
+                    .cmp(b.name.last_name_prefix.as_str_or_empty())
+            })
             .then_with(|| a.name.initials.cmp(&b.name.initials))
             .then_with(|| a.id.cmp(&b.id)),
-        PersonSort::FirstName => cmp_option_string(&a.first_name, &b.first_name)
+        PersonSort::FirstName => a
+            .first_name
+            .as_str_or_empty()
+            .cmp(b.first_name.as_str_or_empty())
             .then_with(|| a.name.last_name.cmp(&b.name.last_name))
             .then_with(|| a.id.cmp(&b.id)),
         PersonSort::Initials => a
@@ -38,11 +46,12 @@ pub fn compare_persons(a: &Person, b: &Person, sort_field: &PersonSort) -> std::
             .cmp(&b.gender)
             .then_with(|| a.name.last_name.cmp(&b.name.last_name))
             .then_with(|| a.id.cmp(&b.id)),
-        PersonSort::PlaceOfResidence => {
-            cmp_option_string(&a.place_of_residence, &b.place_of_residence)
-                .then_with(|| a.name.last_name.cmp(&b.name.last_name))
-                .then_with(|| a.id.cmp(&b.id))
-        }
+        PersonSort::PlaceOfResidence => a
+            .place_of_residence
+            .as_str_or_empty()
+            .cmp(b.place_of_residence.as_str_or_empty())
+            .then_with(|| a.name.last_name.cmp(&b.name.last_name))
+            .then_with(|| a.id.cmp(&b.id)),
         PersonSort::CreatedAt => a
             .created_at
             .cmp(&b.created_at)
@@ -52,13 +61,6 @@ pub fn compare_persons(a: &Person, b: &Person, sort_field: &PersonSort) -> std::
             .cmp(&b.updated_at)
             .then_with(|| a.id.cmp(&b.id)),
     }
-}
-
-fn cmp_option_string<T>(a: &Option<T>, b: &Option<T>) -> std::cmp::Ordering
-where
-    T: std::ops::Deref<Target = String>,
-{
-    a.as_str_or_empty().cmp(b.as_str_or_empty())
 }
 
 #[cfg(test)]
@@ -92,17 +94,6 @@ mod tests {
             updated_at: timestamp(1),
             ..Default::default()
         }
-    }
-
-    #[test]
-    fn cmp_option_string_treats_none_as_empty() {
-        let none_value = None;
-        let empty = Some(FirstName::default());
-        let value = Some("Al".parse::<FirstName>().expect("first name"));
-
-        assert_eq!(cmp_option_string(&none_value, &empty), Ordering::Equal);
-        assert_eq!(cmp_option_string(&none_value, &value), Ordering::Less);
-        assert_eq!(cmp_option_string(&value, &none_value), Ordering::Greater);
     }
 
     #[test]

--- a/src/core/substitute_list_submitters/extractors/substitute_submitter.rs
+++ b/src/core/substitute_list_submitters/extractors/substitute_submitter.rs
@@ -43,7 +43,7 @@ mod tests {
     use tower::ServiceExt;
 
     use crate::{
-        AppEvent, AppState,
+        AppState,
         test_utils::{response_body_string, sample_substitute_submitter},
     };
 
@@ -52,13 +52,7 @@ mod tests {
         let substitute_submitter = sample_substitute_submitter(SubstituteSubmitterId::new());
 
         let app_state = AppState::new_for_tests().await;
-        app_state
-            .store
-            .update(AppEvent::CreateSubstituteSubmitter(
-                substitute_submitter.clone(),
-            ))
-            .await
-            .unwrap();
+        substitute_submitter.create(&app_state.store).await.unwrap();
 
         let app = Router::new()
             .route(

--- a/src/core/substitute_list_submitters/pages/substitute_submitter_delete.rs
+++ b/src/core/substitute_list_submitters/pages/substitute_submitter_delete.rs
@@ -9,21 +9,19 @@ use crate::{
     substitute_list_submitters::SubstituteSubmitter,
 };
 
-use super::{SubstituteSubmitterDeletePath, SubstituteSubmitterUpdatePath};
+use super::SubstituteSubmitterDeletePath;
 
 pub async fn delete_substitute_submitter(
-    SubstituteSubmitterDeletePath { sub_submitter_id }: SubstituteSubmitterDeletePath,
+    _: SubstituteSubmitterDeletePath,
     context: Context,
+    substitute_submitter: SubstituteSubmitter,
     State(store): State<AppStore>,
     Form(form): Form<EmptyForm>,
 ) -> Result<Response, AppError> {
     match form.validate_create(&context.csrf_tokens) {
-        Err(_) => Ok(
-            Redirect::to(&SubstituteSubmitterUpdatePath { sub_submitter_id }.to_string())
-                .into_response(),
-        ),
+        Err(_) => Ok(Redirect::to(&substitute_submitter.update_path()).into_response()),
         Ok(_) => {
-            SubstituteSubmitter::delete_by_id(&store, sub_submitter_id).await?;
+            substitute_submitter.delete(&store).await?;
 
             Ok(Redirect::to(&ListSubmitter::list_path()).into_response())
         }
@@ -60,6 +58,7 @@ mod tests {
         let response = delete_substitute_submitter(
             SubstituteSubmitterDeletePath { sub_submitter_id },
             context,
+            substitute_submitter,
             State(store.clone()),
             Form(EmptyForm::new(csrf_token)),
         )
@@ -98,6 +97,7 @@ mod tests {
         let response = delete_substitute_submitter(
             SubstituteSubmitterDeletePath { sub_submitter_id },
             context,
+            substitute_submitter.clone(),
             State(store.clone()),
             Form(EmptyForm::new(TokenValue("invalid".to_string()))),
         )
@@ -111,10 +111,7 @@ mod tests {
             .expect("location header")
             .to_str()
             .expect("location header value");
-        assert_eq!(
-            location,
-            SubstituteSubmitterUpdatePath { sub_submitter_id }.to_string()
-        );
+        assert_eq!(location, substitute_submitter.update_path());
 
         let submitters = store.get_substitute_submitters()?;
         assert_eq!(submitters.len(), 1);

--- a/src/core/substitute_list_submitters/structs/substitute_submitter.rs
+++ b/src/core/substitute_list_submitters/structs/substitute_submitter.rs
@@ -32,13 +32,10 @@ impl SubstituteSubmitter {
             .await
     }
 
-    pub async fn delete_by_id(
-        store: &AppStore,
-        substitute_submitter_id: SubstituteSubmitterId,
-    ) -> Result<(), AppError> {
+    pub async fn delete(&self, store: &AppStore) -> Result<(), AppError> {
         store
             .update(AppEvent::DeleteSubstituteSubmitter {
-                substitute_submitter_id,
+                substitute_submitter_id: self.id,
                 updated_at: UtcDateTime::now(),
             })
             .await

--- a/src/fixtures/candidate_list.rs
+++ b/src/fixtures/candidate_list.rs
@@ -31,13 +31,11 @@ pub async fn load(store: &AppStore) -> Result<(), AppError> {
     let candidate_list = CandidateList {
         id: uuid.into(),
         electoral_districts,
+        candidates: person_ids,
         ..Default::default()
     };
 
     candidate_list.create(store).await?;
-
-    // Persist the ordered set of persons to ensure deterministic candidate positions.
-    CandidateList::update_order(store, candidate_list.id, &person_ids).await?;
 
     Ok(())
 }

--- a/src/fixtures/persons.rs
+++ b/src/fixtures/persons.rs
@@ -6,9 +6,8 @@ use serde::Deserialize;
 use uuid::Uuid;
 
 use crate::{
-    AppError, AppEvent, AppStore, Bsn, CountryCode, Date, DutchAddress, FirstName, FullName,
-    HouseNumber, Initials, LastName, Locality, PlaceOfResidence, PostalCode, StreetName,
-    UtcDateTime,
+    AppError, AppStore, Bsn, CountryCode, Date, DutchAddress, FirstName, FullName, HouseNumber,
+    Initials, LastName, Locality, PlaceOfResidence, PostalCode, StreetName, UtcDateTime,
     persons::{Gender, Person},
 };
 
@@ -123,8 +122,7 @@ pub async fn load(store: &AppStore) -> Result<(), AppError> {
             ))
         })?;
 
-        let person = record.into_person()?;
-        store.update(AppEvent::CreatePerson(person)).await?;
+        record.into_person()?.create(store).await?;
     }
 
     Ok(())

--- a/src/store/database.rs
+++ b/src/store/database.rs
@@ -1,17 +1,17 @@
 use crate::{
-    AppError, AppEvent, AppStore, constants::DEFAULT_STREAM_ID, store::AppStorePersistance,
+    AppError, AppEvent, AppStore, constants::DEFAULT_STREAM_ID, store::AppStorePersistence,
 };
 
 #[derive(Debug, sqlx::FromRow)]
 pub struct DatabaseEvent {
-    // pub event_id: i64,
+    pub event_id: i64,
     pub payload: serde_json::Value,
     // pub created_at: chrono::DateTime<chrono::Utc>,
 }
 
 impl AppStore {
     pub async fn load(&self) -> Result<(), AppError> {
-        let AppStorePersistance::Database(pool) = &self.persistance else {
+        let AppStorePersistence::Database(pool) = &self.persistence else {
             return Ok(());
         };
 
@@ -33,7 +33,7 @@ impl AppStore {
         &self,
         tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     ) -> Result<usize, AppError> {
-        let last_id = self.get_last_event_id()?;
+        let last_id: usize = self.get_last_event_id()?;
 
         let stream_last_id: i64 = sqlx::query_scalar(
             r#"SELECT last_event_id
@@ -47,7 +47,7 @@ impl AppStore {
 
         let missing: Vec<DatabaseEvent> = sqlx::query_as::<_, DatabaseEvent>(
             r#"
-            SELECT payload
+            SELECT event_id, payload
             FROM events
             WHERE stream_id = $1 AND event_id > $2
             ORDER BY event_id ASC
@@ -61,8 +61,18 @@ impl AppStore {
         let mut data = self.data.write();
 
         for event in missing {
+            if data.last_event_id >= event.event_id as usize {
+                // This can happen if another instance of the application processed events concurrently
+                // and updated the store before this instance could acquire the write lock. In that case,
+                // the store is already up-to-date and we can skip applying the event again.
+                continue;
+            }
+
             match serde_json::from_value::<AppEvent>(event.payload) {
-                Ok(ev) => AppStore::apply(ev, &mut data),
+                Ok(ev) => {
+                    AppStore::apply(ev, &mut data);
+                    data.last_event_id = event.event_id as usize;
+                }
                 Err(e) => {
                     tracing::error!("Failed to deserialize event: {e:?}");
                     continue;
@@ -102,7 +112,7 @@ impl AppStore {
     }
 
     pub async fn update(&self, event: AppEvent) -> Result<(), AppError> {
-        let AppStorePersistance::Database(pool) = &self.persistance else {
+        let AppStorePersistence::Database(pool) = &self.persistence else {
             let mut data = self.data.write();
             AppStore::apply(event, &mut data);
 
@@ -143,6 +153,14 @@ impl AppStore {
         tx.commit().await?;
 
         let mut data = self.data.write();
+
+        if data.last_event_id >= next_id {
+            // This can happen if another instance of the application processed events concurrently
+            // and updated the store before this instance could acquire the write lock. In that case,
+            // the store is already up-to-date and we can skip applying the event again.
+            return Ok(());
+        }
+
         AppStore::apply(event, &mut data);
         data.last_event_id = next_id;
 
@@ -151,7 +169,7 @@ impl AppStore {
 
     #[cfg(feature = "fixtures")]
     pub async fn clear(&self) -> Result<(), AppError> {
-        let AppStorePersistance::Database(pool) = &self.persistance else {
+        let AppStorePersistence::Database(pool) = &self.persistence else {
             return Ok(());
         };
 
@@ -193,7 +211,7 @@ mod tests {
         let person_id = PersonId::new();
         let person = sample_person(person_id);
 
-        store.update(AppEvent::CreatePerson(person.clone())).await?;
+        person.create(&store).await?;
 
         let loaded = store.get_person(person_id)?;
         assert_eq!(loaded.id, person_id);
@@ -213,7 +231,7 @@ mod tests {
         let person_id = PersonId::new();
         let person = sample_person(person_id);
 
-        store.update(AppEvent::CreatePerson(person.clone())).await?;
+        person.create(&store).await?;
 
         let invalid_payload = serde_json::json!({"not": "an app event"});
         sqlx::query(

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -33,21 +33,21 @@ pub struct AppStoreData {
 }
 
 #[derive(Clone)]
-pub enum AppStorePersistance {
+pub enum AppStorePersistence {
     Database(sqlx::PgPool),
     None,
 }
 
 #[derive(Clone)]
 pub struct AppStore {
-    pub persistance: AppStorePersistance,
+    pub persistence: AppStorePersistence,
     data: Arc<parking_lot::RwLock<AppStoreData>>,
 }
 
 impl AppStore {
     pub fn new(pool: sqlx::PgPool) -> Self {
         AppStore {
-            persistance: AppStorePersistance::Database(pool),
+            persistence: AppStorePersistence::Database(pool),
             data: Default::default(),
         }
     }
@@ -58,14 +58,11 @@ impl AppStore {
         let political_group = crate::test_utils::sample_political_group(political_group_id);
 
         let store = AppStore {
-            persistance: AppStorePersistance::None,
+            persistence: AppStorePersistence::None,
             data: Default::default(),
         };
 
-        store
-            .update(AppEvent::UpdatePoliticalGroup(political_group))
-            .await
-            .expect("store update");
+        political_group.update(&store).await.expect("store update");
 
         store
     }

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -347,9 +347,7 @@ async fn store_update_applies_event_in_memory() -> Result<(), crate::AppError> {
     let agent_id = crate::authorised_agents::AuthorisedAgentId::new();
     let agent = sample_authorised_agent(agent_id);
 
-    store
-        .update(AppEvent::CreateAuthorisedAgent(agent.clone()))
-        .await?;
+    agent.create(&store).await?;
 
     let loaded = store.get_authorised_agent(agent_id)?;
     assert_eq!(loaded.id, agent.id);

--- a/templates/candidates/components/update_steps.html
+++ b/templates/candidates/components/update_steps.html
@@ -15,7 +15,7 @@
       </a>
     </li>
     <li>
-      <a href="{{ candidate.update_address_path() }}" class="{% if !candidate.person.is_dutch() %}disabled locked{% else if candidate.person.is_address_complete() %}ok{% else if should_warn|default(true) %}warning{% endif %}">
+      <a href="{{ candidate.update_address_path() }}" class="{% if !candidate.person.is_dutch() %}disabled locked{% else if candidate.person.address.is_complete() %}ok{% else if should_warn|default(true) %}warning{% endif %}">
         {{ "person.correspondence_address"|trans }}
       </a>
     </li>

--- a/templates/persons/components/form.html
+++ b/templates/persons/components/form.html
@@ -19,7 +19,7 @@
       <input type="text" placeholder=" " name="country_of_residence" id="country_of_residence"
         value="{{ form.data.country_of_residence }}" minlength="2" maxlength="2" required />
       <ul>
-        {% for country in countries %}
+        {% for country in crate::persons::COUNTRY_CODES %}
         <li data-country="{{ country }}"><span>{{ country|flag }}</span> {{ country }}</li>
         {% endfor %}
       </ul>

--- a/templates/persons/components/update_steps.html
+++ b/templates/persons/components/update_steps.html
@@ -6,7 +6,7 @@
       </a>
     </li>
     <li>
-      <a href="{{ person.update_address_path() }}" class="{% if !person.is_dutch() %}disabled locked{% else if person.is_address_complete() %}ok{% else if should_warn|default(true) %}warning{% endif %}">
+      <a href="{{ person.update_address_path() }}" class="{% if !person.is_dutch() %}disabled locked{% else if person.address.is_complete() %}ok{% else if should_warn|default(true) %}warning{% endif %}">
         {{ "person.correspondence_address"|trans }}
       </a>
     </li>


### PR DESCRIPTION
- Use struct methods over directly sending events to the store
- Cleanup unused handlers in `src/core/candidate_lists/pages/list_submitter.rs`
- Cleanup some verbose handler logic

Fixes #260 
Fixes #262