### PR TITLE
Fix referrer typo

### DIFF
--- a/src/common/context.rs
+++ b/src/common/context.rs
@@ -23,7 +23,7 @@ pub struct Context {
     /// Whether to show the success alert based on the request query.
     pub show_success_alert: bool,
     /// Whether the request came from an overlay page (via referrer query).
-    pub overlay_refferer: bool,
+    pub overlay_referrer: bool,
     /// CSRF tokens used to protect form submissions.
     pub csrf_tokens: CsrfTokens,
 }
@@ -40,7 +40,7 @@ impl Context {
             election,
             csrf_tokens,
             show_success_alert: false,
-            overlay_refferer: false,
+            overlay_referrer: false,
         }
     }
 
@@ -68,7 +68,7 @@ impl askama::Values for Context {
             "election" => Some(&self.election as &dyn std::any::Any),
             "max_candidates" => Some(&self.max_candidates as &dyn std::any::Any),
             "show_success_alert" => Some(&self.show_success_alert as &dyn std::any::Any),
-            "overlay_refferer" => Some(&self.overlay_refferer as &dyn std::any::Any),
+            "overlay_referrer" => Some(&self.overlay_referrer as &dyn std::any::Any),
             _ => None,
         }
     }
@@ -90,7 +90,7 @@ where
             .uri
             .query()
             .is_some_and(|q| q.contains("success=true"));
-        let overlay_refferer = parts
+        let overlay_referrer = parts
             .headers
             .get(axum::http::header::REFERER)
             .and_then(|value| value.to_str().ok())
@@ -104,7 +104,7 @@ where
             political_group,
             locale,
             show_success_alert,
-            overlay_refferer,
+            overlay_referrer,
             election,
             max_candidates,
             csrf_tokens,

--- a/templates/components/overlay.html
+++ b/templates/components/overlay.html
@@ -3,7 +3,7 @@
 {% block overlay %}
   <div class="overlay-backdrop">
     <form method="post"
-          class="overlay {% if let Ok(overlay_refferer) = "overlay_refferer"|value::<bool> && overlay_refferer %}no-animation{% else %}animation{% endif %}">
+          class="overlay {% if let Ok(overlay_referrer) = "overlay_referrer"|value::<bool> && overlay_referrer %}no-animation{% else %}animation{% endif %}">
       {% if form is defined %}<input type="hidden" name="csrf_token" value="{{ form.data.csrf_token }}" />{% endif %}
       <header>
         <h2>


### PR DESCRIPTION
Despite the HTTP standard [misspelling referrer as referer](https://en.wikipedia.org/wiki/HTTP_referer), I don't think we should introduce yet another misspelling of referrer