### PR TITLE
Added a filesystem storage

### DIFF
--- a/deploy/e-ks/templates/deployment.yaml
+++ b/deploy/e-ks/templates/deployment.yaml
@@ -33,6 +33,8 @@ spec:
                 secretKeyRef:
                   name: secrets
                   key: database_url
+            - name: TYPST_URL
+              value: "http://typst:80"
           resources:
             limits:
               memory: "50Mi"

--- a/deploy/e-ks/values.yaml
+++ b/deploy/e-ks/values.yaml
@@ -14,10 +14,10 @@ typst:
 
 bag:
   image: "ghcr.io/tweedegolf/bag-address-lookup"
-  version: "0.3.3"
+  version: "0.3.5"
 
 eks:
-  image: "ghcr.io/kiesraad/e-ks/eks-core"
+  image: "ghcr.io/kiesraad/e-ks/eks"
 
 db:
   setup: false

--- a/src/store/database.rs
+++ b/src/store/database.rs
@@ -114,17 +114,7 @@ where
 
     tx.commit().await?;
 
-    let mut data = store.data.write();
-
-    if data.last_event_id() >= next_id {
-        // This can happen if another instance of the application processed events concurrently
-        // and updated the store before this instance could acquire the write lock. In that case,
-        // the store is already up-to-date and we can skip applying the event again.
-        return Ok(());
-    }
-
-    data.apply(store_event);
-    data.set_last_event_id(next_id);
+    store.apply_event(next_id, store_event);
 
     Ok(())
 }

--- a/src/store/filesystem.rs
+++ b/src/store/filesystem.rs
@@ -3,54 +3,21 @@
 //! Events are stored as newline-delimited JSON (one event per line) in a single file
 //! per stream. Appends are performed with `O_APPEND` to avoid rewriting the file.
 
-use std::{
-    fs::{self, File, OpenOptions},
-    io::{BufRead, BufReader, Write},
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
-use chrono::{DateTime, Utc};
+use chrono::Utc;
 use serde::{Serialize, de::DeserializeOwned};
+use tokio::{
+    fs::{self, File, OpenOptions},
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+};
 
 use super::{Store, StoreData, StoreEvent};
 use crate::{AppError, constants::DEFAULT_STREAM_ID};
 
-#[derive(Debug, Serialize, serde::Deserialize)]
-struct FileEvent<E> {
-    event_id: usize,
-    payload: E,
-    created_at: DateTime<Utc>,
-}
-
-#[derive(Serialize)]
-struct FileEventRef<'a, E> {
-    event_id: usize,
-    payload: &'a E,
-    created_at: DateTime<Utc>,
-}
-
-impl<E> From<StoreEvent<E>> for FileEvent<E> {
-    fn from(event: StoreEvent<E>) -> Self {
-        Self {
-            event_id: event.event_id,
-            payload: event.payload,
-            created_at: event.created_at,
-        }
-    }
-}
-
 /// Ensure the filesystem storage directory exists.
-pub fn init_local(dir: &Path) -> Result<(), AppError> {
-    fs::create_dir_all(dir).map_err(AppError::ServerError)
-}
-
-/// Load and replay persisted events into the in-memory store.
-pub async fn load_from_filesystem<D>(store: &Store<D>, dir: &Path) -> Result<(), AppError>
-where
-    D: StoreData,
-    D::Event: DeserializeOwned,
-{
-    replay_from_file(store, dir).map(|_| ())
+pub async fn init_local(dir: &Path) -> Result<(), AppError> {
+    fs::create_dir_all(dir).await.map_err(AppError::ServerError)
 }
 
 /// Append the event to the filesystem and apply it to the store.
@@ -63,7 +30,7 @@ where
     D: StoreData,
     D::Event: Serialize + DeserializeOwned,
 {
-    let last_id = catch_up(store, dir)?;
+    let last_id = replay_from_file(store, dir).await?;
     let next_id = last_id + 1;
 
     let store_event = StoreEvent {
@@ -72,55 +39,37 @@ where
         created_at: Utc::now(),
     };
 
-    append_once(dir, &store_event)?;
+    append_once(dir, &store_event).await?;
 
-    let mut data = store.data.write();
-
-    if data.last_event_id() >= next_id {
-        return Ok(());
-    }
-
-    data.apply(store_event);
-    data.set_last_event_id(next_id);
+    store.apply_event(next_id, store_event);
 
     Ok(())
 }
 
-fn catch_up<D>(store: &Store<D>, dir: &Path) -> Result<usize, AppError>
-where
-    D: StoreData,
-    D::Event: DeserializeOwned,
-{
-    replay_from_file(store, dir)
-}
-
-fn replay_from_file<D>(store: &Store<D>, dir: &Path) -> Result<usize, AppError>
+pub async fn replay_from_file<D>(store: &Store<D>, dir: &Path) -> Result<usize, AppError>
 where
     D: StoreData,
     D::Event: DeserializeOwned,
 {
     let path = stream_path(dir);
-    let file = match File::open(&path) {
+    let file = match File::open(&path).await {
         Ok(file) => file,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(0),
         Err(err) => return Err(AppError::ServerError(err)),
     };
 
     let reader = BufReader::new(file);
-    let mut data = store.data.write();
     let mut last_file_id = 0usize;
+    let mut events = Vec::new();
 
-    for line in reader.lines() {
-        let line = match line {
-            Ok(line) => line,
-            Err(err) => return Err(AppError::ServerError(err)),
-        };
+    let mut lines = reader.lines();
 
+    while let Ok(Some(line)) = lines.next_line().await {
         if line.trim().is_empty() {
             continue;
         }
 
-        let event: FileEvent<serde_json::Value> = match serde_json::from_str(&line) {
+        let event: StoreEvent<serde_json::Value> = match serde_json::from_str(&line) {
             Ok(event) => event,
             Err(err) => {
                 tracing::error!("Failed to deserialize event line: {err:?}");
@@ -129,7 +78,12 @@ where
         };
 
         last_file_id = last_file_id.max(event.event_id);
+        events.push(event);
+    }
 
+    let mut data = store.data.write();
+
+    for event in events {
         if data.last_event_id() >= event.event_id {
             continue;
         }
@@ -154,24 +108,25 @@ where
     Ok(last_file_id)
 }
 
-fn append_once<E: Serialize>(dir: &Path, event: &StoreEvent<E>) -> Result<(), AppError> {
+async fn append_once<E: Serialize>(dir: &Path, event: &StoreEvent<E>) -> Result<(), AppError> {
     let path = stream_path(dir);
     let mut file = OpenOptions::new()
         .create(true)
         .append(true)
         .open(&path)
+        .await
         .map_err(AppError::ServerError)?;
 
-    let mut payload = serde_json::to_vec(&FileEventRef {
+    let mut payload = serde_json::to_vec(&StoreEvent {
         event_id: event.event_id,
         payload: &event.payload,
         created_at: event.created_at,
     })
-    .map_err(|_| AppError::InternalServerError)?;
+    .map_err(|e| AppError::ServerError(e.into()))?;
 
     payload.push(b'\n');
 
-    let written = file.write(&payload).map_err(AppError::ServerError)?;
+    let written = file.write(&payload).await.map_err(AppError::ServerError)?;
     if written != payload.len() {
         return Err(AppError::ServerError(std::io::Error::new(
             std::io::ErrorKind::WriteZero,
@@ -179,7 +134,7 @@ fn append_once<E: Serialize>(dir: &Path, event: &StoreEvent<E>) -> Result<(), Ap
         )));
     }
 
-    file.sync_data().map_err(AppError::ServerError)?;
+    file.sync_data().await.map_err(AppError::ServerError)?;
 
     Ok(())
 }
@@ -222,10 +177,10 @@ mod tests {
         }
     }
 
-    fn temp_dir() -> PathBuf {
+    async fn temp_dir() -> PathBuf {
         let mut dir = std::env::temp_dir();
         dir.push(format!("eks-store-test-{}", uuid::Uuid::new_v4()));
-        fs::create_dir_all(&dir).expect("create temp dir");
+        fs::create_dir_all(&dir).await.expect("create temp dir");
         dir
     }
 
@@ -236,17 +191,17 @@ mod tests {
         }
     }
 
-    #[test]
-    fn init_local_creates_directory() {
-        let dir = temp_dir().join("nested");
-        init_local(&dir).expect("init local");
+    #[tokio::test]
+    async fn init_local_creates_directory() {
+        let dir = temp_dir().await.join("nested");
+        init_local(&dir).await.expect("init local");
         assert!(dir.exists());
     }
 
     #[tokio::test]
     async fn update_and_load_replays_events() -> Result<(), AppError> {
-        let dir = temp_dir();
-        init_local(&dir)?;
+        let dir = temp_dir().await;
+        init_local(&dir).await?;
 
         let store = test_store();
         update_in_filesystem(
@@ -267,11 +222,11 @@ mod tests {
         .await?;
 
         let path = stream_path(&dir);
-        let file_contents = fs::read_to_string(&path).expect("read log");
+        let file_contents = fs::read_to_string(&path).await.expect("read log");
         assert_eq!(file_contents.lines().count(), 2);
 
         let fresh = test_store();
-        load_from_filesystem(&fresh, &dir).await?;
+        replay_from_file(&fresh, &dir).await?;
 
         let data = fresh.data.read();
         assert_eq!(data.last_event_id(), 2);
@@ -298,8 +253,8 @@ mod tests {
 
     #[tokio::test]
     async fn update_uses_last_event_id_from_file() -> Result<(), AppError> {
-        let dir = temp_dir();
-        init_local(&dir)?;
+        let dir = temp_dir().await;
+        init_local(&dir).await?;
 
         let first = StoreEvent::new_at(
             5,
@@ -308,7 +263,7 @@ mod tests {
             },
             Utc::now(),
         );
-        append_once(&dir, &first)?;
+        append_once(&dir, &first).await?;
 
         let store = test_store();
         update_in_filesystem(
@@ -320,9 +275,11 @@ mod tests {
         )
         .await?;
 
-        let file_contents = fs::read_to_string(stream_path(&dir)).expect("read log");
+        let file_contents = fs::read_to_string(stream_path(&dir))
+            .await
+            .expect("read log");
         let last_line = file_contents.lines().last().expect("last line");
-        let event: FileEvent<TestEvent> =
+        let event: StoreEvent<TestEvent> =
             serde_json::from_str(last_line).expect("parse last event");
         assert_eq!(event.event_id, 6);
 
@@ -331,11 +288,11 @@ mod tests {
 
     #[tokio::test]
     async fn load_skips_invalid_lines() -> Result<(), AppError> {
-        let dir = temp_dir();
-        init_local(&dir)?;
+        let dir = temp_dir().await;
+        init_local(&dir).await?;
         let path = stream_path(&dir);
 
-        let valid = serde_json::to_string(&FileEventRef {
+        let valid = serde_json::to_string(&StoreEvent {
             event_id: 1,
             payload: &TestEvent {
                 label: "ok".to_string(),
@@ -348,12 +305,15 @@ mod tests {
             .create(true)
             .append(true)
             .open(&path)
+            .await
             .expect("open log");
-        writeln!(file, "{valid}").expect("write valid");
-        writeln!(file, "not json").expect("write invalid");
+
+        file.write_all(valid.as_bytes()).await.expect("write valid");
+        file.write_all(b"\n").await.expect("write valid");
+        file.write_all(b"not json\n").await.expect("write invalid");
 
         let store = test_store();
-        load_from_filesystem(&store, &dir).await?;
+        replay_from_file(&store, &dir).await?;
 
         let data = store.data.read();
         assert_eq!(data.last_event_id(), 1);

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 use std::{path::PathBuf, sync::Arc};
 use url::Url;
 
@@ -10,7 +11,7 @@ pub(crate) mod database;
 mod filesystem;
 mod persistance;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StoreEvent<E> {
     pub event_id: usize,
     pub payload: E,
@@ -73,7 +74,7 @@ impl<D> Clone for Store<D> {
 
 impl<D> Store<D>
 where
-    D: Default,
+    D: StoreData,
 {
     /// Create a new store and initialize persistence from the provided storage URL.
     pub async fn new(storage_url: &str) -> Result<Self, AppError> {
@@ -100,6 +101,21 @@ where
         store.persistence.init().await?;
 
         Ok(store)
+    }
+
+    /// Synchronize the in-memory store with the persistence by replaying any missing events.
+    pub fn apply_event(&self, next_id: usize, store_event: StoreEvent<D::Event>) {
+        let mut data = self.data.write();
+
+        if data.last_event_id() >= next_id {
+            // This can happen if another instance of the application processed events concurrently
+            // and updated the store before this instance could acquire the write lock. In that case,
+            // the store is already up-to-date and we can skip applying the event again.
+            return;
+        }
+
+        data.apply(store_event);
+        data.set_last_event_id(next_id);
     }
 }
 
@@ -151,7 +167,7 @@ impl StorePersistence {
                 database::migrate(pool).await?;
             }
             StorePersistence::Local(dir) => {
-                filesystem::init_local(dir)?;
+                filesystem::init_local(dir).await?;
             }
             StorePersistence::None => {}
         }

--- a/src/store/persistance.rs
+++ b/src/store/persistance.rs
@@ -4,7 +4,7 @@ use serde::{Serialize, de::DeserializeOwned};
 
 #[cfg(feature = "database")]
 use super::database::{load_from_database, update_in_database};
-use super::filesystem::{load_from_filesystem, update_in_filesystem};
+use super::filesystem::{replay_from_file, update_in_filesystem};
 
 impl<D> Store<D>
 where
@@ -15,10 +15,16 @@ where
     pub async fn load(&self) -> Result<(), AppError> {
         match &self.persistence {
             #[cfg(feature = "database")]
-            StorePersistence::Database(pool) => load_from_database(self, pool).await,
-            StorePersistence::Local(dir) => load_from_filesystem(self, dir).await,
-            StorePersistence::None => Ok(()),
+            StorePersistence::Database(pool) => {
+                load_from_database(self, pool).await?;
+            }
+            StorePersistence::Local(dir) => {
+                replay_from_file(self, dir).await?;
+            }
+            StorePersistence::None => {}
         }
+
+        Ok(())
     }
 
     /// Persist an event and apply it to the in-memory store.


### PR DESCRIPTION
Write events as json to a stream file, line by line.
This enables running the application on a desktop computer (without a database server).

Note that we do not yet encrypt the data, but will de so in the future.