### PR TITLE
Fix order of ValueTooLong arguments for initials

### DIFF
--- a/src/structs/initials.rs
+++ b/src/structs/initials.rs
@@ -33,7 +33,7 @@ impl FromStr for Initials {
         }
 
         if initials.len() > 20 {
-            return Err(ValidationError::ValueTooLong(20, initials.len()));
+            return Err(ValidationError::ValueTooLong(initials.len(), 20));
         }
 
         let parts: Vec<&str> = initials


### PR DESCRIPTION
### Before
<img width="651" height="340" alt="image" src="https://github.com/user-attachments/assets/0db340d6-42cb-4563-b761-a9ab374fd4da" />


### After
<img width="641" height="329" alt="image" src="https://github.com/user-attachments/assets/d153fef4-b919-4487-a5b0-0948ee51a39d" />
