### PR TITLE
Add `not_empty` validation attribute and require at leas one electoral district

### DIFF
--- a/locales/en/validation.yml
+++ b/locales/en/validation.yml
@@ -1,4 +1,5 @@
 bsn_already_exists: This BSN is already in use.
+choose_at_least_one_option: Please choose at least one option.
 invalid_bsn: Invalid BSN.
 invalid_csrf_token: The CSRF token is invalid.
 invalid_email: Invalid email address.

--- a/locales/nl/validation.yml
+++ b/locales/nl/validation.yml
@@ -1,4 +1,5 @@
 bsn_already_exists: Dit BSN is al in gebruik.
+choose_at_least_one_option: Kies ten minste één optie.
 invalid_bsn: Ongeldig BSN.
 invalid_csrf_token: De CSRF-token is ongeldig.
 invalid_email: Ongeldig e-mailadres.

--- a/src/app/candidate_lists/components/districts_form.html
+++ b/src/app/candidate_lists/components/districts_form.html
@@ -9,16 +9,16 @@
     </label>
   </div>
   {% let election = "election"|election_value %}
-    <div class="checklist grid" id="district_list">
-      {% for d in election.electoral_districts() %}
-      <div class="checkbox {% if !available_districts.contains(&d) %}disabled{% endif %}">
-        <input type="checkbox" name="electoral_districts" id="electoral_district_{{ d.code() }}" value="{{ d.code() }}"
-          {% if form.data.electoral_districts.contains(&d) %}checked{% endif %} />
-        <label for="electoral_district_{{ d.code() }}">
-          {{ d|district_name }}
-        </label>
-      </div>
-      {% endfor %}
+  <div class="checklist grid" id="district_list">
+    {% for d in election.electoral_districts() %}
+    <div class="checkbox {% if !available_districts.contains(&d) %}disabled{% endif %}">
+      <input type="checkbox" name="electoral_districts" id="electoral_district_{{ d.code() }}" value="{{ d.code() }}"
+        {% if form.data.electoral_districts.contains(&d) %}checked{% endif %} />
+      <label for="electoral_district_{{ d.code() }}">
+        {{ d|district_name }}
+      </label>
     </div>
-
+    {% endfor %}
+  </div>
+  {% for error in form|error("electoral_districts") %}<span class="error">{{ error }}</span>{% endfor %}
 </fieldset>

--- a/src/app/candidate_lists/forms/candidate_list_create_form.rs
+++ b/src/app/candidate_lists/forms/candidate_list_create_form.rs
@@ -7,6 +7,7 @@ use crate::{TokenValue, candidate_lists::CandidateList};
 #[validate(target = "CandidateList")]
 #[serde(default)]
 pub struct CandidateListCreateForm {
+    #[validate(not_empty)]
     pub electoral_districts: Vec<crate::ElectoralDistrict>,
     #[validate(ignore)]
     pub copy_candidates: bool,

--- a/src/app/candidate_lists/forms/candidate_list_form.rs
+++ b/src/app/candidate_lists/forms/candidate_list_form.rs
@@ -7,6 +7,7 @@ use crate::{ElectoralDistrict, TokenValue, candidate_lists::CandidateList};
 #[validate(target = "CandidateList")]
 #[serde(default)]
 pub struct CandidateListForm {
+    #[validate(not_empty)]
     pub electoral_districts: Vec<ElectoralDistrict>,
     #[validate(csrf)]
     pub csrf_token: TokenValue,

--- a/src/form/validation_error.rs
+++ b/src/form/validation_error.rs
@@ -9,6 +9,7 @@ pub enum ValidationError {
     InvalidValue,
     InvalidEmail,
     ValueShouldNotBeEmpty,
+    ChooseAtLeastOneOption,
     InvalidCsrfToken,
     ValueTooLong(ActualLength, MaxLength),
     ValueTooShort(ActualLength, MinLength),
@@ -32,6 +33,9 @@ impl ValidationError {
             ValidationError::InvalidEmail => trans!("validation.invalid_email", locale),
             ValidationError::ValueShouldNotBeEmpty => {
                 trans!("validation.value_should_not_be_empty", locale)
+            }
+            ValidationError::ChooseAtLeastOneOption => {
+                trans!("validation.choose_at_least_one_option", locale)
             }
             ValidationError::ValueTooLong(actual, max) => {
                 trans!("validation.value_too_long", locale, actual, max)
@@ -77,6 +81,10 @@ mod tests {
         assert_eq!(
             ValidationError::ValueShouldNotBeEmpty.message(Locale::En),
             "This field must not be empty."
+        );
+        assert_eq!(
+            ValidationError::ChooseAtLeastOneOption.message(Locale::En),
+            "Please choose at least one option."
         );
         assert_eq!(
             ValidationError::ValueTooLong(10, 5).message(Locale::En),

--- a/validate/src/lib.rs
+++ b/validate/src/lib.rs
@@ -8,6 +8,7 @@ use syn::{Data, DeriveInput, Fields, LitStr, Type, parse_macro_input};
 /// - `#[validate(target = "Type")]` on the struct.
 /// - `#[validate(parse = "Type")]` to parse via `Type::from_str`.
 /// - `#[validate(optional)]` to treat empty strings as `None`.
+/// - `#[validate(not_empty)]` to reject empty values via `is_empty`.
 /// - `#[validate(csrf)]` to validate CSRF tokens.
 /// - `#[validate(ignore)]` to skip validation and mapping for a field.
 /// - `#[validate(flatten)]` to validate a nested form and prefix its errors with `field[child]`.
@@ -31,6 +32,7 @@ struct FieldOptions {
     ignore: bool,
     validator: Option<Validator>,
     flatten: bool,
+    not_empty: bool,
 }
 
 enum Validator {
@@ -61,7 +63,7 @@ struct FieldBlocks {
     has_csrf: bool,
 }
 
-fn collect_named_fields<'a>(input: &'a DeriveInput) -> syn::Result<Vec<&'a syn::Field>> {
+fn collect_named_fields(input: &DeriveInput) -> syn::Result<Vec<&syn::Field>> {
     match &input.data {
         Data::Struct(data) => match &data.fields {
             Fields::Named(fields) => Ok(fields.named.iter().collect::<Vec<_>>()),
@@ -109,6 +111,17 @@ fn build_field_blocks(fields: &[&syn::Field]) -> syn::Result<FieldBlocks> {
             continue;
         }
 
+        if opts.not_empty {
+            let error = if is_vec_type(&field.ty) {
+                quote!(crate::form::ValidationError::ChooseAtLeastOneOption)
+            } else {
+                quote!(crate::form::ValidationError::ValueShouldNotBeEmpty)
+            };
+            let block = build_not_empty_block(ident, &field_name, &error);
+            field_blocks_create.push(block.clone());
+            field_blocks_update.push(block);
+        }
+
         let validation = build_field_validation(ident, &field_name, &opts)?;
 
         field_blocks_create.push(build_field_block(ident, &validation.create_expr));
@@ -130,6 +143,32 @@ fn build_field_blocks(fields: &[&syn::Field]) -> syn::Result<FieldBlocks> {
         field_blocks_update,
         has_csrf,
     })
+}
+
+fn is_vec_type(ty: &Type) -> bool {
+    let Type::Path(type_path) = ty else {
+        return false;
+    };
+    type_path
+        .path
+        .segments
+        .last()
+        .is_some_and(|segment| segment.ident == "Vec")
+}
+
+fn build_not_empty_block(
+    ident: &syn::Ident,
+    field_name: &str,
+    error: &proc_macro2::TokenStream,
+) -> proc_macro2::TokenStream {
+    quote! {
+        if self.#ident.is_empty() {
+            errors.push((
+                #field_name.to_string(),
+                #error,
+            ));
+        }
+    }
 }
 
 fn build_with_csrf_impl(struct_name: &syn::Ident, has_csrf: bool) -> proc_macro2::TokenStream {
@@ -272,9 +311,23 @@ fn parse_field_options(field: &syn::Field) -> syn::Result<FieldOptions> {
                 opts.optional = true;
                 return Ok(());
             }
+            if meta.path.is_ident("not_empty") {
+                if opts.not_empty {
+                    return Err(meta.error("not_empty can only be set once"));
+                }
+                if opts.flatten || opts.ignore || opts.csrf {
+                    return Err(
+                        meta.error("not_empty cannot be combined with flatten, ignore, or csrf")
+                    );
+                }
+                opts.not_empty = true;
+                return Ok(());
+            }
             if meta.path.is_ident("csrf") {
-                if opts.flatten || opts.ignore {
-                    return Err(meta.error("csrf cannot be combined with flatten or ignore"));
+                if opts.flatten || opts.ignore || opts.not_empty {
+                    return Err(
+                        meta.error("csrf cannot be combined with flatten, ignore, or not_empty")
+                    );
                 }
                 opts.csrf = true;
                 return Ok(());
@@ -283,7 +336,12 @@ fn parse_field_options(field: &syn::Field) -> syn::Result<FieldOptions> {
                 if opts.ignore {
                     return Err(meta.error("ignore can only be set once"));
                 }
-                if opts.optional || opts.csrf || opts.validator.is_some() || opts.flatten {
+                if opts.optional
+                    || opts.csrf
+                    || opts.validator.is_some()
+                    || opts.flatten
+                    || opts.not_empty
+                {
                     return Err(
                         meta.error("ignore cannot be combined with other validation options")
                     );
@@ -295,7 +353,12 @@ fn parse_field_options(field: &syn::Field) -> syn::Result<FieldOptions> {
                 if opts.flatten {
                     return Err(meta.error("flatten can only be set once"));
                 }
-                if opts.optional || opts.csrf || opts.validator.is_some() || opts.ignore {
+                if opts.optional
+                    || opts.csrf
+                    || opts.validator.is_some()
+                    || opts.ignore
+                    || opts.not_empty
+                {
                     return Err(
                         meta.error("flatten cannot be combined with other validation options")
                     );


### PR DESCRIPTION
Fixes #317

Adds `not_empty` validation attribute:

```rust
pub struct CandidateListForm {
    #[validate(not_empty)]
    pub electoral_districts: Vec<ElectoralDistrict>,
    #[validate(csrf)]
    pub csrf_token: TokenValue,
}
```

<img width="480" height="300" alt="image" src="https://github.com/user-attachments/assets/81dfed4c-0ade-474b-8fd4-eefb24c42c2c" />
