### PR TITLE
Prevent error on missing form fields + handle form rejections

### DIFF
--- a/src/core/authorised_agents/pages/authorised_agent_create.rs
+++ b/src/core/authorised_agents/pages/authorised_agent_create.rs
@@ -3,11 +3,10 @@ use axum::{
     extract::State,
     response::{IntoResponse, Redirect, Response},
 };
-use axum_extra::extract::Form;
 
 use super::AuthorisedAgentCreatePath;
 use crate::{
-    AppError, AppStore, Context, HtmlTemplate,
+    AppError, AppStore, Context, Form, HtmlTemplate,
     authorised_agents::{AuthorisedAgent, AuthorisedAgentForm},
     filters,
     form::FormData,
@@ -54,7 +53,7 @@ pub async fn create_authorised_agent_submit(
 mod tests {
     use super::*;
     use crate::{
-        AppError, AppStore, Context,
+        AppError, AppStore, Context, Form,
         authorised_agents::AuthorisedAgent,
         political_groups::PoliticalGroupId,
         test_utils::{response_body_string, sample_authorised_agent_form, sample_political_group},
@@ -63,7 +62,6 @@ mod tests {
         http::{StatusCode, header},
         response::IntoResponse,
     };
-    use axum_extra::extract::Form;
 
     #[tokio::test]
     async fn create_authorised_agent_renders_csrf_field() -> Result<(), AppError> {

--- a/src/core/authorised_agents/pages/authorised_agent_delete.rs
+++ b/src/core/authorised_agents/pages/authorised_agent_delete.rs
@@ -1,10 +1,10 @@
+use crate::{
+    AppError, AppStore, Context, Form, authorised_agents::AuthorisedAgent, form::EmptyForm,
+};
 use axum::{
     extract::State,
     response::{IntoResponse, Redirect, Response},
 };
-use axum_extra::extract::Form;
-
-use crate::{AppError, AppStore, Context, authorised_agents::AuthorisedAgent, form::EmptyForm};
 
 use super::AuthorisedAgentDeletePath;
 
@@ -29,12 +29,11 @@ pub async fn delete_authorised_agent(
 mod tests {
     use super::*;
     use crate::{
-        AppError, AppStore, Context, TokenValue,
+        AppError, AppStore, Context, Form, TokenValue,
         authorised_agents::AuthorisedAgentId,
         political_groups::PoliticalGroupId,
         test_utils::{sample_authorised_agent, sample_political_group},
     };
-    use axum_extra::extract::Form;
 
     #[tokio::test]
     async fn delete_authorised_agent_removes_and_redirects() -> Result<(), AppError> {

--- a/src/core/authorised_agents/pages/authorised_agent_update.rs
+++ b/src/core/authorised_agents/pages/authorised_agent_update.rs
@@ -3,10 +3,9 @@ use axum::{
     extract::State,
     response::{IntoResponse, Redirect, Response},
 };
-use axum_extra::extract::Form;
 
 use crate::{
-    AppError, AppStore, Context, HtmlTemplate,
+    AppError, AppStore, Context, Form, HtmlTemplate,
     authorised_agents::{AuthorisedAgent, AuthorisedAgentForm},
     filters,
     form::FormData,
@@ -64,7 +63,7 @@ pub async fn update_authorised_agent_submit(
 mod tests {
     use super::*;
     use crate::{
-        AppError, AppStore, Context,
+        AppError, AppStore, Context, Form,
         authorised_agents::{AuthorisedAgent, AuthorisedAgentId},
         political_groups::PoliticalGroupId,
         test_utils::{
@@ -76,7 +75,6 @@ mod tests {
         http::{StatusCode, header},
         response::IntoResponse,
     };
-    use axum_extra::extract::Form;
 
     #[tokio::test]
     async fn update_authorised_agent_renders_existing_agent() -> Result<(), AppError> {

--- a/src/core/authorised_agents/structs/authorised_agent_form.rs
+++ b/src/core/authorised_agents/structs/authorised_agent_form.rs
@@ -4,6 +4,7 @@ use validate::Validate;
 
 #[derive(Default, Deserialize, Debug, Validate)]
 #[validate(target = "AuthorisedAgent")]
+#[serde(default)]
 pub struct AuthorisedAgentForm {
     #[validate(flatten)]
     #[serde(flatten)]

--- a/src/core/candidate_lists/pages/create.rs
+++ b/src/core/candidate_lists/pages/create.rs
@@ -3,10 +3,9 @@ use axum::{
     extract::State,
     response::{IntoResponse, Redirect, Response},
 };
-use axum_extra::extract::Form;
 
 use crate::{
-    AppError, AppStore, Context, ElectionConfig, HtmlTemplate,
+    AppError, AppStore, Context, ElectionConfig, Form, HtmlTemplate,
     candidate_lists::{CandidateList, CandidateListCreateForm, pages::CandidateListCreatePath},
     filters,
     form::FormData,
@@ -87,7 +86,6 @@ mod test {
         http::{StatusCode, header},
         response::IntoResponse,
     };
-    use axum_extra::extract::Form;
 
     use crate::{
         AppStore, Context, ElectoralDistrict, TokenValue,

--- a/src/core/candidate_lists/pages/delete.rs
+++ b/src/core/candidate_lists/pages/delete.rs
@@ -2,10 +2,9 @@ use axum::{
     extract::State,
     response::{IntoResponse, Redirect, Response},
 };
-use axum_extra::extract::Form;
 
 use crate::{
-    AppError, AppStore, Context,
+    AppError, AppStore, Context, Form,
     candidate_lists::{CandidateList, pages::CandidateListsDeletePath},
     form::EmptyForm,
 };
@@ -30,9 +29,10 @@ pub async fn delete_candidate_list(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{AppStore, ElectoralDistrict, TokenValue, candidate_lists::CandidateListSummary};
+    use crate::{
+        AppStore, ElectoralDistrict, Form, TokenValue, candidate_lists::CandidateListSummary,
+    };
     use axum::http::{StatusCode, header};
-    use axum_extra::extract::Form;
 
     #[tokio::test]
     async fn delete_candidate_list_and_redirect() -> Result<(), AppError> {

--- a/src/core/candidate_lists/pages/list_submitter.rs
+++ b/src/core/candidate_lists/pages/list_submitter.rs
@@ -3,10 +3,9 @@ use axum::{
     extract::{Query, State},
     response::{IntoResponse, Redirect, Response},
 };
-use axum_extra::extract::Form;
 
 use crate::{
-    AppError, AppStore, Context, HtmlTemplate, InitialQuery,
+    AppError, AppStore, Context, Form, HtmlTemplate, InitialQuery,
     candidate_lists::{CandidateList, ListSubmitterForm, pages::UpdateListSubmitterPath},
     filters,
     form::FormData,
@@ -107,7 +106,6 @@ mod tests {
         extract::Query,
         http::{StatusCode, header},
     };
-    use axum_extra::extract::Form;
 
     use crate::{
         AppStore, Context, CsrfTokens, ElectoralDistrict, InitialQuery, Locale, TokenValue,

--- a/src/core/candidate_lists/pages/update.rs
+++ b/src/core/candidate_lists/pages/update.rs
@@ -3,10 +3,9 @@ use axum::{
     extract::{Query, State},
     response::{IntoResponse, Redirect, Response},
 };
-use axum_extra::extract::Form;
 
 use crate::{
-    AppError, AppStore, Context, ElectionConfig, HtmlTemplate, InitialQuery,
+    AppError, AppStore, Context, ElectionConfig, Form, HtmlTemplate, InitialQuery,
     candidate_lists::{CandidateList, CandidateListForm, pages::CandidateListUpdatePath},
     filters,
     form::FormData,
@@ -70,7 +69,7 @@ pub async fn update_candidate_list_submit(
 mod tests {
     use super::*;
     use crate::{
-        AppStore, Context, ElectoralDistrict, InitialQuery, TokenValue, UtcDateTime,
+        AppStore, Context, ElectoralDistrict, Form, InitialQuery, TokenValue, UtcDateTime,
         candidate_lists::{CandidateListId, CandidateListSummary},
         test_utils::{response_body_string, sample_candidate_list},
     };
@@ -78,7 +77,6 @@ mod tests {
         extract::Query,
         http::{StatusCode, header},
     };
-    use axum_extra::extract::Form;
     use chrono::{Duration, Utc};
 
     #[tokio::test]

--- a/src/core/candidate_lists/structs/candidate_list_create_form.rs
+++ b/src/core/candidate_lists/structs/candidate_list_create_form.rs
@@ -5,9 +5,9 @@ use crate::{TokenValue, candidate_lists::CandidateList};
 
 #[derive(Default, Serialize, Deserialize, Clone, Debug, Validate)]
 #[validate(target = "CandidateList")]
+#[serde(default)]
 pub struct CandidateListCreateForm {
     pub electoral_districts: Vec<crate::ElectoralDistrict>,
-    #[serde(default)]
     #[validate(ignore)]
     pub copy_candidates: bool,
     #[validate(csrf)]

--- a/src/core/candidate_lists/structs/candidate_list_form.rs
+++ b/src/core/candidate_lists/structs/candidate_list_form.rs
@@ -5,6 +5,7 @@ use crate::{ElectoralDistrict, TokenValue, candidate_lists::CandidateList};
 
 #[derive(Default, Serialize, Deserialize, Clone, Debug, Validate)]
 #[validate(target = "CandidateList")]
+#[serde(default)]
 pub struct CandidateListForm {
     pub electoral_districts: Vec<ElectoralDistrict>,
     #[validate(csrf)]

--- a/src/core/candidate_lists/structs/list_submitter_form.rs
+++ b/src/core/candidate_lists/structs/list_submitter_form.rs
@@ -8,11 +8,10 @@ use crate::{
 
 #[derive(Default, Serialize, Deserialize, Clone, Debug, Validate)]
 #[validate(target = "CandidateList")]
+#[serde(default)]
 pub struct ListSubmitterForm {
     #[validate(parse = "ListSubmitterId", optional)]
-    #[serde(default)]
     pub list_submitter_id: String,
-    #[serde(default)]
     pub substitute_list_submitter_ids: Vec<SubstituteSubmitterId>,
     #[validate(csrf)]
     pub csrf_token: TokenValue,

--- a/src/core/candidates/pages/add.rs
+++ b/src/core/candidates/pages/add.rs
@@ -3,11 +3,10 @@ use axum::{
     extract::State,
     response::{IntoResponse, Redirect, Response},
 };
-use axum_extra::extract::Form;
 use serde::Deserialize;
 
 use crate::{
-    AppError, AppStore, Context, HtmlTemplate,
+    AppError, AppStore, Context, Form, HtmlTemplate,
     candidate_lists::{CandidateList, FullCandidateList},
     filters,
     persons::{Person, PersonId},
@@ -65,7 +64,7 @@ pub async fn add_person_to_candidate_list(
 mod tests {
     use super::*;
     use crate::{
-        AppStore, Context,
+        AppStore, Context, Form,
         candidate_lists::CandidateListId,
         persons::PersonId,
         test_utils::{
@@ -77,7 +76,6 @@ mod tests {
         http::{StatusCode, header},
         response::IntoResponse,
     };
-    use axum_extra::extract::Form;
 
     #[tokio::test]
     async fn view_candidate_list_renders_persons() -> Result<(), AppError> {

--- a/src/core/candidates/pages/create.rs
+++ b/src/core/candidates/pages/create.rs
@@ -3,10 +3,9 @@ use axum::{
     extract::State,
     response::{IntoResponse, Redirect, Response},
 };
-use axum_extra::extract::Form;
 
 use crate::{
-    AppError, AppStore, Context, HtmlTemplate, candidate_lists::FullCandidateList, filters,
+    AppError, AppStore, Context, Form, HtmlTemplate, candidate_lists::FullCandidateList, filters,
     form::FormData, persons::PersonForm,
 };
 
@@ -65,7 +64,7 @@ pub async fn create_person_candidate_list_submit(
 mod tests {
     use super::*;
     use crate::{
-        AppStore, Context,
+        AppStore, Context, Form,
         candidate_lists::CandidateListId,
         test_utils::{response_body_string, sample_candidate_list, sample_person_form},
     };
@@ -73,7 +72,6 @@ mod tests {
         http::{StatusCode, header},
         response::IntoResponse,
     };
-    use axum_extra::extract::Form;
 
     #[tokio::test]
     async fn create_person_candidate_list_renders_form() -> Result<(), AppError> {

--- a/src/core/candidates/pages/delete.rs
+++ b/src/core/candidates/pages/delete.rs
@@ -2,10 +2,9 @@ use axum::{
     extract::State,
     response::{IntoResponse, Redirect, Response},
 };
-use axum_extra::extract::Form;
 
 use crate::{
-    AppError, AppStore, Context, candidate_lists::CandidateList, candidates::Candidate,
+    AppError, AppStore, Context, Form, candidate_lists::CandidateList, candidates::Candidate,
     form::EmptyForm,
 };
 
@@ -35,13 +34,12 @@ pub async fn delete_person(
 mod tests {
     use super::*;
     use crate::{
-        AppStore,
+        AppStore, Form,
         candidate_lists::{CandidateListId, FullCandidateList},
         persons::PersonId,
         test_utils::{sample_candidate_list, sample_person, sample_person_with_last_name},
     };
     use axum::http::{StatusCode, header};
-    use axum_extra::extract::Form;
 
     #[tokio::test]
     async fn delete_person_removes_from_list_and_redirects() -> Result<(), AppError> {

--- a/src/core/candidates/pages/update.rs
+++ b/src/core/candidates/pages/update.rs
@@ -3,11 +3,11 @@ use axum::{
     extract::State,
     response::{IntoResponse, Redirect, Response},
 };
-use axum_extra::extract::Form;
 
 use crate::{
-    AppError, AppResponse, AppStore, Context, HtmlTemplate, candidate_lists::FullCandidateList,
-    candidates::Candidate, filters, form::FormData, persons::PersonForm,
+    AppError, AppResponse, AppStore, Context, Form, HtmlTemplate,
+    candidate_lists::FullCandidateList, candidates::Candidate, filters, form::FormData,
+    persons::PersonForm,
 };
 
 use super::CandidateListUpdatePersonPath;
@@ -68,7 +68,7 @@ pub async fn update_person_submit(
 mod tests {
     use super::*;
     use crate::{
-        AppStore, Context,
+        AppStore, Context, Form,
         candidate_lists::CandidateListId,
         persons::PersonId,
         test_utils::{
@@ -79,7 +79,6 @@ mod tests {
         http::{StatusCode, header},
         response::IntoResponse,
     };
-    use axum_extra::extract::Form;
 
     #[tokio::test]
     async fn update_person_renders_candidate() -> Result<(), AppError> {

--- a/src/core/candidates/pages/update_address.rs
+++ b/src/core/candidates/pages/update_address.rs
@@ -3,10 +3,9 @@ use axum::{
     extract::{Query, State},
     response::{IntoResponse, Redirect, Response},
 };
-use axum_extra::extract::Form;
 
 use crate::{
-    AppError, AppResponse, AppStore, Context, HtmlTemplate,
+    AppError, AppResponse, AppStore, Context, Form, HtmlTemplate,
     candidate_lists::FullCandidateList,
     candidates::Candidate,
     filters,
@@ -81,7 +80,7 @@ pub async fn update_person_address_submit(
 mod tests {
     use super::*;
     use crate::{
-        AppStore, Context,
+        AppStore, Context, Form,
         candidate_lists::CandidateListId,
         persons::PersonId,
         test_utils::{
@@ -94,7 +93,6 @@ mod tests {
         http::{StatusCode, header},
         response::IntoResponse,
     };
-    use axum_extra::extract::Form;
 
     #[tokio::test]
     async fn update_person_address_renders_candidate() -> Result<(), AppError> {

--- a/src/core/candidates/pages/update_position.rs
+++ b/src/core/candidates/pages/update_position.rs
@@ -3,10 +3,9 @@ use axum::{
     extract::State,
     response::{IntoResponse, Redirect},
 };
-use axum_extra::extract::Form;
 
 use crate::{
-    AppError, AppStore, Context, HtmlTemplate,
+    AppError, AppStore, Context, Form, HtmlTemplate,
     candidate_lists::FullCandidateList,
     candidates::{Candidate, CandidatePosition, CandidatePositionAction, CandidatePositionForm},
     filters,
@@ -99,7 +98,7 @@ pub async fn update_candidate_position_submit(
 mod tests {
     use super::*;
     use crate::{
-        AppStore, Context, TokenValue,
+        AppStore, Context, Form, TokenValue,
         candidate_lists::CandidateListId,
         persons::PersonId,
         test_utils::{
@@ -108,7 +107,6 @@ mod tests {
         },
     };
     use axum::{http::StatusCode, response::IntoResponse};
-    use axum_extra::extract::Form;
 
     fn sample_position_form(
         csrf_token: &TokenValue,

--- a/src/core/candidates/pages/update_representative.rs
+++ b/src/core/candidates/pages/update_representative.rs
@@ -3,10 +3,9 @@ use axum::{
     extract::{Query, State},
     response::{IntoResponse, Redirect, Response},
 };
-use axum_extra::extract::Form;
 
 use crate::{
-    AppError, AppResponse, AppStore, Context, HtmlTemplate,
+    AppError, AppResponse, AppStore, Context, Form, HtmlTemplate,
     candidate_lists::FullCandidateList,
     candidates::Candidate,
     filters,
@@ -82,7 +81,7 @@ pub async fn update_representative_submit(
 mod tests {
     use super::*;
     use crate::{
-        AppError, AppStore, Context,
+        AppError, AppStore, Context, Form,
         candidate_lists::CandidateListId,
         persons::PersonId,
         test_utils::{
@@ -95,7 +94,6 @@ mod tests {
         http::{StatusCode, header},
         response::IntoResponse,
     };
-    use axum_extra::extract::Form;
 
     #[tokio::test]
     async fn update_representative_renders_candidate() -> Result<(), AppError> {

--- a/src/core/candidates/structs/candidate_position.rs
+++ b/src/core/candidates/structs/candidate_position.rs
@@ -25,6 +25,7 @@ pub struct CandidatePosition {
 
 #[derive(Default, Serialize, Deserialize, Clone, Debug, Validate)]
 #[validate(target = "CandidatePosition")]
+#[serde(default)]
 pub struct CandidatePositionForm {
     #[validate(parse = "usize")]
     pub position: String,

--- a/src/core/list_submitters/pages/list_submitter_create.rs
+++ b/src/core/list_submitters/pages/list_submitter_create.rs
@@ -3,11 +3,10 @@ use axum::{
     extract::State,
     response::{IntoResponse, Redirect, Response},
 };
-use axum_extra::extract::Form;
 
 use super::ListSubmitterCreatePath;
 use crate::{
-    AppError, AppStore, Context, HtmlTemplate, filters,
+    AppError, AppStore, Context, Form, HtmlTemplate, filters,
     form::FormData,
     list_submitters::{ListSubmitter, ListSubmitterForm},
 };
@@ -54,7 +53,7 @@ pub async fn create_list_submitter_submit(
 mod tests {
     use super::*;
     use crate::{
-        AppError, AppStore, Context,
+        AppError, AppStore, Context, Form,
         list_submitters::ListSubmitter,
         political_groups::PoliticalGroupId,
         test_utils::{response_body_string, sample_list_submitter_form, sample_political_group},
@@ -63,7 +62,6 @@ mod tests {
         http::{StatusCode, header},
         response::IntoResponse,
     };
-    use axum_extra::extract::Form;
 
     #[tokio::test]
     async fn create_list_submitter_renders_csrf_field() {

--- a/src/core/list_submitters/pages/list_submitter_delete.rs
+++ b/src/core/list_submitters/pages/list_submitter_delete.rs
@@ -2,9 +2,8 @@ use axum::{
     extract::State,
     response::{IntoResponse, Redirect, Response},
 };
-use axum_extra::extract::Form;
 
-use crate::{AppError, AppStore, Context, form::EmptyForm, list_submitters::ListSubmitter};
+use crate::{AppError, AppStore, Context, Form, form::EmptyForm, list_submitters::ListSubmitter};
 
 use super::ListSubmitterDeletePath;
 
@@ -29,12 +28,11 @@ pub async fn delete_list_submitter(
 mod tests {
     use super::*;
     use crate::{
-        AppError, AppStore, Context, TokenValue,
+        AppError, AppStore, Context, Form, TokenValue,
         list_submitters::{ListSubmitter, ListSubmitterId},
         political_groups::PoliticalGroupId,
         test_utils::{sample_list_submitter, sample_political_group},
     };
-    use axum_extra::extract::Form;
 
     #[tokio::test]
     async fn delete_list_submitter_removes_and_redirects() -> Result<(), AppError> {

--- a/src/core/list_submitters/pages/list_submitter_update.rs
+++ b/src/core/list_submitters/pages/list_submitter_update.rs
@@ -3,10 +3,9 @@ use axum::{
     extract::State,
     response::{IntoResponse, Redirect, Response},
 };
-use axum_extra::extract::Form;
 
 use crate::{
-    AppError, AppStore, Context, HtmlTemplate, filters,
+    AppError, AppStore, Context, Form, HtmlTemplate, filters,
     form::FormData,
     list_submitters::{ListSubmitter, ListSubmitterForm},
 };
@@ -63,7 +62,7 @@ pub async fn update_list_submitter_submit(
 mod tests {
     use super::*;
     use crate::{
-        AppError, AppStore, Context,
+        AppError, AppStore, Context, Form,
         list_submitters::{ListSubmitter, ListSubmitterId},
         political_groups::PoliticalGroupId,
         test_utils::{
@@ -75,7 +74,6 @@ mod tests {
         http::{StatusCode, header},
         response::IntoResponse,
     };
-    use axum_extra::extract::Form;
 
     #[tokio::test]
     async fn update_list_submitter_renders_existing_submitter() -> Result<(), AppError> {

--- a/src/core/list_submitters/structs/list_submitter_form.rs
+++ b/src/core/list_submitters/structs/list_submitter_form.rs
@@ -4,6 +4,7 @@ use validate::Validate;
 
 #[derive(Default, Deserialize, Debug, Validate)]
 #[validate(target = "ListSubmitter")]
+#[serde(default)]
 pub struct ListSubmitterForm {
     #[validate(flatten)]
     #[serde(flatten)]

--- a/src/core/persons/pages/address.rs
+++ b/src/core/persons/pages/address.rs
@@ -3,10 +3,9 @@ use axum::{
     extract::{Query, State},
     response::{IntoResponse, Redirect, Response},
 };
-use axum_extra::extract::Form;
 
 use crate::{
-    AppError, AppResponse, AppStore, Context, HtmlTemplate, filters,
+    AppError, AppResponse, AppStore, Context, Form, HtmlTemplate, filters,
     form::FormData,
     persons::{AddressForm, InitialQuery, Person, pages::UpdatePersonAddressPath},
 };
@@ -67,7 +66,7 @@ pub async fn update_person_address_submit(
 mod tests {
     use super::*;
     use crate::{
-        AppError, AppStore, Context, DutchAddressForm,
+        AppError, AppStore, Context, DutchAddressForm, Form,
         persons::PersonId,
         test_utils::{response_body_string, sample_address_form, sample_person},
     };
@@ -76,7 +75,6 @@ mod tests {
         http::{StatusCode, header},
         response::IntoResponse,
     };
-    use axum_extra::extract::Form;
 
     #[tokio::test]
     async fn update_person_address_renders_existing_person() -> Result<(), AppError> {

--- a/src/core/persons/pages/create.rs
+++ b/src/core/persons/pages/create.rs
@@ -3,10 +3,9 @@ use axum::{
     extract::State,
     response::{IntoResponse, Redirect, Response},
 };
-use axum_extra::extract::Form;
 
 use crate::{
-    AppError, AppStore, Context, HtmlTemplate, filters,
+    AppError, AppStore, Context, Form, HtmlTemplate, filters,
     form::FormData,
     persons::{Person, PersonForm, pages::PersonsCreatePath},
 };
@@ -51,14 +50,13 @@ pub async fn create_person_submit(
 mod tests {
     use super::*;
     use crate::{
-        AppError, AppStore, Context,
+        AppError, AppStore, Context, Form,
         test_utils::{response_body_string, sample_person_form},
     };
     use axum::{
         http::{StatusCode, header},
         response::IntoResponse,
     };
-    use axum_extra::extract::Form;
 
     #[tokio::test]
     async fn create_person_renders_csrf_field() {

--- a/src/core/persons/pages/delete.rs
+++ b/src/core/persons/pages/delete.rs
@@ -2,10 +2,9 @@ use axum::{
     extract::State,
     response::{IntoResponse, Redirect, Response},
 };
-use axum_extra::extract::Form;
 
 use crate::{
-    AppError, AppStore, Context,
+    AppError, AppStore, Context, Form,
     form::EmptyForm,
     persons::{Person, pages::DeletePersonPath},
 };
@@ -33,8 +32,7 @@ pub async fn delete_person(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{AppError, AppStore, Context, persons::PersonId, test_utils::sample_person};
-    use axum_extra::extract::Form;
+    use crate::{AppError, AppStore, Context, Form, persons::PersonId, test_utils::sample_person};
 
     #[tokio::test]
     async fn delete_person_removes_and_redirects() -> Result<(), AppError> {

--- a/src/core/persons/pages/representative.rs
+++ b/src/core/persons/pages/representative.rs
@@ -3,10 +3,9 @@ use axum::{
     extract::{Query, State},
     response::{IntoResponse, Redirect, Response},
 };
-use axum_extra::extract::Form;
 
 use crate::{
-    AppError, AppResponse, AppStore, Context, HtmlTemplate, filters,
+    AppError, AppResponse, AppStore, Context, Form, HtmlTemplate, filters,
     form::FormData,
     persons::{InitialQuery, Person, RepresentativeForm, pages::UpdateRepresentativePath},
 };
@@ -68,7 +67,7 @@ pub async fn update_representative_submit(
 mod tests {
     use super::*;
     use crate::{
-        AppError, AppStore, Context,
+        AppError, AppStore, Context, Form,
         persons::PersonId,
         test_utils::{
             extract_csrf_token, response_body_string, sample_person, sample_representative_form,
@@ -79,7 +78,6 @@ mod tests {
         http::{StatusCode, header},
         response::IntoResponse,
     };
-    use axum_extra::extract::Form;
 
     #[tokio::test]
     async fn update_representative_renders_existing_person() -> Result<(), AppError> {

--- a/src/core/persons/pages/update.rs
+++ b/src/core/persons/pages/update.rs
@@ -3,10 +3,9 @@ use axum::{
     extract::State,
     response::{IntoResponse, Redirect, Response},
 };
-use axum_extra::extract::Form;
 
 use crate::{
-    AppError, AppResponse, AppStore, Context, HtmlTemplate, filters,
+    AppError, AppResponse, AppStore, Context, Form, HtmlTemplate, filters,
     form::FormData,
     persons::{Person, PersonForm, pages::UpdatePersonPath},
 };
@@ -60,7 +59,7 @@ pub async fn update_person_submit(
 mod tests {
     use super::*;
     use crate::{
-        AppError, AppStore, Context,
+        AppError, AppStore, Context, Form,
         persons::PersonId,
         test_utils::{response_body_string, sample_person, sample_person_form},
     };
@@ -68,7 +67,6 @@ mod tests {
         http::{StatusCode, header},
         response::IntoResponse,
     };
-    use axum_extra::extract::Form;
 
     #[tokio::test]
     async fn update_person_renders_existing_person() -> Result<(), AppError> {

--- a/src/core/persons/structs/address_form.rs
+++ b/src/core/persons/structs/address_form.rs
@@ -5,6 +5,7 @@ use crate::{DutchAddressForm, TokenValue, persons::Person};
 
 #[derive(Default, Serialize, Deserialize, Clone, Debug, Validate)]
 #[validate(target = "Person")]
+#[serde(default)]
 pub struct AddressForm {
     #[validate(flatten)]
     #[serde(flatten)]

--- a/src/core/persons/structs/person_form.rs
+++ b/src/core/persons/structs/person_form.rs
@@ -11,6 +11,7 @@ use crate::{
 
 #[derive(Default, Serialize, Deserialize, Clone, Debug, Validate)]
 #[validate(target = "Person")]
+#[serde(default)]
 pub struct PersonForm {
     #[validate(parse = "Gender", optional)]
     pub gender: String,
@@ -23,7 +24,6 @@ pub struct PersonForm {
     pub date_of_birth: String,
     #[validate(parse = "Bsn", optional)]
     pub bsn: String,
-    #[serde(default)]
     pub no_bsn_confirmed: bool,
     #[validate(parse = "PlaceOfResidence", optional)]
     pub place_of_residence: String,

--- a/src/core/persons/structs/representative_form.rs
+++ b/src/core/persons/structs/representative_form.rs
@@ -5,6 +5,7 @@ use crate::{DutchAddressForm, FullNameForm, TokenValue, persons::Representative}
 
 #[derive(Default, Serialize, Deserialize, Clone, Debug, Validate)]
 #[validate(target = "Representative", timestamps = false)]
+#[serde(default)]
 pub struct RepresentativeForm {
     #[validate(flatten)]
     #[serde(flatten)]

--- a/src/core/political_groups/pages/update.rs
+++ b/src/core/political_groups/pages/update.rs
@@ -3,13 +3,12 @@ use axum::{
     extract::State,
     response::{IntoResponse, Redirect, Response},
 };
-use axum_extra::extract::Form;
 
 use crate::{
     AppError, AppStore, Context, HtmlTemplate,
     authorised_agents::AuthorisedAgent,
     filters,
-    form::FormData,
+    form::{Form, FormData},
     list_submitters::ListSubmitter,
     political_groups::{PoliticalGroup, PoliticalGroupForm, PoliticalGroupSteps},
 };
@@ -71,7 +70,7 @@ pub async fn update_political_group_submit(
 mod tests {
     use super::*;
     use crate::{
-        AppError, AppStore, Context,
+        AppError, AppStore, Context, Form,
         authorised_agents::AuthorisedAgentId,
         political_groups::PoliticalGroupId,
         test_utils::{
@@ -83,7 +82,6 @@ mod tests {
         http::{StatusCode, header},
         response::IntoResponse,
     };
-    use axum_extra::extract::Form;
 
     #[tokio::test]
     async fn update_political_group_renders_existing_data() -> Result<(), AppError> {

--- a/src/core/political_groups/structs/political_group_form.rs
+++ b/src/core/political_groups/structs/political_group_form.rs
@@ -7,9 +7,9 @@ use crate::{
 
 #[derive(Default, Deserialize, Debug, Validate)]
 #[validate(target = "PoliticalGroup")]
+#[serde(default)]
 pub struct PoliticalGroupForm {
     #[validate(parse = "bool", optional)]
-    #[serde(default)]
     pub long_list_allowed: String,
     #[validate(parse = "LegalName", optional)]
     pub legal_name: String,

--- a/src/core/substitute_list_submitters/pages/substitute_submitter_create.rs
+++ b/src/core/substitute_list_submitters/pages/substitute_submitter_create.rs
@@ -3,11 +3,10 @@ use axum::{
     extract::State,
     response::{IntoResponse, Redirect, Response},
 };
-use axum_extra::extract::Form;
 
 use super::SubstituteSubmitterCreatePath;
 use crate::{
-    AppError, AppStore, Context, HtmlTemplate, filters,
+    AppError, AppStore, Context, Form, HtmlTemplate, filters,
     form::FormData,
     list_submitters::ListSubmitter,
     substitute_list_submitters::{SubstituteSubmitter, SubstituteSubmitterForm},
@@ -58,7 +57,6 @@ mod tests {
         http::{StatusCode, header},
         response::IntoResponse,
     };
-    use axum_extra::extract::Form;
 
     use crate::{
         AppError, AppStore, Context,

--- a/src/core/substitute_list_submitters/pages/substitute_submitter_delete.rs
+++ b/src/core/substitute_list_submitters/pages/substitute_submitter_delete.rs
@@ -2,10 +2,9 @@ use axum::{
     extract::State,
     response::{IntoResponse, Redirect, Response},
 };
-use axum_extra::extract::Form;
 
 use crate::{
-    AppError, AppStore, Context, form::EmptyForm, list_submitters::ListSubmitter,
+    AppError, AppStore, Context, Form, form::EmptyForm, list_submitters::ListSubmitter,
     substitute_list_submitters::SubstituteSubmitter,
 };
 
@@ -31,7 +30,6 @@ pub async fn delete_substitute_submitter(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum_extra::extract::Form;
 
     use crate::{
         AppError, AppStore, Context, TokenValue,

--- a/src/core/substitute_list_submitters/pages/substitute_submitter_update.rs
+++ b/src/core/substitute_list_submitters/pages/substitute_submitter_update.rs
@@ -3,10 +3,9 @@ use axum::{
     extract::State,
     response::{IntoResponse, Redirect, Response},
 };
-use axum_extra::extract::Form;
 
 use crate::{
-    AppError, AppStore, Context, HtmlTemplate, filters,
+    AppError, AppStore, Context, Form, HtmlTemplate, filters,
     form::FormData,
     list_submitters::ListSubmitter,
     substitute_list_submitters::{SubstituteSubmitter, SubstituteSubmitterForm},
@@ -70,7 +69,6 @@ mod tests {
         http::{StatusCode, header},
         response::IntoResponse,
     };
-    use axum_extra::extract::Form;
 
     use crate::{
         AppError, AppStore, Context,

--- a/src/core/substitute_list_submitters/structs/substitute_submitter_form.rs
+++ b/src/core/substitute_list_submitters/structs/substitute_submitter_form.rs
@@ -6,6 +6,7 @@ use validate::Validate;
 
 #[derive(Default, Deserialize, Debug, Validate)]
 #[validate(target = "SubstituteSubmitter")]
+#[serde(default)]
 pub struct SubstituteSubmitterForm {
     #[validate(flatten)]
     #[serde(flatten)]

--- a/src/error/app_error.rs
+++ b/src/error/app_error.rs
@@ -1,7 +1,8 @@
 use axum::extract::{
     multipart::{MultipartError, MultipartRejection},
-    rejection::{FormRejection, JsonRejection, PathRejection, QueryRejection},
+    rejection::{JsonRejection, PathRejection, QueryRejection},
 };
+use axum_extra::extract::FormRejection;
 use std::{
     convert::Infallible,
     fmt::{Display, Formatter},
@@ -132,14 +133,14 @@ impl From<Infallible> for AppError {
 mod tests {
     use super::*;
     use crate::{
-        Context, ErrorResponse, HtmlTemplate, error::response::ErrorTemplate,
+        Context, ErrorResponse, Form, HtmlTemplate, error::response::ErrorTemplate,
         form::ValidationError, test_utils,
     };
     use axum::{
         body::Body,
         extract::{
             FromRequest, Multipart, Path, Request,
-            rejection::{InvalidFormContentType, JsonRejection, MissingJsonContentType},
+            rejection::{JsonRejection, MissingJsonContentType},
         },
         response::IntoResponse,
     };
@@ -187,7 +188,15 @@ mod tests {
 
     #[tokio::test]
     async fn app_error_variants_convert_to_error_response() {
-        let form_rejection: FormRejection = InvalidFormContentType::default().into();
+        let form_rejection = Form::<bool>::from_request(
+            Request::builder()
+                .uri("/save")
+                .body(Body::from("incorrect"))
+                .unwrap(),
+            &(),
+        )
+        .await
+        .unwrap_err();
         let json_rejection: JsonRejection = MissingJsonContentType::default().into();
         let multipart_rejection = Multipart::from_request(get_multipart_rejection_request(), &())
             .await
@@ -215,7 +224,7 @@ mod tests {
             AppError::from(askama::Error::Fmt),
             AppError::from(multipart_rejection),
             AppError::from(multipart_error),
-            AppError::from(form_rejection),
+            form_rejection,
             AppError::from(json_rejection),
             AppError::from(path_rejection),
             AppError::ValidationError(vec![("name".to_string(), ValidationError::InvalidValue)]),

--- a/src/form/empty_form.rs
+++ b/src/form/empty_form.rs
@@ -8,6 +8,7 @@ pub struct EmptyFormValue;
 
 #[derive(Default, Serialize, Deserialize, Clone, Debug, Validate)]
 #[validate(target = "EmptyFormValue", timestamps = false)]
+#[serde(default)]
 pub struct EmptyForm {
     #[validate(csrf)]
     pub csrf_token: TokenValue,

--- a/src/form/mod.rs
+++ b/src/form/mod.rs
@@ -10,7 +10,30 @@ pub use form_data::FormData;
 pub use string_validators::{is_teletex_char, validate_length, validate_teletex_chars};
 pub use validation_error::ValidationError;
 
+use axum::extract::{FromRequest, Request};
+use axum_extra::extract::Form as AxumForm;
+use serde::de::DeserializeOwned;
+
+use crate::AppError;
+
 pub type FieldErrors = Vec<(String, ValidationError)>;
+
+#[derive(Debug)]
+pub struct Form<T>(pub T);
+
+impl<T, S> FromRequest<S> for Form<T>
+where
+    S: Sync + Send,
+    T: DeserializeOwned,
+{
+    type Rejection = AppError;
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        let AxumForm(form) = AxumForm::<T>::from_request(req, state).await?;
+
+        Ok(Form(form))
+    }
+}
 
 pub trait IntoValidationError {
     fn into_validation_error(self) -> ValidationError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub use core::{
     substitute_list_submitters,
 };
 pub use error::{AppError, AppResponse, ErrorResponse, render_error_pages};
-pub use form::{CsrfToken, CsrfTokens, TokenValue};
+pub use form::{CsrfToken, CsrfTokens, Form, TokenValue};
 pub use store::{AppEvent, AppStore, AppStoreData};
 pub use structs::{
     Bsn, CountryCode, Date, DutchAddress, DutchAddressForm, FirstName, FullName, FullNameForm,

--- a/src/structs/address.rs
+++ b/src/structs/address.rs
@@ -33,6 +33,7 @@ impl DutchAddress {
 
 #[derive(Default, Serialize, Deserialize, Clone, Debug, Validate)]
 #[validate(target = "DutchAddress", timestamps = false)]
+#[serde(default)]
 pub struct DutchAddressForm {
     #[validate(parse = "Locality", optional)]
     pub locality: String,

--- a/src/structs/name.rs
+++ b/src/structs/name.rs
@@ -44,6 +44,7 @@ impl FullName {
 
 #[derive(Default, Serialize, Deserialize, Clone, Debug, Validate)]
 #[validate(target = "FullName", timestamps = false)]
+#[serde(default)]
 pub struct FullNameForm {
     #[validate(parse = "LastName")]
     pub last_name: String,


### PR DESCRIPTION
- Previously you would get a black page with an error message if form deserialisation failed
- This introduces a Form type that will render the standard AppError page
- Added `#[serde(default)]` for all forms, to prevent errors when a field is missing