### PR TITLE
Fix flake PW test: remove check that triggers race condition

### DIFF
--- a/playwright/tests/edit-candidate-list.spec.ts
+++ b/playwright/tests/edit-candidate-list.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { test } from "@playwright/test";
 import { CandidateListsOverviewPage } from "./pages/candidateListsOverviewPage";
 import { ManageCandidateListPage } from "./pages/manageCandidateListPage";
 
@@ -27,7 +27,4 @@ test("edit candidate list", async ({ page }) => {
     "Friesland",
     "Groningen",
   ]);
-
-  await candidateListsOverviewPage.open();
-  await expect(page.getByText("Kieskringen: Alle")).toBeVisible();
 });


### PR DESCRIPTION
This is a temporary fix.

This test should be improved, see issue #281