### PR TITLE
Refactor usage of context in templates

### DIFF
--- a/locales/en/candidate_list.yml
+++ b/locales/en/candidate_list.yml
@@ -37,7 +37,7 @@ not_found: "Candidate {} not found."
 remove_candidate: Remove candidate
 search_existing_person: Search existing person
 search_placeholder: "Search by name, initials or locality"
-title: Candidate lists
+title_plural: Candidate lists
 title_single: Candidate list
 view:
   empty: This candidate list has no persons yet.

--- a/locales/nl/candidate_list.yml
+++ b/locales/nl/candidate_list.yml
@@ -37,7 +37,7 @@ not_found: "Kandidatenlijst {} niet gevonden."
 remove_candidate: Uit deze lijst verwijderen
 search_existing_person: Zoek bestaande kandidaat
 search_placeholder: "Zoek op naam, voorletters of woonplaats"
-title: Kandidatenlijsten
+title_plural: Kandidatenlijsten
 title_single: Kandidatenlijst
 view:
   empty: Deze kandidatenlijst heeft nog geen kandidaten.

--- a/src/app/authorised_agents/extractors/authorised_agent.rs
+++ b/src/app/authorised_agents/extractors/authorised_agent.rs
@@ -52,7 +52,7 @@ mod tests {
         let authorised_agent = sample_authorised_agent(AuthorisedAgentId::new());
 
         let app_state = AppState::new_for_tests().await;
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         authorised_agent
             .create(&store)
             .await

--- a/src/app/authorised_agents/pages/create.rs
+++ b/src/app/authorised_agents/pages/create.rs
@@ -52,8 +52,8 @@ pub async fn create_authorised_agent_submit(
 mod tests {
     use super::*;
     use crate::{
-        AppError, AppStore, Context, Form, PoliticalGroupId, QueryParamState,
-        test_utils::{response_body_string, sample_authorised_agent_form, sample_political_group},
+        AppError, AppStore, Context, Form, QueryParamState,
+        test_utils::{response_body_string, sample_authorised_agent_form},
     };
     use axum::{
         http::{StatusCode, header},
@@ -63,11 +63,6 @@ mod tests {
 
     #[tokio::test]
     async fn create_authorised_agent_renders_csrf_field() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let group_id = PoliticalGroupId::new();
-        let political_group = sample_political_group(group_id);
-        political_group.create(&store).await?;
-
         let response =
             create_authorised_agent(AuthorisedAgentCreatePath {}, Context::new_test_without_db())
                 .await
@@ -83,10 +78,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_authorised_agent_persists_and_redirects() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let group_id = PoliticalGroupId::new();
-        let political_group = sample_political_group(group_id);
-        political_group.create(&store).await?;
+        let store = AppStore::new_for_test();
 
         let context = Context::new_test_without_db();
         let csrf_token = context.session.csrf_tokens.issue().value;
@@ -108,7 +100,7 @@ mod tests {
             .expect("location header")
             .to_str()
             .expect("location header value");
-        let agents = store.get_authorised_agents()?;
+        let agents = store.get_authorised_agents();
         assert_eq!(agents.len(), 1);
         assert_eq!(
             location,
@@ -122,10 +114,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_authorised_agent_invalid_form_renders_template() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let group_id = PoliticalGroupId::new();
-        let political_group = sample_political_group(group_id);
-        political_group.create(&store).await?;
+        let store = AppStore::new_for_test();
 
         let context = Context::new_test_without_db();
         let csrf_token = context.session.csrf_tokens.issue().value;

--- a/src/app/authorised_agents/pages/delete.rs
+++ b/src/app/authorised_agents/pages/delete.rs
@@ -29,20 +29,16 @@ mod tests {
 
     use super::*;
     use crate::{
-        AppError, AppStore, Context, Form, PoliticalGroupId, QueryParamState, TokenValue,
-        authorised_agents::AuthorisedAgentId,
-        test_utils::{sample_authorised_agent, sample_political_group},
+        AppError, AppStore, Context, Form, QueryParamState, TokenValue,
+        authorised_agents::AuthorisedAgentId, test_utils::sample_authorised_agent,
     };
 
     #[tokio::test]
     async fn delete_authorised_agent_removes_and_redirects() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let group_id = PoliticalGroupId::new();
-        let political_group = sample_political_group(group_id);
+        let store = AppStore::new_for_test();
         let agent_id = AuthorisedAgentId::new();
         let authorised_agent = sample_authorised_agent(agent_id);
 
-        political_group.create(&store).await?;
         authorised_agent.create(&store).await?;
 
         let context = Context::new_test_without_db();
@@ -72,7 +68,7 @@ mod tests {
                 .to_string()
         );
 
-        let agents = store.get_authorised_agents()?;
+        let agents = store.get_authorised_agents();
         assert!(agents.is_empty());
 
         Ok(())
@@ -80,13 +76,10 @@ mod tests {
 
     #[tokio::test]
     async fn delete_authorised_agent_invalid_csrf_error_page() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let group_id = PoliticalGroupId::new();
-        let political_group = sample_political_group(group_id);
+        let store = AppStore::new_for_test();
+
         let agent_id = AuthorisedAgentId::new();
         let authorised_agent = sample_authorised_agent(agent_id);
-
-        political_group.create(&store).await?;
         authorised_agent.create(&store).await?;
 
         let context = Context::new_test_without_db();
@@ -103,7 +96,7 @@ mod tests {
 
         assert!(matches!(response, AppError::CsrfTokenInvalid));
 
-        let agents = store.get_authorised_agents()?;
+        let agents = store.get_authorised_agents();
         assert_eq!(agents.len(), 1);
 
         Ok(())

--- a/src/app/authorised_agents/pages/update.rs
+++ b/src/app/authorised_agents/pages/update.rs
@@ -64,12 +64,9 @@ pub async fn update_authorised_agent_submit(
 mod tests {
     use super::*;
     use crate::{
-        AppError, AppStore, Context, Form, PoliticalGroupId, QueryParamState,
+        AppError, AppStore, Context, Form, QueryParamState,
         authorised_agents::AuthorisedAgentId,
-        test_utils::{
-            response_body_string, sample_authorised_agent, sample_authorised_agent_form,
-            sample_political_group,
-        },
+        test_utils::{response_body_string, sample_authorised_agent, sample_authorised_agent_form},
     };
     use axum::{
         http::{StatusCode, header},
@@ -79,13 +76,11 @@ mod tests {
 
     #[tokio::test]
     async fn update_authorised_agent_renders_existing_agent() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let group_id = PoliticalGroupId::new();
-        let political_group = sample_political_group(group_id);
+        let store = AppStore::new_for_test();
+
         let agent_id = AuthorisedAgentId::new();
         let authorised_agent = sample_authorised_agent(agent_id);
 
-        political_group.create(&store).await?;
         authorised_agent.create(&store).await?;
 
         let response = update_authorised_agent(
@@ -106,13 +101,10 @@ mod tests {
 
     #[tokio::test]
     async fn update_authorised_agent_persists_and_redirects() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let group_id = PoliticalGroupId::new();
-        let political_group = sample_political_group(group_id);
+        let store = AppStore::new_for_test();
+
         let agent_id = AuthorisedAgentId::new();
         let authorised_agent = sample_authorised_agent(agent_id);
-
-        political_group.create(&store).await?;
         authorised_agent.create(&store).await?;
 
         let context = Context::new_test_without_db();
@@ -152,13 +144,10 @@ mod tests {
 
     #[tokio::test]
     async fn update_authorised_agent_invalid_form_renders_template() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let group_id = PoliticalGroupId::new();
-        let political_group = sample_political_group(group_id);
+        let store = AppStore::new_for_test();
+
         let agent_id = AuthorisedAgentId::new();
         let authorised_agent = sample_authorised_agent(agent_id);
-
-        political_group.create(&store).await?;
         authorised_agent.create(&store).await?;
 
         let context = Context::new_test_without_db();

--- a/src/app/authorised_agents/pages/view.rs
+++ b/src/app/authorised_agents/pages/view.rs
@@ -35,21 +35,18 @@ pub async fn list_authorised_agents(
 mod tests {
     use super::*;
     use crate::{
-        AppError, AppStore, Context, PoliticalGroupId,
+        AppError, AppStore, Context,
         authorised_agents::AuthorisedAgentId,
-        test_utils::{response_body_string, sample_authorised_agent, sample_political_group},
+        test_utils::{response_body_string, sample_authorised_agent},
     };
     use axum::{http::StatusCode, response::IntoResponse};
 
     #[tokio::test]
     async fn list_authorised_agents_shows_created_agent() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let group_id = PoliticalGroupId::new();
-        let political_group = sample_political_group(group_id);
+        let store = AppStore::new_for_test();
+
         let agent_id = AuthorisedAgentId::new();
         let authorised_agent = sample_authorised_agent(agent_id);
-
-        political_group.create(&store).await?;
         authorised_agent.create(&store).await?;
 
         let response = list_authorised_agents(
@@ -70,13 +67,10 @@ mod tests {
 
     #[tokio::test]
     async fn list_authorised_agents_shows_edit_link() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let group_id = PoliticalGroupId::new();
-        let political_group = sample_political_group(group_id);
+        let store = AppStore::new_for_test();
+
         let agent_id = AuthorisedAgentId::new();
         let authorised_agent = sample_authorised_agent(agent_id);
-
-        political_group.create(&store).await?;
         authorised_agent.create(&store).await?;
 
         let response = list_authorised_agents(

--- a/src/app/candidate_lists/components/candidates_table.html
+++ b/src/app/candidate_lists/components/candidates_table.html
@@ -22,10 +22,7 @@
         </td>
         <td>
           <strong>{{ candidate.person.name.last_name_with_prefix_appended() }},</strong>
-          {% if let Ok(locale) = "locale"|value::<crate::Locale> %}
-            {% let any_locale = AnyLocale::from(***locale) %}
-            {{ candidate.person.initials_as_printed_on_list(*any_locale) }}
-          {% endif %}
+          {{ candidate.person|initials_as_printed_on_list }}
         </td>
         <td>
           {% if let Some(place_of_residence) = candidate.person.place_of_residence %}{{ place_of_residence }}{% endif %}
@@ -41,7 +38,7 @@
     {% endfor %}
   </tbody>
 </table>
-{% if full_list.candidates.len() > **max_candidates %}
+{% if full_list.candidates.len() > max_candidates %}
   <p class="note-warning mt-md">
     {{ "candidate_list.view.max_candidates_exceeded"|trans(&max_candidates.to_string() ) }}
   </p>

--- a/src/app/candidate_lists/components/districts_form.html
+++ b/src/app/candidate_lists/components/districts_form.html
@@ -8,20 +8,17 @@
       {{ "candidate_list.actions.select_all_districts"|trans }}
     </label>
   </div>
-  {% if let Ok(election) = "election"|value::<ElectionConfig> %}
+  {% let election = "election"|election_value %}
     <div class="checklist grid" id="district_list">
       {% for d in election.electoral_districts() %}
       <div class="checkbox {% if !available_districts.contains(&d) %}disabled{% endif %}">
         <input type="checkbox" name="electoral_districts" id="electoral_district_{{ d.code() }}" value="{{ d.code() }}"
           {% if form.data.electoral_districts.contains(&d) %}checked{% endif %} />
         <label for="electoral_district_{{ d.code() }}">
-          {% if let Ok(locale) = "locale"|value::<crate::Locale> %}
-            {% let any_locale = AnyLocale::from(***locale) %}
-            {{ d.title(*any_locale) }}
-          {% endif %}
+          {{ d|district_name }}
         </label>
       </div>
       {% endfor %}
     </div>
-  {% endif %}
+
 </fieldset>

--- a/src/app/candidate_lists/extractors/candidate_list.rs
+++ b/src/app/candidate_lists/extractors/candidate_list.rs
@@ -57,7 +57,7 @@ mod tests {
         let list = sample_candidate_list(CandidateListId::new());
 
         let app_state = AppState::new_for_tests().await;
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         list.create(&store).await.expect("create candidate list");
 
         let app = Router::new()
@@ -87,7 +87,7 @@ mod tests {
     async fn candidate_list_extractor_returns_not_found() {
         let state = AppState::new_for_tests().await;
         let list_id = CandidateListId::new();
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
 
         let app = Router::new()
             .route(

--- a/src/app/candidate_lists/extractors/full_candidate_list.rs
+++ b/src/app/candidate_lists/extractors/full_candidate_list.rs
@@ -59,7 +59,7 @@ mod tests {
         let person = sample_person(PersonId::new());
 
         let app_state = AppState::new_for_tests().await;
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         list.create(&store).await.expect("create candidate list");
         person.create(&store).await.expect("create person");
         list.clone()
@@ -98,7 +98,7 @@ mod tests {
     async fn full_candidate_list_extractor_returns_not_found() {
         let state = AppState::new_for_tests().await;
         let list_id = CandidateListId::new();
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
 
         let app = Router::new()
             .route(

--- a/src/app/candidate_lists/pages/create.rs
+++ b/src/app/candidate_lists/pages/create.rs
@@ -2,9 +2,8 @@ use askama::Template;
 use axum::response::{IntoResponse, Redirect, Response};
 
 use crate::{
-    AppError, AppStore, Context, ElectionConfig, ElectoralDistrict, Form, HtmlTemplate,
+    AppError, AppStore, Context, ElectoralDistrict, Form, HtmlTemplate,
     candidate_lists::{CandidateList, CandidateListCreateForm, pages::CandidateListCreatePath},
-    core::AnyLocale,
     filters,
     form::FormData,
 };
@@ -23,7 +22,7 @@ pub async fn create_candidate_list(
     store: AppStore,
 ) -> Result<impl IntoResponse, AppError> {
     let available_districts = CandidateList::available_districts(&store, &context.session.election);
-    let has_previous_list = !store.get_candidate_lists()?.is_empty();
+    let has_previous_list = !store.get_candidate_lists().is_empty();
 
     Ok(HtmlTemplate(
         CandidateListCreateTemplate {
@@ -48,7 +47,7 @@ pub async fn create_candidate_list_submit(
         Err(form_data) => Ok(HtmlTemplate(
             CandidateListCreateTemplate {
                 form: form_data,
-                has_previous_list: !store.get_candidate_lists()?.is_empty(),
+                has_previous_list: !store.get_candidate_lists().is_empty(),
                 available_districts,
             },
             context,
@@ -57,7 +56,7 @@ pub async fn create_candidate_list_submit(
         Ok(mut candidate_list) => {
             if should_copy_candidates {
                 candidate_list.candidates = store
-                    .get_candidate_lists()?
+                    .get_candidate_lists()
                     .last()
                     .map(|list| list.candidates.clone())
                     .unwrap_or_default();
@@ -81,7 +80,7 @@ mod test {
     };
 
     use crate::{
-        AppStore, Context, ElectoralDistrict, TokenValue,
+        AppStore, Context, ElectionConfig, ElectoralDistrict, TokenValue,
         candidate_lists::{CandidateListId, CandidateListSummary},
         persons::PersonId,
         test_utils::{response_body_string, sample_candidate_list, sample_person},
@@ -89,7 +88,7 @@ mod test {
 
     #[tokio::test]
     async fn create_candidate_list_renders_csrf_field() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let response = create_candidate_list(
             CandidateListCreatePath {},
             Context::new_test_without_db(),
@@ -107,7 +106,7 @@ mod test {
 
     #[tokio::test]
     async fn create_candidate_list_persists_and_redirects() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let context = Context::new_test_without_db();
         let csrf_token = context.session.csrf_tokens.issue().value;
         let form = CandidateListCreateForm {
@@ -143,7 +142,7 @@ mod test {
 
     #[tokio::test]
     async fn create_candidate_list_invalid_form_renders_template() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let form = CandidateListCreateForm {
             electoral_districts: vec![ElectoralDistrict::UT],
             copy_candidates: false,
@@ -167,7 +166,7 @@ mod test {
 
     #[tokio::test]
     async fn create_candidate_list_copies_previous_candidates() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let context = Context::new_test_without_db();
         let csrf_token = context.session.csrf_tokens.issue().value;
         let list_id = CandidateListId::new();

--- a/src/app/candidate_lists/pages/delete.rs
+++ b/src/app/candidate_lists/pages/delete.rs
@@ -36,7 +36,7 @@ mod tests {
 
     #[tokio::test]
     async fn delete_candidate_list_and_redirect() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let context = Context::new_test_without_db();
         let csrf_token = context.session.csrf_tokens.issue().value;
         let candidate_list = CandidateList {
@@ -81,7 +81,7 @@ mod tests {
 
     #[tokio::test]
     async fn delete_candidate_invalid_csrf_error_page() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let context = Context::new_test_without_db();
         let csrf_token = TokenValue("invalid".to_string());
         let candidate_list = CandidateList {

--- a/src/app/candidate_lists/pages/list.html
+++ b/src/app/candidate_lists/pages/list.html
@@ -1,5 +1,11 @@
 {% extends "common/components/layout.html" %}
-{% block page_title %}{{ "candidate_list.title"|trans }}{% endblock %}
+{% block page_title %}
+  {% if "multiple_candidate_lists"|value_true %}
+    {{ "candidate_list.title_plural"|trans }}
+  {% else %}
+    {{ "candidate_list.title_single"|trans }}
+  {% endif %}
+{% endblock %}
 {% block candidate_lists_nav_class %}active{% endblock %}
 {% block header_action %}<a href="/" class="button secondary">{{ "action.back"|trans }}</a>{% endblock %}
 {% block content %}
@@ -14,36 +20,31 @@
         <p>{{ "action.manage_candidates"|trans }}</p>
       </a>
       <div class="cards-right">
-        {% if let Ok(election) = "election"|value::<crate::ElectionConfig> %}
-          {% if let Ok(max_candidates) = "max_candidates"|value::<usize> %}
-            {% for candidate_list in candidate_lists %}
-              <a href="{{ candidate_list.list.view_path() }}"
-                 {% if candidate_list.duplicate_districts.is_empty() %} class="card card-candidate-list" {% else %} class="card card-list-warning" {% endif %}>
-                <div class="badge"></div>
-                <h3>{{ "candidate_list.title_single"|trans }}</h3>
-                <p class="statistic">
-                  {{ "candidate_list.candidate_count"|trans(&candidate_list.person_count.to_string() , &max_candidates.to_string())|safe }}
-                </p>
-                <h5>{{ "common.electoral_districts"|trans }}:</h5>
-                {% if candidate_list.list.electoral_districts.len() == election.electoral_districts().len() && candidate_list.duplicate_districts.is_empty() %}
-                  <p>{{ "candidate_list.districts.all"|trans }}</p>
-                {% else %}
-                  <ul class="districts">
-                    {% if let Ok(locale) = "locale"|value::<crate::Locale> %}
-                      {% let any_locale = AnyLocale::from(***locale) %}
-                      {% for district in candidate_list.list.electoral_districts %}
-                        <li {% if candidate_list.duplicate_districts.contains(district) %}class="warning"{% endif %}>
-                          <span>{{ district.title(*any_locale) }}</span>
-                        </li>
-                      {% endfor %}
-                    {% endif %}
-                  </ul>
-                {% endif %}
-                <p>{{ "action.manage_candidate_list"|trans }}</p>
-              </a>
-            {% endfor %}
-          {% endif %}
-        {% endif %}
+        {% let election = "election"|election_value %}
+        {% let max_candidates = "max_candidates"|integer_value %}
+        {% for candidate_list in candidate_lists %}
+          <a href="{{ candidate_list.list.view_path() }}"
+             {% if candidate_list.duplicate_districts.is_empty() %} class="card card-candidate-list" {% else %} class="card card-list-warning" {% endif %}>
+            <div class="badge"></div>
+            <h3>{{ "candidate_list.title_single"|trans }}</h3>
+            <p class="statistic">
+              {{ "candidate_list.candidate_count"|trans(&candidate_list.person_count.to_string() , &max_candidates.to_string())|safe }}
+            </p>
+            <h5>{{ "common.electoral_districts"|trans }}:</h5>
+            {% if candidate_list.list.electoral_districts.len() == election.electoral_districts().len() && candidate_list.duplicate_districts.is_empty() %}
+              <p>{{ "candidate_list.districts.all"|trans }}</p>
+            {% else %}
+              <ul class="districts">
+                {% for district in candidate_list.list.electoral_districts %}
+                  <li {% if candidate_list.duplicate_districts.contains(district) %}class="warning"{% endif %}>
+                    <span>{{ district|district_name }}</span>
+                  </li>
+                {% endfor %}
+              </ul>
+            {% endif %}
+            <p>{{ "action.manage_candidate_list"|trans }}</p>
+          </a>
+        {% endfor %}
         {# add new candidate list card #}
         <div class="card card-add-list">
           <a href="{{ CandidateList::create_path() }}"

--- a/src/app/candidate_lists/pages/list.rs
+++ b/src/app/candidate_lists/pages/list.rs
@@ -4,7 +4,6 @@ use axum::response::IntoResponse;
 use crate::{
     AppError, AppStore, Context, HtmlTemplate,
     candidate_lists::{CandidateList, CandidateListSummary, pages::CandidateListsPath},
-    core::AnyLocale,
     filters,
     persons::Person,
 };
@@ -22,7 +21,7 @@ pub async fn list_candidate_lists(
     store: AppStore,
 ) -> Result<impl IntoResponse, AppError> {
     let candidate_lists = CandidateListSummary::list(&store)?;
-    let total_persons = store.get_person_count()?;
+    let total_persons = store.get_person_count();
 
     Ok(HtmlTemplate(
         CandidateListIndexTemplate {
@@ -45,7 +44,7 @@ mod tests {
 
     #[tokio::test]
     async fn list_candidate_lists_shows_created_list() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list = sample_candidate_list(CandidateListId::new());
         list.create(&store).await?;
 

--- a/src/app/candidate_lists/pages/reorder.rs
+++ b/src/app/candidate_lists/pages/reorder.rs
@@ -36,7 +36,7 @@ mod tests {
 
     #[tokio::test]
     async fn reorder_candidate_list_updates_positions() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list_id = CandidateListId::new();
         let list = sample_candidate_list(list_id);
         let person_a = sample_person_with_last_name(PersonId::new(), "Jansen");

--- a/src/app/candidate_lists/pages/update.rs
+++ b/src/app/candidate_lists/pages/update.rs
@@ -5,10 +5,8 @@ use axum::{
 };
 
 use crate::{
-    AppError, AppStore, Context, ElectionConfig, ElectoralDistrict, Form, HtmlTemplate,
-    QueryParamState,
+    AppError, AppStore, Context, ElectoralDistrict, Form, HtmlTemplate, QueryParamState,
     candidate_lists::{CandidateList, CandidateListForm, pages::CandidateListUpdatePath},
-    core::AnyLocale,
     filters,
     form::FormData,
     redirect_success,
@@ -92,7 +90,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_candidate_list_renders_existing_list() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let candidate_list = sample_candidate_list(CandidateListId::new());
 
         candidate_list.create(&store).await?;
@@ -120,7 +118,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_candidate_list_persists_and_redirects() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let context = Context::new_test_without_db();
         let csrf_token = context.session.csrf_tokens.issue().value;
         let candidate_list = CandidateList {
@@ -179,7 +177,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_candidate_list_invalid_form_renders_template() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let candidate_list = CandidateList {
             electoral_districts: vec![ElectoralDistrict::UT],
             ..Default::default()

--- a/src/app/candidate_lists/pages/update_list_submitter.rs
+++ b/src/app/candidate_lists/pages/update_list_submitter.rs
@@ -31,8 +31,8 @@ fn render_submitter_form(
     should_warn: bool,
     form: FormData<ListSubmitterForm>,
 ) -> Result<Response, AppError> {
-    let list_submitters = store.get_list_submitters()?;
-    let substitute_submitters = store.get_substitute_submitters()?;
+    let list_submitters = store.get_list_submitters();
+    let substitute_submitters = store.get_substitute_submitters();
 
     Ok(HtmlTemplate(
         ListSubmitterUpdateTemplate {
@@ -101,34 +101,28 @@ mod tests {
     use axum_extra::routing::TypedPath;
 
     use crate::{
-        AppStore, Context, ElectoralDistrict, Locale, PoliticalGroupId, QueryParamState, Session,
-        TokenValue,
+        AppStore, Context, ElectoralDistrict, Locale, QueryParamState, Session, TokenValue,
         candidate_lists::{CandidateListId, CandidateListSummary},
         list_submitters::ListSubmitterId,
         substitute_list_submitters::SubstituteSubmitterId,
         test_utils::{
             response_body_string, sample_candidate_list, sample_list_submitter,
-            sample_political_group, sample_substitute_submitter,
+            sample_substitute_submitter,
         },
     };
 
     #[tokio::test]
     async fn update_list_submitter_renders_submitter_form() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let candidate_list = sample_candidate_list(CandidateListId::new());
         let list_submitter = sample_list_submitter(ListSubmitterId::new());
         let substitute_submitter = sample_substitute_submitter(SubstituteSubmitterId::new());
-        let political_group = sample_political_group(PoliticalGroupId::new());
 
         candidate_list.create(&store).await?;
-        political_group.create(&store).await?;
         list_submitter.create(&store).await?;
         substitute_submitter.create(&store).await?;
 
-        let context = Context::new(
-            political_group.clone(),
-            Session::new_with_locale(Locale::En),
-        );
+        let context = Context::new(&store, Session::new_with_locale(Locale::En));
 
         let response = update_list_submitter(
             UpdateListSubmitterPath {
@@ -158,21 +152,15 @@ mod tests {
 
     #[tokio::test]
     async fn update_list_submitter_selects_defaults_on_initial_query() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let political_group = sample_political_group(PoliticalGroupId::new());
-        political_group.create(&store).await?;
-        let context = Context::new(
-            political_group.clone(),
-            Session::new_with_locale(Locale::En),
-        );
+        let store = AppStore::new_for_test();
+        let context = Context::new(&store, Session::new_with_locale(Locale::En));
         let candidate_list = sample_candidate_list(CandidateListId::new());
+
         let list_submitter = sample_list_submitter(ListSubmitterId::new());
         let substitute_submitter_a = sample_substitute_submitter(SubstituteSubmitterId::new());
         let substitute_submitter_b = sample_substitute_submitter(SubstituteSubmitterId::new());
-        let political_group = sample_political_group(PoliticalGroupId::new());
 
         candidate_list.create(&store).await?;
-        political_group.create(&store).await?;
         list_submitter.create(&store).await?;
         substitute_submitter_a.create(&store).await?;
         substitute_submitter_b.create(&store).await?;
@@ -200,13 +188,9 @@ mod tests {
 
     #[tokio::test]
     async fn update_list_submitters_persists_and_redirects() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let political_group = sample_political_group(PoliticalGroupId::new());
-        political_group.create(&store).await?;
-        let context = Context::new(
-            political_group.clone(),
-            Session::new_with_locale(Locale::En),
-        );
+        let store = AppStore::new_for_test();
+
+        let context = Context::new(&store, Session::new_with_locale(Locale::En));
         let csrf_token = context.session.csrf_tokens.issue().value;
         let candidate_list = CandidateList {
             electoral_districts: vec![ElectoralDistrict::UT],
@@ -278,13 +262,9 @@ mod tests {
 
     #[tokio::test]
     async fn update_list_submitters_invalid_form_renders_template() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let political_group = sample_political_group(PoliticalGroupId::new());
-        political_group.create(&store).await?;
-        let context = Context::new(
-            political_group.clone(),
-            Session::new_with_locale(Locale::En),
-        );
+        let store = AppStore::new_for_test();
+
+        let context = Context::new(&store, Session::new_with_locale(Locale::En));
         let candidate_list = sample_candidate_list(CandidateListId::new());
         let list_submitter = sample_list_submitter(ListSubmitterId::new());
         let substitute_submitter = sample_substitute_submitter(SubstituteSubmitterId::new());

--- a/src/app/candidate_lists/pages/view.html
+++ b/src/app/candidate_lists/pages/view.html
@@ -3,27 +3,21 @@
 {% block candidate_lists_nav_class %}active{% endblock %}
 {% block main_class %}pt-sm{% endblock %}
 {% block page_sub_title %}
-  {% if full_list.list.electoral_districts.is_empty() || full_list.list.electoral_districts.len() >= 3 %}
-    {% if let Ok(election) = "election"|value::<crate::ElectionConfig> %}
-      <span class="subtitle">
-        {% if full_list.list.contains_all_districts(election) %}
-          {# skip #}
-        {% else if full_list.list.electoral_districts.is_empty() %}
-          {# skip #}
-        {% else %}
-          {% if let Ok(locale) = "locale"|value::<crate::Locale> %}
-            {% let any_locale = AnyLocale::from(***locale) %}
-            <ul class="districts">
-              {% for district in full_list.list.electoral_districts %}
-                <li>
-                  <span>{{ district.title(*any_locale) }}</span>
-                </li>
-              {% endfor %}
-            </ul>
-          {% endif %}
-        {% endif %}
-      </span>
-    {% endif %}
+  {% if !full_list.list.electoral_districts.is_empty() %}
+    {% let election = "election"|election_value %}
+    <span class="subtitle">
+      {% if full_list.list.contains_all_districts(election) %}
+        {# skip #}
+      {% else %}
+        <ul class="districts">
+          {% for district in full_list.list.electoral_districts %}
+            <li>
+              <span>{{ district|district_name }}</span>
+            </li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+    </span>
   {% endif %}
 {% endblock %}
 {% block header_action %}
@@ -56,9 +50,8 @@
     {% if full_list.candidates.is_empty() %}
       <p>{{ "candidate_list.view.empty"|trans }}</p>
     {% else %}
-      {% if let Ok(max_candidates) = "max_candidates"|value::<usize> %}
-        {% include "candidate_lists/components/candidates_table.html" %}
-      {% endif %}
+      {% let max_candidates = "max_candidates"|integer_value %}
+      {% include "candidate_lists/components/candidates_table.html" %}
     {% endif %}
   </section>
 {% endblock %}

--- a/src/app/candidate_lists/pages/view.rs
+++ b/src/app/candidate_lists/pages/view.rs
@@ -4,7 +4,6 @@ use axum::response::IntoResponse;
 use crate::{
     AppError, Context, HtmlTemplate,
     candidate_lists::{CandidateList, FullCandidateList, pages::ViewCandidateListPath},
-    core::AnyLocale,
     filters,
 };
 
@@ -38,7 +37,7 @@ mod tests {
 
     #[tokio::test]
     async fn view_candidate_list_renders_candidates() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list_id = CandidateListId::new();
         let list = sample_candidate_list(list_id);
         let person = sample_person(PersonId::new());

--- a/src/app/candidate_lists/structs/candidate_list.rs
+++ b/src/app/candidate_lists/structs/candidate_list.rs
@@ -40,7 +40,7 @@ impl CandidateList {
 
     pub fn used_districts(store: &AppStore) -> Result<Vec<ElectoralDistrict>, AppError> {
         let used: BTreeSet<ElectoralDistrict> = store
-            .get_candidate_lists()?
+            .get_candidate_lists()
             .into_iter()
             .flat_map(|list| list.electoral_districts.into_iter())
             .collect();
@@ -63,7 +63,7 @@ impl CandidateList {
         person_ids: &[PersonId],
     ) -> Result<(), AppError> {
         let existing_person_ids = store
-            .get_persons()?
+            .get_persons()
             .iter()
             .map(|p| p.id)
             .collect::<BTreeSet<_>>();
@@ -178,7 +178,7 @@ impl CandidateList {
             list.candidates.into_iter().map(|id| (id, ())).collect();
 
         Ok(store
-            .get_persons()?
+            .get_persons()
             .into_iter()
             .filter(|person| !existing.contains_key(&person.id))
             .collect())
@@ -216,14 +216,14 @@ impl CandidateList {
     pub fn select_default_submitters(&mut self, store: &AppStore) -> Result<(), AppError> {
         if self.list_submitter_id.is_none() {
             self.list_submitter_id = store
-                .get_list_submitters()?
+                .get_list_submitters()
                 .first()
                 .map(|submitter| submitter.id);
         }
 
         if self.substitute_list_submitter_ids.is_empty() {
             self.substitute_list_submitter_ids = store
-                .get_substitute_submitters()?
+                .get_substitute_submitters()
                 .iter()
                 .map(|submitter| submitter.id)
                 .collect();
@@ -317,7 +317,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_and_list_candidate_lists() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list = sample_candidate_list(CandidateListId::new());
 
         list.create(&store).await?;
@@ -333,7 +333,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_candidate_list_summaries_with_duplicate_districts() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         // setup
         let list1 = insert_list(&store, vec![ElectoralDistrict::UT, ElectoralDistrict::DR]).await?;
         let list2 = insert_list(&store, vec![ElectoralDistrict::UT, ElectoralDistrict::GR]).await?;
@@ -380,7 +380,7 @@ mod tests {
 
     #[tokio::test]
     async fn list_candidate_list_orders_by_created_at() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list_early = CandidateList {
             electoral_districts: vec![ElectoralDistrict::UT],
             ..Default::default()
@@ -396,7 +396,7 @@ mod tests {
         };
         list_late.create(&store).await?;
 
-        let lists = store.get_candidate_lists()?;
+        let lists = store.get_candidate_lists();
         assert_eq!(lists.len(), 2);
         assert_eq!(lists[0].id, list_early.id);
         assert_eq!(lists[1].id, list_late.id);
@@ -406,7 +406,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_candidate_list_returns_list() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list = sample_candidate_list(CandidateListId::new());
 
         list.create(&store).await?;
@@ -420,7 +420,7 @@ mod tests {
 
     #[tokio::test]
     async fn select_default_submitters_uses_store_defaults() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
 
         let list_submitter_a =
             sample_list_submitter(crate::list_submitters::ListSubmitterId::new());
@@ -458,7 +458,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_candidate_list_updates_districts() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list = sample_candidate_list(CandidateListId::new());
 
         list.create(&store).await?;
@@ -481,7 +481,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_used_districts() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         // setup
         let expected = BTreeSet::from([
             ElectoralDistrict::UT,
@@ -504,7 +504,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_used_districts_no_lists() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let result = CandidateList::used_districts(&store)?;
 
         assert_eq!(Vec::<ElectoralDistrict>::new(), result);
@@ -514,7 +514,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_used_districts_double_districts() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let expected = BTreeSet::from([
             ElectoralDistrict::UT,
             ElectoralDistrict::DR,
@@ -536,7 +536,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_used_district_with_exclude() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let expected = BTreeSet::from([
             ElectoralDistrict::UT,
             ElectoralDistrict::DR,
@@ -559,7 +559,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_remove_candidate_list() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         // setup
         let list_a = sample_candidate_list(CandidateListId::new());
         let person_a = sample_person_with_last_name(PersonId::new(), "Jansen");
@@ -590,7 +590,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_candidate_list_includes_candidates() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list_id = CandidateListId::new();
         let list = sample_candidate_list(list_id);
         let person_a = sample_person_with_last_name(PersonId::new(), "Jansen");
@@ -613,7 +613,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_candidate_list_order_returns_not_found() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let mut missing_list = sample_candidate_list(CandidateListId::new());
         let err = missing_list.update_order(&store, &[]).await.unwrap_err();
         assert!(matches!(err, AppError::GenericNotFound));
@@ -623,7 +623,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_full_candidate_list_returns_none_for_missing_list() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let missing = FullCandidateList::get(&store, CandidateListId::new());
         assert!(missing.is_err());
 
@@ -632,7 +632,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_append_candidate_to_list() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list_id = CandidateListId::new();
         let mut list = sample_candidate_list(list_id);
         let person_a = sample_person_with_last_name(PersonId::new(), "Jansen");
@@ -658,7 +658,7 @@ mod tests {
 
     #[tokio::test]
     async fn append_candidate_to_list_returns_not_found() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let mut missing_list = sample_candidate_list(CandidateListId::new());
         let err = missing_list
             .append_candidate(&store, PersonId::new())
@@ -671,7 +671,7 @@ mod tests {
 
     #[tokio::test]
     async fn remove_candidate_removes_from_list() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list_id = CandidateListId::new();
         let list = sample_candidate_list(list_id);
         let person_a = sample_person_with_last_name(PersonId::new(), "Jansen");
@@ -695,7 +695,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_candidate_returns_candidate() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list_id = CandidateListId::new();
         let mut list = sample_candidate_list(list_id);
         let person = sample_person_with_last_name(PersonId::new(), "Jansen");

--- a/src/app/candidate_lists/structs/candidate_list_summary.rs
+++ b/src/app/candidate_lists/structs/candidate_list_summary.rs
@@ -13,7 +13,7 @@ pub struct CandidateListSummary {
 
 impl CandidateListSummary {
     pub fn list(store: &AppStore) -> Result<Vec<CandidateListSummary>, AppError> {
-        let lists = store.get_candidate_lists()?;
+        let lists = store.get_candidate_lists();
 
         let mut district_count = BTreeMap::<ElectoralDistrict, usize>::new();
         for list in &lists {

--- a/src/app/candidates/components/update_steps.html
+++ b/src/app/candidates/components/update_steps.html
@@ -1,14 +1,13 @@
 <div class="steps-nav">
   <ul>
-    {% if let Ok(max_candidates) = "max_candidates"|value::<usize> %}
-      {% if should_warn|default(true) %}
-        <li>
-          <a href="{{ candidate.update_position_path() }}"
-             class="{% if candidate.position <= **max_candidates %}ok{% else %}warning{% endif %}">
-            {{ "candidate_list.edit_position"|trans }}
-          </a>
-        </li>
-      {% endif %}
+    {% let max_candidates = "max_candidates"|integer_value %}
+    {% if should_warn|default(true) %}
+      <li>
+        <a href="{{ candidate.update_position_path() }}"
+           class="{% if candidate.position <= max_candidates %}ok{% else %}warning{% endif %}">
+          {{ "candidate_list.edit_position"|trans }}
+        </a>
+      </li>
     {% endif %}
     <li>
       <a href="{{ candidate.update_path() }}"

--- a/src/app/candidates/extractors/candidate.rs
+++ b/src/app/candidates/extractors/candidate.rs
@@ -68,7 +68,7 @@ mod tests {
         let person = sample_person(PersonId::new());
 
         let app_state = AppState::new_for_tests().await;
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         list.create(&store).await.unwrap();
         person.create(&store).await.unwrap();
         list.clone()
@@ -105,7 +105,7 @@ mod tests {
     #[tokio::test]
     async fn candidate_extractor_returns_not_found() {
         let state = AppState::new_for_tests().await;
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list_id = CandidateListId::new();
         let list = sample_candidate_list(list_id);
         let person = sample_person(PersonId::new());

--- a/src/app/candidates/pages/add.rs
+++ b/src/app/candidates/pages/add.rs
@@ -43,7 +43,7 @@ pub async fn add_person_to_candidate_list(
     Form(form): Form<AddPersonForm>,
 ) -> Result<Response, AppError> {
     let person_exists = store
-        .get_persons()?
+        .get_persons()
         .iter()
         .any(|person| person.id == form.person_id);
 
@@ -73,7 +73,7 @@ mod tests {
 
     #[tokio::test]
     async fn view_candidate_list_renders_persons() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list_id = CandidateListId::new();
         let list = sample_candidate_list(list_id);
         let person = sample_person(PersonId::new());
@@ -101,7 +101,7 @@ mod tests {
 
     #[tokio::test]
     async fn add_person_to_candidate_list_adds_and_redirects() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list_id = CandidateListId::new();
         let list = sample_candidate_list(list_id);
         let person = sample_person_with_last_name(PersonId::new(), "Bakker");
@@ -139,7 +139,7 @@ mod tests {
     #[tokio::test]
     async fn add_person_to_candidate_list_redirects_when_person_not_on_list() -> Result<(), AppError>
     {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list_id = CandidateListId::new();
         let mut list = sample_candidate_list(list_id);
         let existing_person = sample_person_with_last_name(PersonId::new(), "Jansen");

--- a/src/app/candidates/pages/create.rs
+++ b/src/app/candidates/pages/create.rs
@@ -73,7 +73,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_person_candidate_list_renders_form() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list_id = CandidateListId::new();
         let list = sample_candidate_list(list_id);
         list.create(&store).await?;
@@ -98,7 +98,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_person_candidate_list_persists_and_redirects() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list_id = CandidateListId::new();
         let list = sample_candidate_list(list_id);
         list.create(&store).await?;
@@ -136,7 +136,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_person_candidate_list_invalid_form_renders_template() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list_id = CandidateListId::new();
         let list = sample_candidate_list(list_id);
         list.create(&store).await?;

--- a/src/app/candidates/pages/delete.rs
+++ b/src/app/candidates/pages/delete.rs
@@ -39,7 +39,7 @@ mod tests {
 
     #[tokio::test]
     async fn delete_person_removes_from_list_and_redirects() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list_id = CandidateListId::new();
         let mut list = sample_candidate_list(list_id);
         let person = sample_person(PersonId::new());

--- a/src/app/candidates/pages/update.rs
+++ b/src/app/candidates/pages/update.rs
@@ -30,7 +30,7 @@ pub async fn update_person(
                 PersonForm::from(candidate.person.clone()),
                 &context.session.csrf_tokens,
             ),
-            on_candidate_lists: store.count_candidate_lists(candidate.person.id)?,
+            on_candidate_lists: store.count_candidate_lists(candidate.person.id),
             candidate,
             full_list,
         },
@@ -50,7 +50,7 @@ pub async fn update_person_submit(
         Err(form_data) => Ok(HtmlTemplate(
             PersonUpdateTemplate {
                 full_list,
-                on_candidate_lists: store.count_candidate_lists(candidate.person.id)?,
+                on_candidate_lists: store.count_candidate_lists(candidate.person.id),
                 candidate,
                 form: form_data,
             },
@@ -84,7 +84,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_person_renders_candidate() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list_id = CandidateListId::new();
         let list = sample_candidate_list(list_id);
         let person = sample_person(PersonId::new());
@@ -121,7 +121,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_person_persists_and_redirects() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list_id = CandidateListId::new();
         let list = sample_candidate_list(list_id);
         let person = sample_person(PersonId::new());
@@ -165,7 +165,7 @@ mod tests {
         assert_eq!(location, expected_path);
 
         let updated = store
-            .get_persons()?
+            .get_persons()
             .into_iter()
             .find(|p| p.id == person.id)
             .expect("updated person");
@@ -176,7 +176,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_person_invalid_form_renders_template() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list_id = CandidateListId::new();
         let list = sample_candidate_list(list_id);
         let person = sample_person(PersonId::new());

--- a/src/app/candidates/pages/update_address.rs
+++ b/src/app/candidates/pages/update_address.rs
@@ -99,7 +99,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_person_address_renders_candidate() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list_id = CandidateListId::new();
         let list = sample_candidate_list(list_id);
         let person = sample_person_with_last_name(PersonId::new(), "Jansen");
@@ -136,7 +136,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_person_address_persists_and_redirects() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list_id = CandidateListId::new();
         let mut list = sample_candidate_list(list_id);
         let person = sample_person_with_last_name(PersonId::new(), "Jansen");
@@ -184,7 +184,7 @@ mod tests {
         assert_eq!(location, expected_path);
 
         let updated = store
-            .get_persons()?
+            .get_persons()
             .into_iter()
             .find(|p| p.id == person.id)
             .expect("updated person");
@@ -198,7 +198,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_person_address_invalid_form_renders_template() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list_id = CandidateListId::new();
         let mut list = sample_candidate_list(list_id);
         let person = sample_person_with_last_name(PersonId::new(), "Jansen");

--- a/src/app/candidates/pages/update_position.rs
+++ b/src/app/candidates/pages/update_position.rs
@@ -117,7 +117,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_candidate_position_renders_form() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list_id = CandidateListId::new();
         let mut list = sample_candidate_list(list_id);
         let person = sample_person(PersonId::new());
@@ -151,7 +151,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_candidate_position_moves_candidate() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list_id = CandidateListId::new();
         let list = sample_candidate_list(list_id);
         let person_a = sample_person_with_last_name(PersonId::new(), "Jansen");
@@ -200,7 +200,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_candidate_position_removes_candidate() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list_id = CandidateListId::new();
         let list = sample_candidate_list(list_id);
         let person_a = sample_person_with_last_name(PersonId::new(), "Jansen");
@@ -248,7 +248,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_candidate_position_invalid_csrf_renders_template() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list_id = CandidateListId::new();
         let list = sample_candidate_list(list_id);
         let person_a = sample_person_with_last_name(PersonId::new(), "Jansen");

--- a/src/app/candidates/pages/update_representative.rs
+++ b/src/app/candidates/pages/update_representative.rs
@@ -103,7 +103,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_representative_renders_candidate() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list_id = CandidateListId::new();
         let list = sample_candidate_list(list_id);
         let person = sample_person(PersonId::new());
@@ -141,7 +141,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_representative_renders_valid_csrf_token() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list_id = CandidateListId::new();
         let list = sample_candidate_list(list_id);
         let person = sample_person(PersonId::new());
@@ -183,7 +183,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_representative_persists_and_redirects() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list_id = CandidateListId::new();
         let list = sample_candidate_list(list_id);
         let person = sample_person(PersonId::new());
@@ -239,7 +239,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_representative_invalid_form_renders_template() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list_id = CandidateListId::new();
         let list = sample_candidate_list(list_id);
         let person = sample_person(PersonId::new());

--- a/src/app/common/components/layout.html
+++ b/src/app/common/components/layout.html
@@ -12,7 +12,13 @@
           <a href="{{ crate::political_groups::PoliticalGroup::update_path() }}">{{ "common.general_information"|trans }}</a>
         </li>
         <li>
-          <a href="{{ crate::candidate_lists::CandidateList::list_path() }}">{{ "candidate_list.title"|trans }}</a>
+          <a href="{{ crate::candidate_lists::CandidateList::list_path() }}">
+            {% if "multiple_candidate_lists"|value_true %}
+              {{ "candidate_list.title_plural"|trans }}
+            {% else %}
+              {{ "candidate_list.title_single"|trans }}
+            {% endif %}
+          </a>
         </li>
         <li>
           <a href="{{ crate::submit::SubmitPath{}.to_string() }}">{{ "common.submit"|trans }}</a>
@@ -22,22 +28,21 @@
         <li>
           <a href="/" class="logout">{{ "action.signout"|trans }}</a>
         </li>
-        {% if let Ok(locale) = "locale"|value::<crate::Locale> %}
-          <li>
-            <form action="{{ crate::common::SwitchLanguagePath{}.to_string() }}"
-                  method="post"
-                  class="language-switch">
-              <button class="button sm {% if (**locale == crate::Locale::Nl) %}active{% endif %}"
-                      type="submit"
-                      name="lang"
-                      value="nl">NL</button>
-              <button class="button sm {% if (**locale == crate::Locale::En) %}active{% endif %}"
-                      type="submit"
-                      name="lang"
-                      value="en">EN</button>
-            </form>
-          </li>
-        {% endif %}
+        {% let locale = "locale"|locale_value %}
+        <li>
+          <form action="{{ crate::common::SwitchLanguagePath{}.to_string() }}"
+                method="post"
+                class="language-switch">
+            <button class="button sm {% if locale == crate::Locale::Nl %}active{% endif %}"
+                    type="submit"
+                    name="lang"
+                    value="nl">NL</button>
+            <button class="button sm {% if locale == crate::Locale::En %}active{% endif %}"
+                    type="submit"
+                    name="lang"
+                    value="en">EN</button>
+          </form>
+        </li>
       </ul>
     </nav>
     <div class="header-content">
@@ -58,9 +63,7 @@
     <span>{{ "common.version"|trans }} <strong>{{ env!("CARGO_PKG_VERSION") }}</strong></span>
   </footer>
   {% block overlay %}{% endblock %}
-  {% if let Ok(show_success_alert) = "show_success_alert"|value::<bool> %}
-    {% if show_success_alert %}
-      <div class="alert alert-success alert-floating">{{ "common.save_success"|trans }}</div>
-    {% endif %}
+  {% if "show_success_alert"|value_true %}
+    <div class="alert alert-success alert-floating">{{ "common.save_success"|trans }}</div>
   {% endif %}
 {% endblock %}

--- a/src/app/common/components/overlay.html
+++ b/src/app/common/components/overlay.html
@@ -3,7 +3,7 @@
 {% block overlay %}
   <div class="overlay-backdrop">
     <form method="post"
-          class="overlay {% if let Ok(overlay_referrer) = "overlay_referrer"|value::<bool> && overlay_referrer %}no-animation{% else %}animation{% endif %}">
+          class="overlay {% if "overlay_referrer"|value_true %}no-animation{% else %}animation{% endif %}">
       {% if form is defined %}<input type="hidden" name="csrf_token" value="{{ form.data.csrf_token }}" />{% endif %}
       <header>
         <h2>

--- a/src/app/common/pages/index.html
+++ b/src/app/common/pages/index.html
@@ -1,9 +1,7 @@
 {% extends "common/components/layout.html" %}
 {% block page_title %}
-  {% if let Ok(locale) = "locale"|value::<crate::Locale> %}
-    {% let any_locale = AnyLocale::from(***locale) %}
-    {% if let Ok(election) = "election"|value::<ElectionConfig> %}{{ election.title(*any_locale) }}{% endif %}
-  {% endif %}
+  {% let election = "election"|election_value %}
+  {{ (&election)|election_title }}
 {% endblock %}
 {% block content %}
   <h2 class="hidden">{{ "common.steps"|trans }}</h2>
@@ -23,7 +21,13 @@
        class="card card-candidate-list">
       <div class="badge"></div>
       <h3>{{ "common.step"|trans("2") }}</h3>
-      <h4>{{ "candidate_list.title"|trans }}</h4>
+      <h4>
+        {% if "multiple_candidate_lists"|value_true %}
+          {{ "candidate_list.title_plural"|trans }}
+        {% else %}
+          {{ "candidate_list.title_single"|trans }}
+        {% endif %}
+      </h4>
       <ul class="instruction">
         <li>{{ "candidate_list.candidate_list_description.add_candidate"|trans }}</li>
         <li>{{ "candidate_list.candidate_list_description.add_candidate_list"|trans }}</li>
@@ -43,9 +47,8 @@
       <div class="alert alert-info">
         <span class="instruction">{{ "common.submit_instruction"|trans }}:</span>
         <p class="font-bold mt-md">
-          {% if let Ok(election) = "election"|value::<ElectionConfig> %}
-            {{ election.nomination_day_date().format("%d-%m-%Y") }}
-          {% endif %}
+          {% let election = "election"|election_value %}
+          {{ election.nomination_day_date().format("%d-%m-%Y") }}
         </p>
       </div>
       <p>{{ "action.review_and_submit"|trans }}</p>

--- a/src/app/common/pages/index.rs
+++ b/src/app/common/pages/index.rs
@@ -2,7 +2,7 @@ use askama::Template;
 use axum::response::IntoResponse;
 
 use super::IndexPath;
-use crate::{Context, ElectionConfig, HtmlTemplate, core::AnyLocale, filters};
+use crate::{Context, HtmlTemplate, filters};
 
 #[derive(Template)]
 #[template(path = "common/pages/index.html")]
@@ -16,11 +16,11 @@ pub async fn index(_: IndexPath, context: Context) -> impl IntoResponse {
 mod tests {
     use super::*;
 
-    use crate::test_utils::response_body_string;
+    use crate::{ElectionConfig, core::AnyLocale, test_utils::response_body_string};
 
     #[tokio::test]
     async fn index_renders_html() {
-        let body = index(IndexPath, Context::new_test().await)
+        let body = index(IndexPath, Context::new_test_without_db())
             .await
             .into_response();
         let body = response_body_string(body).await;

--- a/src/app/common/pages/not_found.rs
+++ b/src/app/common/pages/not_found.rs
@@ -33,7 +33,7 @@ mod tests {
     async fn not_found_renders_html() {
         let into_response = not_found(
             OriginalUri("/not_found".parse().unwrap()),
-            Context::new_test().await,
+            Context::new_test_without_db(),
         )
         .await
         .unwrap();

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -3,7 +3,7 @@
 
 use axum::{extract::FromRequestParts, http::request::Parts};
 
-use crate::{AppError, Session, political_groups::PoliticalGroup};
+use crate::{AppError, AppStore, Session, political_groups::PoliticalGroup};
 
 #[cfg(test)]
 use crate::Locale;
@@ -15,6 +15,8 @@ pub struct Context {
     pub political_group: PoliticalGroup,
     /// Maximum number of candidates allowed for this political group.
     pub max_candidates: usize,
+    /// Multiple candidate lists present
+    pub multiple_candidate_lists: bool,
     /// Whether to show the success alert based on the request query.
     pub show_success_alert: bool,
     /// Whether the request came from an overlay page (via referrer query).
@@ -24,13 +26,16 @@ pub struct Context {
 }
 
 impl Context {
-    pub fn new(political_group: PoliticalGroup, session: Session) -> Self {
+    pub fn new(store: &AppStore, session: Session) -> Self {
         let election = session.election;
+        let political_group = store.get_political_group();
         let long_list_allowed = political_group.long_list_allowed.unwrap_or(false);
+        let multiple_candidate_lists = store.get_candidate_list_count() > 1;
 
         Self {
             political_group,
             max_candidates: election.get_max_candidates(long_list_allowed),
+            multiple_candidate_lists,
             show_success_alert: false,
             overlay_referrer: false,
             session,
@@ -38,18 +43,10 @@ impl Context {
     }
 
     #[cfg(test)]
-    pub async fn new_test() -> Self {
-        let political_group = PoliticalGroup::default();
-
-        Self::new(political_group, Session::new_with_locale(Locale::En))
-    }
-
-    #[cfg(test)]
     pub fn new_test_without_db() -> Self {
-        Self::new(
-            PoliticalGroup::default(),
-            Session::new_with_locale(Locale::En),
-        )
+        let store = AppStore::new_for_test();
+
+        Self::new(&store, Session::new_with_locale(Locale::En))
     }
 
     pub fn livereload_enabled() -> bool {
@@ -64,6 +61,9 @@ impl askama::Values for Context {
             "election" => Some(&self.session.election as &dyn std::any::Any),
             "max_candidates" => Some(&self.max_candidates as &dyn std::any::Any),
             "show_success_alert" => Some(&self.show_success_alert as &dyn std::any::Any),
+            "multiple_candidate_lists" => {
+                Some(&self.multiple_candidate_lists as &dyn std::any::Any)
+            }
             "overlay_referrer" => Some(&self.overlay_referrer as &dyn std::any::Any),
             _ => None,
         }
@@ -78,27 +78,21 @@ where
 
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         let session = Session::from_request_parts(parts, state).await?;
-        let political_group = PoliticalGroup::from_request_parts(parts, state).await?;
-        let show_success_alert = parts
+        let store = AppStore::from_request_parts(parts, state).await?;
+        let mut context = Context::new(&store, session);
+
+        context.show_success_alert = parts
             .uri
             .query()
             .is_some_and(|q| q.contains("success=true"));
-        let overlay_referrer = parts
+
+        context.overlay_referrer = parts
             .headers
             .get(axum::http::header::REFERER)
             .and_then(|value| value.to_str().ok())
             .is_some_and(|url| url.contains("overlay=true"));
 
-        let long_list_allowed = political_group.long_list_allowed.unwrap_or(false);
-        let max_candidates = session.election.get_max_candidates(long_list_allowed);
-
-        Ok(Context {
-            political_group,
-            show_success_alert,
-            overlay_referrer,
-            max_candidates,
-            session,
-        })
+        Ok(context)
     }
 }
 
@@ -108,7 +102,7 @@ mod tests {
 
     #[tokio::test]
     async fn new_context_sets_locale() {
-        let context = Context::new_test().await;
+        let context = Context::new_test_without_db();
         assert_eq!(context.session.locale, Locale::En);
     }
 

--- a/src/app/getters.rs
+++ b/src/app/getters.rs
@@ -9,56 +9,56 @@ use crate::{
 };
 
 impl AppStore {
-    pub fn get_candidate_lists(&self) -> Result<Vec<CandidateList>, AppError> {
+    pub fn get_candidate_lists(&self) -> Vec<CandidateList> {
         let data = self.data.read();
 
         let mut lists: Vec<CandidateList> = data.candidate_lists.values().cloned().collect();
 
         lists.sort_unstable_by(|a, b| a.created_at.cmp(&b.created_at));
 
-        Ok(lists)
+        lists
     }
 
-    pub fn get_political_group(&self) -> Result<PoliticalGroup, AppError> {
+    pub fn get_political_group(&self) -> PoliticalGroup {
         let data = self.data.read();
 
-        Ok(data.political_group.clone())
+        data.political_group.clone()
     }
 
-    pub fn get_persons(&self) -> Result<Vec<Person>, AppError> {
+    pub fn get_persons(&self) -> Vec<Person> {
         let data = self.data.read();
 
-        Ok(data.persons.values().cloned().collect())
+        data.persons.values().cloned().collect()
     }
 
-    pub fn get_authorised_agents(&self) -> Result<Vec<AuthorisedAgent>, AppError> {
+    pub fn get_authorised_agents(&self) -> Vec<AuthorisedAgent> {
         let data = self.data.read();
 
-        Ok(data.authorised_agents.values().cloned().collect())
+        data.authorised_agents.values().cloned().collect()
     }
 
-    pub fn get_list_submitters(&self) -> Result<Vec<ListSubmitter>, AppError> {
+    pub fn get_list_submitters(&self) -> Vec<ListSubmitter> {
         let data = self.data.read();
 
-        Ok(data.list_submitters.values().cloned().collect())
+        data.list_submitters.values().cloned().collect()
     }
 
-    pub fn get_substitute_submitters(&self) -> Result<Vec<SubstituteSubmitter>, AppError> {
+    pub fn get_substitute_submitters(&self) -> Vec<SubstituteSubmitter> {
         let data = self.data.read();
 
-        Ok(data.substitute_submitters.values().cloned().collect())
+        data.substitute_submitters.values().cloned().collect()
     }
 
-    pub fn get_person_count(&self) -> Result<usize, AppError> {
+    pub fn get_person_count(&self) -> usize {
         let data = self.data.read();
 
-        Ok(data.persons.len())
+        data.persons.len()
     }
 
-    pub fn get_candidate_list_count(&self) -> Result<usize, AppError> {
+    pub fn get_candidate_list_count(&self) -> usize {
         let data = self.data.read();
 
-        Ok(data.candidate_lists.len())
+        data.candidate_lists.len()
     }
 
     pub fn get_candidate_list(&self, list_id: CandidateListId) -> Result<CandidateList, AppError> {
@@ -115,15 +115,12 @@ impl AppStore {
         }
     }
 
-    pub fn count_candidate_lists(&self, person_id: PersonId) -> Result<usize, AppError> {
+    pub fn count_candidate_lists(&self, person_id: PersonId) -> usize {
         let data = self.data.read();
 
-        let count = data
-            .candidate_lists
+        data.candidate_lists
             .values()
             .filter(|list| list.candidates.contains(&person_id))
-            .count();
-
-        Ok(count)
+            .count()
     }
 }

--- a/src/app/list_submitters/extractors/list_submitter.rs
+++ b/src/app/list_submitters/extractors/list_submitter.rs
@@ -52,7 +52,7 @@ mod tests {
         let list_submitter = sample_list_submitter(ListSubmitterId::new());
 
         let app_state = AppState::new_for_tests().await;
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         list_submitter.create(&store).await.unwrap();
 
         let app = Router::new()

--- a/src/app/list_submitters/pages/create.rs
+++ b/src/app/list_submitters/pages/create.rs
@@ -51,8 +51,8 @@ pub async fn create_list_submitter_submit(
 mod tests {
     use super::*;
     use crate::{
-        AppError, AppStore, Context, Form, PoliticalGroupId, QueryParamState,
-        test_utils::{response_body_string, sample_list_submitter_form, sample_political_group},
+        AppError, AppStore, Context, Form, QueryParamState,
+        test_utils::{response_body_string, sample_list_submitter_form},
     };
     use axum::{
         http::{StatusCode, header},
@@ -76,10 +76,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_list_submitter_persists_and_redirects() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let group_id = PoliticalGroupId::new();
-        let political_group = sample_political_group(group_id);
-        political_group.create(&store).await?;
+        let store = AppStore::new_for_test();
 
         let context = Context::new_test_without_db();
         let csrf_token = context.session.csrf_tokens.issue().value;
@@ -101,7 +98,7 @@ mod tests {
             .expect("location header")
             .to_str()
             .expect("location header value");
-        let submitters = store.get_list_submitters()?;
+        let submitters = store.get_list_submitters();
         assert_eq!(submitters.len(), 1);
         assert_eq!(
             location,
@@ -115,10 +112,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_list_submitter_invalid_form_renders_template() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let group_id = PoliticalGroupId::new();
-        let political_group = sample_political_group(group_id);
-        political_group.create(&store).await?;
+        let store = AppStore::new_for_test();
 
         let context = Context::new_test_without_db();
         let csrf_token = context.session.csrf_tokens.issue().value;

--- a/src/app/list_submitters/pages/delete.rs
+++ b/src/app/list_submitters/pages/delete.rs
@@ -30,20 +30,17 @@ mod tests {
 
     use super::*;
     use crate::{
-        AppError, AppStore, Context, Form, PoliticalGroupId, QueryParamState, TokenValue,
+        AppError, AppStore, Context, Form, QueryParamState, TokenValue,
         list_submitters::{ListSubmitter, ListSubmitterId},
-        test_utils::{sample_list_submitter, sample_political_group},
+        test_utils::sample_list_submitter,
     };
 
     #[tokio::test]
     async fn delete_list_submitter_removes_and_redirects() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let group_id = PoliticalGroupId::new();
-        let political_group = sample_political_group(group_id);
+        let store = AppStore::new_for_test();
+
         let submitter_id = ListSubmitterId::new();
         let submitter = sample_list_submitter(submitter_id);
-
-        political_group.create(&store).await?;
         submitter.create(&store).await?;
 
         let context = Context::new_test_without_db();
@@ -73,7 +70,7 @@ mod tests {
                 .to_string()
         );
 
-        let submitters = store.get_list_submitters()?;
+        let submitters = store.get_list_submitters();
         assert!(submitters.is_empty());
 
         Ok(())
@@ -81,13 +78,10 @@ mod tests {
 
     #[tokio::test]
     async fn delete_list_submitter_invalid_csrf_error_page() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let group_id = PoliticalGroupId::new();
-        let political_group = sample_political_group(group_id);
+        let store = AppStore::new_for_test();
+
         let submitter_id = ListSubmitterId::new();
         let list_submitter = sample_list_submitter(submitter_id);
-
-        political_group.create(&store).await?;
         list_submitter.create(&store).await?;
 
         let context = Context::new_test_without_db();
@@ -104,7 +98,7 @@ mod tests {
 
         assert!(matches!(response, AppError::CsrfTokenInvalid));
 
-        let submitters = store.get_list_submitters()?;
+        let submitters = store.get_list_submitters();
         assert_eq!(submitters.len(), 1);
 
         Ok(())

--- a/src/app/list_submitters/pages/update.rs
+++ b/src/app/list_submitters/pages/update.rs
@@ -63,12 +63,9 @@ pub async fn update_list_submitter_submit(
 mod tests {
     use super::*;
     use crate::{
-        AppError, AppStore, Context, Form, PoliticalGroupId, QueryParamState,
+        AppError, AppStore, Context, Form, QueryParamState,
         list_submitters::ListSubmitterId,
-        test_utils::{
-            response_body_string, sample_list_submitter, sample_list_submitter_form,
-            sample_political_group,
-        },
+        test_utils::{response_body_string, sample_list_submitter, sample_list_submitter_form},
     };
     use axum::{
         http::{StatusCode, header},
@@ -78,13 +75,10 @@ mod tests {
 
     #[tokio::test]
     async fn update_list_submitter_renders_existing_submitter() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let group_id = PoliticalGroupId::new();
-        let political_group = sample_political_group(group_id);
+        let store = AppStore::new_for_test();
+
         let submitter_id = ListSubmitterId::new();
         let list_submitter = sample_list_submitter(submitter_id);
-
-        political_group.create(&store).await?;
         list_submitter.create(&store).await?;
 
         let response = update_list_submitter(
@@ -105,13 +99,10 @@ mod tests {
 
     #[tokio::test]
     async fn update_list_submitter_persists_and_redirects() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let group_id = PoliticalGroupId::new();
-        let political_group = sample_political_group(group_id);
+        let store = AppStore::new_for_test();
+
         let submitter_id = ListSubmitterId::new();
         let list_submitter = sample_list_submitter(submitter_id);
-
-        political_group.create(&store).await?;
         list_submitter.create(&store).await?;
 
         let context = Context::new_test_without_db();
@@ -151,13 +142,10 @@ mod tests {
 
     #[tokio::test]
     async fn update_list_submitter_invalid_form_renders_template() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let group_id = PoliticalGroupId::new();
-        let political_group = sample_political_group(group_id);
+        let store = AppStore::new_for_test();
+
         let submitter_id = ListSubmitterId::new();
         let list_submitter = sample_list_submitter(submitter_id);
-
-        political_group.create(&store).await?;
         list_submitter.create(&store).await?;
 
         let context = Context::new_test_without_db();

--- a/src/app/list_submitters/pages/view.rs
+++ b/src/app/list_submitters/pages/view.rs
@@ -39,21 +39,18 @@ pub async fn list_submitters(
 mod tests {
     use super::*;
     use crate::{
-        AppError, AppStore, Context, PoliticalGroupId,
+        AppError, AppStore, Context,
         list_submitters::ListSubmitterId,
-        test_utils::{response_body_string, sample_list_submitter, sample_political_group},
+        test_utils::{response_body_string, sample_list_submitter},
     };
     use axum::{http::StatusCode, response::IntoResponse};
 
     #[tokio::test]
     async fn list_submitters_shows_created_submitter() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let group_id = PoliticalGroupId::new();
-        let political_group = sample_political_group(group_id);
+        let store = AppStore::new_for_test();
+
         let submitter_id = ListSubmitterId::new();
         let list_submitter = sample_list_submitter(submitter_id);
-
-        political_group.create(&store).await?;
         list_submitter.create(&store).await?;
 
         let response =
@@ -71,13 +68,10 @@ mod tests {
 
     #[tokio::test]
     async fn list_submitters_shows_edit_link() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let group_id = PoliticalGroupId::new();
-        let political_group = sample_political_group(group_id);
+        let store = AppStore::new_for_test();
+
         let submitter_id = ListSubmitterId::new();
         let list_submitter = sample_list_submitter(submitter_id);
-
-        political_group.create(&store).await?;
         list_submitter.create(&store).await?;
 
         let response =

--- a/src/app/persons/extractors/person.rs
+++ b/src/app/persons/extractors/person.rs
@@ -59,7 +59,7 @@ mod tests {
         let person = sample_person(PersonId::new());
 
         let app_state = AppState::new_for_tests().await;
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         person.create(&store).await.unwrap();
 
         let app = Router::new()
@@ -87,7 +87,7 @@ mod tests {
         let person_id = PersonId::new();
 
         let app_state = AppState::new_for_tests().await;
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
 
         let app = Router::new()
             .route(

--- a/src/app/persons/extractors/person_pagination.rs
+++ b/src/app/persons/extractors/person_pagination.rs
@@ -21,7 +21,7 @@ where
         let pagination: Pagination<PersonSort> =
             Pagination::from_request_parts(parts, state).await?;
 
-        let total_items = store.get_person_count()?;
+        let total_items = store.get_person_count();
         let pagination = pagination.set_total(total_items);
 
         let persons = persons::Person::list(
@@ -59,7 +59,7 @@ mod tests {
     #[tokio::test]
     async fn person_pagination_extractor_slices_and_orders() {
         let app_state = AppState::new_for_tests().await;
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         sample_person_with_last_name(PersonId::new(), "Bakker")
             .create(&store)
             .await

--- a/src/app/persons/forms/person_form.rs
+++ b/src/app/persons/forms/person_form.rs
@@ -63,7 +63,7 @@ impl PersonForm {
         csrf_tokens: &CsrfTokens,
         store: &AppStore,
     ) -> Result<Person, Box<FormData<Self>>> {
-        let existing = store.get_persons().unwrap_or_default();
+        let existing = store.get_persons();
         let person = self.clone().validate_create(csrf_tokens)?;
         let errors = PersonForm::uniqueness_errors(&person, &existing);
 

--- a/src/app/persons/pages/create.rs
+++ b/src/app/persons/pages/create.rs
@@ -73,7 +73,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_person_persists_and_redirects() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let context = Context::new_test_without_db();
         let csrf_token = context.session.csrf_tokens.issue().value;
         let form = sample_person_form(&csrf_token);
@@ -90,12 +90,12 @@ mod tests {
             .expect("location header")
             .to_str()
             .expect("location header value");
-        let persons = store.get_persons()?;
+        let persons = store.get_persons();
         assert_eq!(persons.len(), 1);
         let created = persons.first().expect("person");
         assert_eq!(location, created.after_create_path());
 
-        let count = store.get_person_count()?;
+        let count = store.get_person_count();
         assert_eq!(count, 1);
 
         Ok(())
@@ -103,7 +103,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_person_invalid_form_renders_template() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let context = Context::new_test_without_db();
         let csrf_token = context.session.csrf_tokens.issue().value;
         let mut form = sample_person_form(&csrf_token);
@@ -122,7 +122,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_person_duplicate_name_renders_error() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let existing = crate::test_utils::sample_person(crate::persons::PersonId::new());
         existing.create(&store).await?;
 

--- a/src/app/persons/pages/delete.rs
+++ b/src/app/persons/pages/delete.rs
@@ -36,7 +36,7 @@ mod tests {
 
     #[tokio::test]
     async fn delete_person_removes_and_redirects() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let person_id = PersonId::new();
         let person = sample_person(person_id);
 

--- a/src/app/persons/pages/list.rs
+++ b/src/app/persons/pages/list.rs
@@ -36,7 +36,7 @@ mod tests {
 
     #[tokio::test]
     async fn list_persons_shows_created_person() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let id = PersonId::new();
         let person = sample_person(id);
 

--- a/src/app/persons/pages/update.rs
+++ b/src/app/persons/pages/update.rs
@@ -27,7 +27,7 @@ pub async fn update_person(
                 PersonForm::from(person.clone()),
                 &context.session.csrf_tokens,
             ),
-            on_candidate_lists: store.count_candidate_lists(person.id)?,
+            on_candidate_lists: store.count_candidate_lists(person.id),
             person,
         },
         context,
@@ -44,7 +44,7 @@ pub async fn update_person_submit(
     match form.validate_update(&person, &context.session.csrf_tokens) {
         Err(form_data) => Ok(HtmlTemplate(
             PersonUpdateTemplate {
-                on_candidate_lists: store.count_candidate_lists(person.id)?,
+                on_candidate_lists: store.count_candidate_lists(person.id),
                 person,
                 form: form_data,
             },
@@ -74,7 +74,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_person_renders_existing_person() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let person_id = PersonId::new();
         let person = sample_person(person_id);
 
@@ -99,7 +99,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_person_persists_and_redirects() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let person_id = PersonId::new();
         let person = sample_person(person_id);
 
@@ -138,7 +138,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_person_invalid_form_renders_template() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let person_id = PersonId::new();
         let person = sample_person(person_id);
 

--- a/src/app/persons/pages/update_address.rs
+++ b/src/app/persons/pages/update_address.rs
@@ -82,7 +82,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_person_address_renders_existing_person() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let person_id: PersonId = PersonId::new();
         let person = sample_person(person_id);
 
@@ -107,7 +107,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_person_address_persists_and_redirects() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let person_id = PersonId::new();
         let person = sample_person(person_id);
 
@@ -150,7 +150,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_person_address_invalid_form_renders_template() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let person_id = PersonId::new();
         let person = sample_person(person_id);
 
@@ -182,7 +182,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_person_address_dutch_xor_non_dutch() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let person_id = PersonId::new();
         let person = sample_person(person_id);
 

--- a/src/app/persons/pages/update_representative.rs
+++ b/src/app/persons/pages/update_representative.rs
@@ -81,7 +81,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_representative_renders_existing_person() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let person_id = PersonId::new();
         let person = sample_person(person_id);
 
@@ -106,7 +106,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_representative_renders_valid_csrf_token() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let person_id = PersonId::new();
         let person = sample_person(person_id);
 
@@ -135,7 +135,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_representative_persists_and_redirects() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let person_id = PersonId::new();
         let person = sample_person(person_id);
 
@@ -175,7 +175,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_representative_invalid_form_renders_template() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let person_id = PersonId::new();
         let person = sample_person(person_id);
 

--- a/src/app/persons/structs/person.rs
+++ b/src/app/persons/structs/person.rs
@@ -160,7 +160,7 @@ impl Person {
         sort_field: &PersonSort,
         sort_direction: &SortDirection,
     ) -> Result<Vec<Person>, AppError> {
-        let mut persons = store.get_persons()?;
+        let mut persons = store.get_persons();
         persons.sort_by(|a, b| compare_persons(a, b, sort_field));
 
         if matches!(sort_direction, SortDirection::Desc) {
@@ -197,7 +197,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_and_get_person() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let id = PersonId::new();
         let person = sample_person(id);
 
@@ -212,7 +212,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_person_overwrites_fields() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let id = PersonId::new();
         let mut person = sample_person(id);
 
@@ -229,7 +229,7 @@ mod tests {
 
     #[tokio::test]
     async fn remove_person_deletes_record() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let id = PersonId::new();
         let person = sample_person(id);
 
@@ -244,7 +244,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_address_overwrites_fields() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let id = PersonId::new();
         let mut person = sample_person(id);
 
@@ -292,7 +292,7 @@ mod tests {
 
     #[tokio::test]
     async fn list_and_count_persons() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         sample_person_with_last_name(PersonId::new(), "Jansen")
             .create(&store)
             .await?;
@@ -300,7 +300,7 @@ mod tests {
             .create(&store)
             .await?;
 
-        let total = store.get_person_count()?;
+        let total = store.get_person_count();
         assert_eq!(total, 2);
 
         let persons = Person::list(&store, 10, 0, &PersonSort::LastName, &SortDirection::Asc)?;

--- a/src/app/political_groups/extractors/political_group.rs
+++ b/src/app/political_groups/extractors/political_group.rs
@@ -14,6 +14,6 @@ where
     ) -> Result<Self, Self::Rejection> {
         let store = AppStore::from_request_parts(parts, state).await?;
 
-        store.get_political_group()
+        Ok(store.get_political_group())
     }
 }

--- a/src/app/political_groups/pages/update.rs
+++ b/src/app/political_groups/pages/update.rs
@@ -71,12 +71,9 @@ pub async fn update_political_group_submit(
 mod tests {
     use super::*;
     use crate::{
-        AppError, AppStore, Context, Form, PoliticalGroupId, QueryParamState,
+        AppError, AppStore, Context, Form, QueryParamState,
         authorised_agents::AuthorisedAgentId,
-        test_utils::{
-            response_body_string, sample_authorised_agent, sample_political_group,
-            sample_political_group_form,
-        },
+        test_utils::{response_body_string, sample_authorised_agent, sample_political_group_form},
     };
     use axum::{
         http::{StatusCode, header},
@@ -86,11 +83,8 @@ mod tests {
 
     #[tokio::test]
     async fn update_political_group_renders_existing_data() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let group_id = PoliticalGroupId::new();
-        let political_group = sample_political_group(group_id);
-
-        political_group.create(&store).await?;
+        let store = AppStore::new_for_test();
+        let political_group = store.get_political_group();
 
         let response = update_political_group(
             PoliticalGroupUpdatePath {},
@@ -112,13 +106,11 @@ mod tests {
 
     #[tokio::test]
     async fn update_political_group_persists_and_redirects() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let group_id = PoliticalGroupId::new();
-        let political_group = sample_political_group(group_id);
+        let store = AppStore::new_for_test();
+        let political_group = store.get_political_group();
+
         let agent_id = AuthorisedAgentId::new();
         let authorised_agent = sample_authorised_agent(agent_id);
-
-        political_group.create(&store).await?;
         authorised_agent.create(&store).await?;
 
         let context = Context::new_test_without_db();
@@ -149,7 +141,7 @@ mod tests {
                 .to_string()
         );
 
-        let updated = store.get_political_group()?;
+        let updated = store.get_political_group();
         assert_eq!(updated.long_list_allowed, Some(true));
         assert_eq!(
             updated.legal_name.as_deref().map(|v| v.to_string()),
@@ -165,13 +157,10 @@ mod tests {
 
     #[tokio::test]
     async fn update_political_group_invalid_form_renders_template() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let group_id = PoliticalGroupId::new();
-        let political_group = sample_political_group(group_id);
+        let store = AppStore::new_for_test();
+
         let agent_id = AuthorisedAgentId::new();
         let authorised_agent = sample_authorised_agent(agent_id);
-
-        political_group.create(&store).await?;
         authorised_agent.create(&store).await?;
 
         let context = Context::new_test_without_db();
@@ -183,7 +172,7 @@ mod tests {
         let response = update_political_group_submit(
             PoliticalGroupUpdatePath {},
             context,
-            political_group,
+            store.get_political_group(),
             store,
             Form(form),
         )

--- a/src/app/political_groups/steps.rs
+++ b/src/app/political_groups/steps.rs
@@ -16,10 +16,10 @@ pub struct PoliticalGroupSteps {
 
 impl PoliticalGroupSteps {
     pub fn new(store: &AppStore) -> Result<Self, AppError> {
-        let political_group = store.get_political_group()?;
-        let authorised_agents = store.get_authorised_agents()?;
-        let list_submitters = store.get_list_submitters()?;
-        let substitute_submitters = store.get_substitute_submitters()?;
+        let political_group = store.get_political_group();
+        let authorised_agents = store.get_authorised_agents();
+        let list_submitters = store.get_list_submitters();
+        let substitute_submitters = store.get_substitute_submitters();
 
         Ok(Self {
             basic_state: if political_group.is_basic_info_complete() {

--- a/src/app/store.rs
+++ b/src/app/store.rs
@@ -190,16 +190,17 @@ impl StoreData for AppStoreData {
 
 #[cfg(test)]
 impl crate::store::Store<AppStoreData> {
-    pub async fn new_for_test() -> Self {
-        let political_group_id = crate::PoliticalGroupId::new();
-        let political_group = crate::test_utils::sample_political_group(political_group_id);
+    pub fn new_for_test() -> Self {
+        let political_group =
+            crate::test_utils::sample_political_group(crate::PoliticalGroupId::new());
 
-        let store = crate::store::Store::new_for_stream("memory:", political_group_id.uuid())
-            .await
-            .expect("create in-memory store");
-
-        political_group.update(&store).await.expect("store update");
-
-        store
+        crate::store::Store {
+            stream_id: uuid::Uuid::new_v4(),
+            persistence: crate::store::StorePersistence::None,
+            data: std::sync::Arc::new(parking_lot::RwLock::new(AppStoreData {
+                political_group,
+                ..Default::default()
+            })),
+        }
     }
 }

--- a/src/app/store_tests.rs
+++ b/src/app/store_tests.rs
@@ -295,7 +295,7 @@ fn apply_update_candidate_list_submitters_sets_ids() {
 
 #[tokio::test]
 async fn store_update_applies_event_in_memory() -> Result<(), AppError> {
-    let store = AppStore::new_for_test().await;
+    let store = AppStore::new_for_test();
     let agent_id = crate::authorised_agents::AuthorisedAgentId::new();
     let agent = sample_authorised_agent(agent_id);
 

--- a/src/app/submit/pages/h1.rs
+++ b/src/app/submit/pages/h1.rs
@@ -39,7 +39,7 @@ mod tests {
 
     #[tokio::test]
     async fn gen_h1_missing_list_submitter_returns_error() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list_id = CandidateListId::new();
         let list = sample_candidate_list(list_id);
         list.create(&store).await?;
@@ -71,7 +71,7 @@ mod tests {
     #[cfg_attr(not(feature = "net-tests"), ignore = "requires network")]
     #[tokio::test]
     async fn gen_h1_returns_pdf_response() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list_id = CandidateListId::new();
         let list_submitter_id = ListSubmitterId::new();
         let person_id = PersonId::new();

--- a/src/app/submit/pages/index.html
+++ b/src/app/submit/pages/index.html
@@ -2,33 +2,28 @@
 {% block page_title %}{{ "common.submit"|trans }}{% endblock %}
 {% block overview_nav_class %}active{% endblock %}
 {% block content %}
+  {% let max_candidates = "max_candidates"|integer_value %}
+  {% let election = "election"|election_value %}
   <section>
     <div class="cards cards-candidate-lists">
       {% for candidate_list in candidate_lists %}
         <div class="{% if candidate_list.duplicate_districts.is_empty() %}card card-candidate-list{% else %}card card-list-warning{% endif %}">
           <div class="badge"></div>
           <h3>{{ "candidate_list.title_single"|trans }}</h3>
-          {% if let Ok(max_candidates) = "max_candidates"|value::<usize> %}
-            <p class="statistic">
-              {{ "candidate_list.candidate_count"|trans(&candidate_list.person_count.to_string() , &max_candidates.to_string())|safe }}
-            </p>
-          {% endif %}
+          <p class="statistic">
+            {{ "candidate_list.candidate_count"|trans(&candidate_list.person_count.to_string() , &max_candidates.to_string())|safe }}
+          </p>
           <h5>{{ "common.electoral_districts"|trans }}:</h5>
-          {% if let Ok(election) = "election"|value::<crate::ElectionConfig> %}
-            {% if candidate_list.list.electoral_districts.len() == election.electoral_districts().len() && candidate_list.duplicate_districts.is_empty() %}
-              <p>{{ "candidate_list.districts.all"|trans }}</p>
-            {% else %}
-              <ul class="districts">
-                {% if let Ok(locale) = "locale"|value::<crate::Locale> %}
-                  {% let any_locale = AnyLocale::from(***locale) %}
-                  {% for district in candidate_list.list.electoral_districts %}
-                    <li {% if candidate_list.duplicate_districts.contains(district) %}class="warning"{% endif %}>
-                      <span>{{ district.title(*any_locale) }}</span>
-                    </li>
-                  {% endfor %}
-                {% endif %}
-              </ul>
-            {% endif %}
+          {% if candidate_list.list.electoral_districts.len() == election.electoral_districts().len() && candidate_list.duplicate_districts.is_empty() %}
+            <p>{{ "candidate_list.districts.all"|trans }}</p>
+          {% else %}
+            <ul class="districts">
+              {% for district in candidate_list.list.electoral_districts %}
+                <li {% if candidate_list.duplicate_districts.contains(district) %}class="warning"{% endif %}>
+                  <span>{{ district|district_name }}</span>
+                </li>
+              {% endfor %}
+            </ul>
           {% endif %}
           <div class="card-actions">
             {% if candidate_list.can_download %}

--- a/src/app/submit/pages/index.rs
+++ b/src/app/submit/pages/index.rs
@@ -4,7 +4,7 @@ use axum::response::IntoResponse;
 use crate::{
     AppError, AppStore, Context, ElectoralDistrict, HtmlTemplate,
     candidate_lists::{CandidateList, CandidateListSummary, FullCandidateList},
-    core::{AnyLocale, ModelLocale},
+    core::ModelLocale,
     filters,
     submit::H1,
 };
@@ -83,7 +83,7 @@ mod tests {
 
     #[tokio::test]
     async fn index_shows_h1_downloads_for_complete_lists() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let complete_list_id = CandidateListId::new();
         let incomplete_list_id = CandidateListId::new();
         let list_submitter_id = ListSubmitterId::new();

--- a/src/app/submit/structs/h1.rs
+++ b/src/app/submit/structs/h1.rs
@@ -72,7 +72,7 @@ impl H1 {
             election_type: election.election_type(),
             electoral_districts: ElectoralDistricts::from(&list, election, locale),
             designation: store
-                .get_political_group()?
+                .get_political_group()
                 .display_name
                 .ok_or(AppError::IncompleteData(
                     "Missing registered designation from political group",
@@ -416,7 +416,7 @@ mod tests {
 
     #[tokio::test]
     async fn substitute_submitter_from_ids_resolves_submitters() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let submitter_a = sample_substitute_submitter(SubstituteSubmitterId::new());
         let mut submitter_b = sample_substitute_submitter(SubstituteSubmitterId::new());
         submitter_b.name.last_name = "Janssen".parse::<LastName>().expect("last name");
@@ -440,7 +440,7 @@ mod tests {
 
     #[tokio::test]
     async fn substitute_submitter_from_ids_returns_integrity_error_on_missing() {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let list = CandidateList {
             substitute_list_submitter_ids: vec![SubstituteSubmitterId::new()],
             ..Default::default()

--- a/src/app/substitute_list_submitters/extractors/substitute_submitter.rs
+++ b/src/app/substitute_list_submitters/extractors/substitute_submitter.rs
@@ -52,7 +52,7 @@ mod tests {
         let substitute_submitter = sample_substitute_submitter(SubstituteSubmitterId::new());
 
         let app_state = AppState::new_for_tests().await;
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         substitute_submitter.create(&store).await.unwrap();
 
         let app = Router::new()

--- a/src/app/substitute_list_submitters/pages/create.rs
+++ b/src/app/substitute_list_submitters/pages/create.rs
@@ -59,10 +59,8 @@ mod tests {
     use axum_extra::routing::TypedPath;
 
     use crate::{
-        AppError, AppStore, Context, PoliticalGroupId,
-        test_utils::{
-            response_body_string, sample_political_group, sample_substitute_submitter_form,
-        },
+        AppError, AppStore, Context,
+        test_utils::{response_body_string, sample_substitute_submitter_form},
     };
 
     #[tokio::test]
@@ -81,11 +79,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_substitute_submitter_persists_and_redirects() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let group_id = PoliticalGroupId::new();
-        let political_group = sample_political_group(group_id);
-        political_group.create(&store).await?;
-
+        let store = AppStore::new_for_test();
         let context = Context::new_test_without_db();
         let csrf_token = context.session.csrf_tokens.issue().value;
         let form = sample_substitute_submitter_form(&csrf_token);
@@ -106,7 +100,7 @@ mod tests {
             .expect("location header")
             .to_str()
             .expect("location header value");
-        let submitters = store.get_substitute_submitters()?;
+        let submitters = store.get_substitute_submitters();
         assert_eq!(submitters.len(), 1);
         assert_eq!(
             location,
@@ -120,10 +114,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_substitute_submitter_invalid_form_renders_template() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let group_id = PoliticalGroupId::new();
-        let political_group = sample_political_group(group_id);
-        political_group.create(&store).await?;
+        let store = AppStore::new_for_test();
 
         let context = Context::new_test_without_db();
         let csrf_token = context.session.csrf_tokens.issue().value;

--- a/src/app/substitute_list_submitters/pages/delete.rs
+++ b/src/app/substitute_list_submitters/pages/delete.rs
@@ -32,22 +32,17 @@ mod tests {
     use crate::QueryParamState;
 
     use crate::{
-        AppError, AppStore, Context, PoliticalGroupId, TokenValue,
-        substitute_list_submitters::SubstituteSubmitterId,
-        test_utils::{sample_political_group, sample_substitute_submitter},
+        AppError, AppStore, Context, TokenValue, substitute_list_submitters::SubstituteSubmitterId,
+        test_utils::sample_substitute_submitter,
     };
 
     #[tokio::test]
     async fn delete_substitute_submitter_removes_and_redirects() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let group_id = PoliticalGroupId::new();
-        let political_group = sample_political_group(group_id);
+        let store = AppStore::new_for_test();
+
         let sub_submitter_id = SubstituteSubmitterId::new();
         let substitute_submitter = sample_substitute_submitter(sub_submitter_id);
-
-        political_group.create(&store).await?;
         substitute_submitter.create(&store).await?;
-        political_group.update(&store).await?;
 
         let context = Context::new_test_without_db();
         let csrf_token = context.session.csrf_tokens.issue().value;
@@ -76,7 +71,7 @@ mod tests {
                 .to_string()
         );
 
-        let submitters = store.get_substitute_submitters()?;
+        let submitters = store.get_substitute_submitters();
         assert!(submitters.is_empty());
 
         Ok(())
@@ -84,15 +79,11 @@ mod tests {
 
     #[tokio::test]
     async fn delete_substitute_submitter_invalid_csrf_error_page() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let group_id = PoliticalGroupId::new();
-        let political_group = sample_political_group(group_id);
+        let store = AppStore::new_for_test();
+
         let sub_submitter_id = SubstituteSubmitterId::new();
         let substitute_submitter = sample_substitute_submitter(sub_submitter_id);
-
-        political_group.create(&store).await?;
         substitute_submitter.create(&store).await?;
-        political_group.update(&store).await?;
 
         let context = Context::new_test_without_db();
 
@@ -108,7 +99,7 @@ mod tests {
 
         assert!(matches!(response, AppError::CsrfTokenInvalid));
 
-        let submitters = store.get_substitute_submitters()?;
+        let submitters = store.get_substitute_submitters();
         assert_eq!(submitters.len(), 1);
 
         Ok(())

--- a/src/app/substitute_list_submitters/pages/update.rs
+++ b/src/app/substitute_list_submitters/pages/update.rs
@@ -71,23 +71,19 @@ mod tests {
     use axum_extra::routing::TypedPath;
 
     use crate::{
-        AppError, AppStore, Context, PoliticalGroupId,
+        AppError, AppStore, Context,
         substitute_list_submitters::SubstituteSubmitterId,
         test_utils::{
-            response_body_string, sample_political_group, sample_substitute_submitter,
-            sample_substitute_submitter_form,
+            response_body_string, sample_substitute_submitter, sample_substitute_submitter_form,
         },
     };
 
     #[tokio::test]
     async fn update_substitute_submitter_renders_existing_submitter() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let group_id = PoliticalGroupId::new();
-        let political_group = sample_political_group(group_id);
+        let store = AppStore::new_for_test();
+
         let sub_submitter_id = SubstituteSubmitterId::new();
         let substitute_submitter = sample_substitute_submitter(sub_submitter_id);
-
-        political_group.create(&store).await?;
         substitute_submitter.create(&store).await?;
 
         let response = update_substitute_submitter(
@@ -108,13 +104,10 @@ mod tests {
 
     #[tokio::test]
     async fn update_substitute_submitter_persists_and_redirects() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let group_id = PoliticalGroupId::new();
-        let political_group = sample_political_group(group_id);
+        let store = AppStore::new_for_test();
+
         let sub_submitter_id = SubstituteSubmitterId::new();
         let substitute_submitter = sample_substitute_submitter(sub_submitter_id);
-
-        political_group.create(&store).await?;
         substitute_submitter.create(&store).await?;
 
         let context = Context::new_test_without_db();
@@ -154,13 +147,10 @@ mod tests {
 
     #[tokio::test]
     async fn update_substitute_submitter_invalid_form_renders_template() -> Result<(), AppError> {
-        let store = AppStore::new_for_test().await;
-        let group_id = PoliticalGroupId::new();
-        let political_group = sample_political_group(group_id);
+        let store = AppStore::new_for_test();
+
         let sub_submitter_id = SubstituteSubmitterId::new();
         let substitute_submitter = sample_substitute_submitter(sub_submitter_id);
-
-        political_group.create(&store).await?;
         substitute_submitter.create(&store).await?;
 
         let context = Context::new_test_without_db();

--- a/src/core/election.rs
+++ b/src/core/election.rs
@@ -46,7 +46,7 @@ impl ElectoralDistrict {
         ]
     }
 
-    pub fn title(&self, locale: AnyLocale) -> &str {
+    pub fn title(&self, locale: AnyLocale) -> &'static str {
         match (self, locale) {
             (Self::DR, AnyLocale::Nl | AnyLocale::En) => "Drenthe",
             (Self::DR, AnyLocale::Fry) => "Drinte",
@@ -132,7 +132,7 @@ impl ElectionConfig {
         }
     }
 
-    pub fn title(&self, locale: AnyLocale) -> &str {
+    pub fn title(&self, locale: AnyLocale) -> &'static str {
         match self {
             Self::EK2027 => match locale {
                 AnyLocale::En => "Election of the Senate of the States General 2027",
@@ -142,7 +142,7 @@ impl ElectionConfig {
         }
     }
 
-    pub fn short_title(&self, locale: AnyLocale) -> &str {
+    pub fn short_title(&self, locale: AnyLocale) -> &'static str {
         match self {
             Self::EK2027 => match locale {
                 AnyLocale::En => "Election of the Senate 2027",

--- a/src/core/templates.rs
+++ b/src/core/templates.rs
@@ -41,7 +41,7 @@ mod tests {
 
     #[tokio::test]
     async fn html_template_returns_500_when_render_fails() {
-        let context = Context::new_test().await;
+        let context = Context::new_test_without_db();
         let response = HtmlTemplate(MyTemplate, context).into_response();
 
         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);

--- a/src/error/app_error.rs
+++ b/src/error/app_error.rs
@@ -261,7 +261,7 @@ mod tests {
             let response = error_response.into_response();
             let error_template = response.extensions().get::<ErrorTemplate>().unwrap();
             let content = error_template.title.clone();
-            let context = Context::new_test().await;
+            let context = Context::new_test_without_db();
             let html_response = (
                 error_template.status_code,
                 HtmlTemplate(error_template, context),

--- a/src/error/response.rs
+++ b/src/error/response.rs
@@ -192,7 +192,7 @@ mod tests {
     #[tokio::test]
     async fn not_found_renders_template_with_message() {
         let state = AppState::new_for_tests().await;
-        let store = crate::AppStore::new_for_test().await;
+        let store = crate::AppStore::new_for_test();
         let app = Router::new()
             .route(
                 "/",
@@ -216,7 +216,7 @@ mod tests {
     #[tokio::test]
     async fn validation_error_maps_to_bad_request() {
         let state = AppState::new_for_tests().await;
-        let store = crate::AppStore::new_for_test().await;
+        let store = crate::AppStore::new_for_test();
         let app = Router::new()
             .route(
                 "/",
@@ -242,7 +242,7 @@ mod tests {
     #[tokio::test]
     async fn database_error_maps_to_internal_server_error() {
         let state = AppState::new_for_tests().await;
-        let store = crate::AppStore::new_for_test().await;
+        let store = crate::AppStore::new_for_test();
         let app = Router::new()
             .route(
                 "/",

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -3,9 +3,11 @@
 use chrono::{DateTime, Utc};
 
 use crate::{
-    Locale,
+    ElectionConfig, ElectoralDistrict, Locale,
     constants::DEFAULT_DATE_TIME_FORMAT,
+    core::AnyLocale,
     form::{FormData, WithCsrfToken},
+    persons::Person,
 };
 
 #[askama::filter_fn]
@@ -19,6 +21,70 @@ pub fn display<T: std::fmt::Display>(
 #[askama::filter_fn]
 pub fn datetime(value: &DateTime<Utc>, _: &dyn askama::Values) -> askama::Result<String> {
     Ok(value.format(DEFAULT_DATE_TIME_FORMAT).to_string())
+}
+
+#[askama::filter_fn]
+pub fn value_true(value_name: &str, values: &dyn askama::Values) -> askama::Result<bool> {
+    let value = askama::get_value::<bool>(values, value_name)?;
+
+    Ok(*value)
+}
+
+#[askama::filter_fn]
+pub fn locale_value(value_name: &str, values: &dyn askama::Values) -> askama::Result<Locale> {
+    let value = askama::get_value::<Locale>(values, value_name)?;
+
+    Ok(*value)
+}
+
+#[askama::filter_fn]
+pub fn election_value(
+    value_name: &str,
+    values: &dyn askama::Values,
+) -> askama::Result<ElectionConfig> {
+    let value = askama::get_value::<ElectionConfig>(values, value_name)?;
+
+    Ok(*value)
+}
+
+#[askama::filter_fn]
+pub fn integer_value(value_name: &str, values: &dyn askama::Values) -> askama::Result<usize> {
+    let value = askama::get_value::<usize>(values, value_name)?;
+
+    Ok(*value)
+}
+
+#[askama::filter_fn]
+pub fn initials_as_printed_on_list(
+    value: &Person,
+    values: &dyn askama::Values,
+) -> askama::Result<String> {
+    let locale: &Locale = askama::get_value(values, "locale")?;
+    let any_locale = AnyLocale::from(*locale);
+
+    Ok(value.initials_as_printed_on_list(any_locale))
+}
+
+#[askama::filter_fn]
+pub fn district_name(
+    value: &ElectoralDistrict,
+    values: &dyn askama::Values,
+) -> askama::Result<&'static str> {
+    let locale: &Locale = askama::get_value(values, "locale")?;
+    let any_locale = AnyLocale::from(*locale);
+
+    Ok(value.title(any_locale))
+}
+
+#[askama::filter_fn]
+pub fn election_title(
+    value: &ElectionConfig,
+    values: &dyn askama::Values,
+) -> askama::Result<&'static str> {
+    let locale: &Locale = askama::get_value(values, "locale")?;
+    let any_locale = AnyLocale::from(*locale);
+
+    Ok(value.title(any_locale))
 }
 
 #[askama::filter_fn]

--- a/src/fixtures/candidate_list.rs
+++ b/src/fixtures/candidate_list.rs
@@ -90,7 +90,7 @@ mod tests {
     use crate::candidate_lists::CandidateListSummary;
     #[tokio::test]
     async fn test_load() {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         crate::fixtures::persons::load(&store).await.unwrap();
         load(&store).await.unwrap();
 

--- a/src/fixtures/mod.rs
+++ b/src/fixtures/mod.rs
@@ -5,8 +5,8 @@ mod persons;
 mod political_groups;
 
 pub async fn load(store: &AppStore, political_group_id: PoliticalGroupId) -> Result<(), AppError> {
-    let person_count = store.get_person_count()?;
-    let candidate_list_count = store.get_candidate_list_count()?;
+    let person_count = store.get_person_count();
+    let candidate_list_count = store.get_candidate_list_count();
 
     if person_count > 0 && candidate_list_count > 0 {
         tracing::warn!("Skip loading fixtures, store not empty");
@@ -27,7 +27,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_load_all_fixtures() {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let political_group_id = PoliticalGroupId::new();
         load(&store, political_group_id).await.unwrap();
         let persons = crate::persons::Person::list(

--- a/src/fixtures/persons.rs
+++ b/src/fixtures/persons.rs
@@ -138,7 +138,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_load() {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         load(&store).await.unwrap();
 
         let persons =

--- a/src/fixtures/political_groups.rs
+++ b/src/fixtures/political_groups.rs
@@ -121,15 +121,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_load() {
-        let store = AppStore::new_for_test().await;
+        let store = AppStore::new_for_test();
         let political_group_id: PoliticalGroupId =
             Uuid::new_v5(&Uuid::NAMESPACE_OID, b"fixture_political_group").into();
         load(&store, political_group_id).await.unwrap();
 
-        let list_submitters = store.get_list_submitters().unwrap();
+        let list_submitters = store.get_list_submitters();
         assert_eq!(list_submitters.len(), 1);
 
-        let substitute_submitters = store.get_substitute_submitters().unwrap();
+        let substitute_submitters = store.get_substitute_submitters();
         assert_eq!(substitute_submitters.len(), 2);
     }
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -114,7 +114,7 @@ mod tests {
         let session = crate::Session::new();
         let token = session.token().to_exposed_string();
         state.sessions.insert(session);
-        let store = crate::AppStore::new_for_test().await;
+        let store = crate::AppStore::new_for_test();
         request.headers_mut().insert(
             header::COOKIE,
             format!("{}={}", crate::SESSION_COOKIE_NAME, token)
@@ -141,7 +141,7 @@ mod tests {
         let session = crate::Session::new();
         let token = session.token().to_exposed_string();
         state.sessions.insert(session);
-        let store = crate::AppStore::new_for_test().await;
+        let store = crate::AppStore::new_for_test();
         request.headers_mut().insert(
             header::COOKIE,
             format!("{}={}", crate::SESSION_COOKIE_NAME, token)


### PR DESCRIPTION
Fixes #283

- Refactor `Context::new_test_without_db()` and `AppStore::new_for_test()` to also load a sample political group, this simplifies the tests.
- Add Askama utility functions to fetch context variables and render district names / election names. This removed boiler-plate logic from templates.