### PR TITLE
[#433] Always include fill in for district in H4 model

### DIFF
--- a/models/example-inputs/model-h4-example-1.json
+++ b/models/example-inputs/model-h4-example-1.json
@@ -1,14 +1,6 @@
 {
   "election_name": "de Eerste Kamer der Staten-Generaal",
   "election_type": "EK",
-  "electoral_districts": {
-    "tag": "Some",
-    "districts": [
-      "Provincie Utrecht",
-      "Gemeente Rotterdam",
-      "Gemeenten Berg en Dal, Beuningen, Buren, Culemborg, Druten, Heumen, Maasdriel, Neder-Betuwe, Nijmegen, Tiel, West Betuwe, West Maas en Waal, Wijchen, Zaltbommel"
-    ]
-  },
   "designation": "Test Partij (TP)",
   "candidates": [
     {

--- a/models/example-inputs/model-h4-example-2.json
+++ b/models/example-inputs/model-h4-example-2.json
@@ -1,14 +1,6 @@
 {
   "election_name": "de gemeenteraad van Amsterdam",
   "election_type": "GR",
-  "electoral_districts": {
-    "tag": "Some",
-    "districts": [
-      "Provincie Utrecht",
-      "Gemeente Rotterdam",
-      "Gemeenten Berg en Dal, Beuningen, Buren, Culemborg, Druten, Heumen, Maasdriel, Neder-Betuwe, Nijmegen, Tiel, West Betuwe, West Maas en Waal, Wijchen, Zaltbommel"
-    ]
-  },
   "designation": "Test Partij (TP)",
   "candidates": [
     {

--- a/models/example-inputs/model-h4-example-3.json
+++ b/models/example-inputs/model-h4-example-3.json
@@ -1,12 +1,6 @@
 {
   "election_name": "de Twadde Keamer fan de Steaten-Generaal",
   "election_type": "TK",
-  "electoral_districts": {
-    "tag": "Some",
-    "districts": [
-      "Fryslân"
-    ]
-  },
   "designation": "Test Partij (TP)",
   "candidates": [
     {

--- a/models/model-h4.typ
+++ b/models/model-h4.typ
@@ -68,7 +68,6 @@
 ))
 
 #let gr_or_other = (gr, non_gr) => if input.election_type == "GR" { gr } else { non_gr }
-#let districts = input.electoral_districts.districts
 #if input.election_type != "EK" {
   [
     = #trans[
@@ -88,7 +87,7 @@
           "De kiezer behoort tot kieskring",
           "De kiezer heart ta kiesrûnte",
         ),
-        [#if districts.len() == 1 { districts.at(0) } else { fill_in() }],
+        fill_in(),
       ),
       (trans("Datum", "Datum"), fill_in()),
       (trans("Ondertekening of gemeentestempel", "Undertekening of gemeentestimpel"), fill_in(height: 4em)),

--- a/src/app/submit/structs/h4.rs
+++ b/src/app/submit/structs/h4.rs
@@ -7,7 +7,6 @@ use crate::{
     submit::structs::{
         typst_candidate::{TypstCandidate, ordered_candidates},
         typst_datetime::TypstDatetime,
-        typst_electoral_districts::TypstElectoralDistricts,
     },
 };
 
@@ -15,7 +14,6 @@ use crate::{
 pub struct H4 {
     election_name: String,
     election_type: ElectionType,
-    electoral_districts: TypstElectoralDistricts,
     designation: String,
     candidates: Vec<TypstCandidate>,
     timestamp: TypstDatetime,
@@ -57,7 +55,6 @@ impl H4 {
         Ok(Self {
             election_name: election.title(locale.into()).to_string(),
             election_type: election.election_type(),
-            electoral_districts: TypstElectoralDistricts::from(&list, election, locale),
             designation: store
                 .get_political_group()
                 .display_name


### PR DESCRIPTION
Closes #433

# [DOD](/docs/definition-of-done.md) checklist

## For PR maintainer

- [x] I have linked the PR to at least one issue.
- [x] I assigned the PR to myself.
- [x] I have added a description how to test this PR (see "Review Instructions").
- [x] I have added documentation where necessary.

## For reviewer

- [ ] I have read all code changes.
- [ ] I have audited the code quality.
- I have tested the changes...
  - [ ] locally
- [ ] I have validated that the PR is functionally correct (use-cases, figma designs, etc.)

### Review instructions
Since the current election config is for EK and doesn't include  the district field anyway, testing is a bit more elaborate:
1. create a file `models/input.json`
2. copy the contents of `models/example-inputs/model-h4-example-2.json` into `models/input.json`
3. run `typst compile ./models/model-h4.typ --font-path=./models/fonts`
4. open the generated pdf `models/model-h4.pdf`
5. observe that the district field present a line to fill in a district

Alternatively, download the PDF diff artifacts :upside_down_face: 