### PR TITLE
[#452] Added test login endpoint

### DIFF
--- a/src/auth/dev_login.rs
+++ b/src/auth/dev_login.rs
@@ -1,0 +1,223 @@
+use axum::{
+    extract::{Query, State},
+    response::{IntoResponse, Redirect},
+};
+use axum_extra::extract::CookieJar;
+use serde::Deserialize;
+use uuid::Uuid;
+
+use crate::{
+    AppError, AppState, Locale, PoliticalGroupId, Session,
+    auth::session_extractor::build_session_cookie, form::ValidationError,
+    political_groups::PoliticalGroup,
+};
+
+pub const DEV_LOGIN_PATH: &str = "/dev/login";
+
+#[derive(Debug, Deserialize)]
+pub struct DevLoginQuery {
+    name: String,
+    fixtures: bool,
+}
+
+pub async fn dev_login(
+    State(state): State<AppState>,
+    jar: CookieJar,
+    Query(query): Query<DevLoginQuery>,
+    headers: axum::http::HeaderMap,
+) -> Result<impl IntoResponse, AppError> {
+    let name = query.name.trim();
+    if name.is_empty() {
+        return Err(AppError::ValidationError(vec![(
+            "name".to_string(),
+            ValidationError::InvalidValue,
+        )]));
+    }
+
+    let political_group_id = dev_political_group_id(name);
+    ensure_dev_store(&state, political_group_id, query.fixtures).await?;
+
+    let locale = request_locale(&headers);
+    let mut session = Session::new_with_locale(locale);
+    session.set_political_group(political_group_id);
+
+    state.sessions.cleanup_expired();
+    state.sessions.insert(session.clone());
+
+    Ok((jar.add(build_session_cookie(&session)), Redirect::to("/")))
+}
+
+pub(crate) fn request_locale(headers: &axum::http::HeaderMap) -> Locale {
+    headers
+        .get(axum::http::header::ACCEPT_LANGUAGE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(Locale::from_accept_language)
+        .unwrap_or_default()
+}
+
+fn dev_political_group_id(name: &str) -> PoliticalGroupId {
+    Uuid::new_v5(
+        &Uuid::NAMESPACE_URL,
+        format!("eks/dev-login/{name}").as_bytes(),
+    )
+    .into()
+}
+
+async fn ensure_dev_store(
+    state: &AppState,
+    political_group_id: PoliticalGroupId,
+    load_fixtures: bool,
+) -> Result<(), AppError> {
+    let store = state
+        .store_registry
+        .get_or_create(political_group_id.uuid())
+        .await?;
+    let store_is_empty = store.data.read().last_event_id == 0;
+
+    if load_fixtures {
+        #[cfg(feature = "fixtures")]
+        {
+            crate::fixtures::load(&store, political_group_id).await?;
+            return Ok(());
+        }
+    }
+
+    if store_is_empty {
+        PoliticalGroup {
+            id: political_group_id,
+            ..Default::default()
+        }
+        .create(&store)
+        .await?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode, header},
+    };
+    use tower::ServiceExt;
+
+    use crate::{AppState, router, test_utils::response_body_string};
+
+    use super::*;
+
+    fn cookie_value(response: &axum::response::Response) -> &str {
+        response
+            .headers()
+            .get(header::SET_COOKIE)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.split(';').next())
+            .expect("cookie value")
+    }
+
+    #[tokio::test]
+    async fn dev_login_sets_cookie_and_redirects_home() {
+        let state = AppState::new_for_tests().await;
+        let app = router::create(state.clone()).with_state(state.clone());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/dev/login?name=alice&fixtures=false")
+                    .header(header::ACCEPT_LANGUAGE, "en")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::SEE_OTHER);
+        assert_eq!(response.headers().get(header::LOCATION).unwrap(), "/");
+
+        let token = cookie_value(&response)
+            .split_once('=')
+            .map(|(_, value)| value)
+            .expect("session token");
+        let session = state.sessions.get(token).expect("session");
+        assert_eq!(session.locale, Locale::En);
+        assert_eq!(
+            session.political_group_id,
+            Some(dev_political_group_id("alice"))
+        );
+    }
+
+    #[tokio::test]
+    async fn dev_login_without_fixtures_keeps_store_empty() {
+        let state = AppState::new_for_tests().await;
+        let app = router::create(state.clone()).with_state(state.clone());
+
+        let login = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/dev/login?name=empty-store&fixtures=false")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("response");
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .header(header::COOKIE, cookie_value(&login))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_body_string(response).await;
+        assert!(body.contains("Kiesraad - Kandidaatstelling"));
+
+        let store = state
+            .store_registry
+            .get_or_create(dev_political_group_id("empty-store").uuid())
+            .await
+            .expect("store");
+        assert_eq!(store.get_person_count(), 0);
+        assert_eq!(store.get_candidate_list_count(), 0);
+        assert_eq!(
+            store.get_political_group().id,
+            dev_political_group_id("empty-store")
+        );
+    }
+
+    #[cfg(feature = "fixtures")]
+    #[tokio::test]
+    async fn dev_login_with_fixtures_loads_fixture_data() {
+        let state = AppState::new_for_tests().await;
+        let app = router::create(state.clone()).with_state(state.clone());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/dev/login?name=fixture-store&fixtures=true")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::SEE_OTHER);
+
+        let store = state
+            .store_registry
+            .get_or_create(dev_political_group_id("fixture-store").uuid())
+            .await
+            .expect("store");
+        assert!(store.get_person_count() > 0);
+        assert!(store.get_candidate_list_count() > 0);
+        assert_eq!(
+            store.get_political_group().id,
+            dev_political_group_id("fixture-store")
+        );
+    }
+}

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,5 +1,7 @@
 //! Authentication and session helpers.
 
+#[cfg(feature = "dev-features")]
+pub mod dev_login;
 /// Session model and token utilities.
 pub mod session;
 /// Session middleware and request extraction.

--- a/src/auth/session_extractor.rs
+++ b/src/auth/session_extractor.rs
@@ -19,7 +19,7 @@ use crate::{AppError, AppState, Locale, Session};
 pub const SESSION_COOKIE_NAME: &str = "EKS_SESSION_ID";
 
 /// Builds a secure, HTTP-only cookie that carries the session token.
-fn build_session_cookie(session: &Session) -> Cookie<'static> {
+pub(crate) fn build_session_cookie(session: &Session) -> Cookie<'static> {
     let mut cookie = Cookie::new(SESSION_COOKIE_NAME, session.token().to_exposed_string());
     cookie.set_http_only(true);
     cookie.set_secure(true);
@@ -36,6 +36,11 @@ pub async fn session_middleware(
     mut request: Request,
     next: Next,
 ) -> Response {
+    #[cfg(feature = "dev-features")]
+    if request.uri().path() == crate::auth::dev_login::DEV_LOGIN_PATH {
+        return next.run(request).await;
+    }
+
     let token = jar.get(SESSION_COOKIE_NAME).map(|cookie| cookie.value());
 
     let mut session = match state.sessions.get_existing(token) {
@@ -57,12 +62,7 @@ pub async fn session_middleware(
 
             // TODO: only create a new session after a successfull login
             state.sessions.cleanup_expired();
-            let locale = request
-                .headers()
-                .get(axum::http::header::ACCEPT_LANGUAGE)
-                .and_then(|value| value.to_str().ok())
-                .and_then(Locale::from_accept_language)
-                .unwrap_or_default();
+            let locale = request_locale(request.headers());
             let mut new_session = Session::new_with_locale(locale);
             new_session.set_political_group(uuid::Uuid::nil().into());
             state.sessions.insert(new_session.clone());
@@ -79,6 +79,21 @@ pub async fn session_middleware(
     request.extensions_mut().insert(session.clone());
 
     next.run(request).await
+}
+
+fn request_locale(headers: &axum::http::HeaderMap) -> Locale {
+    #[cfg(feature = "dev-features")]
+    {
+        crate::auth::dev_login::request_locale(headers)
+    }
+    #[cfg(not(feature = "dev-features"))]
+    {
+        headers
+            .get(axum::http::header::ACCEPT_LANGUAGE)
+            .and_then(|value| value.to_str().ok())
+            .and_then(Locale::from_accept_language)
+            .unwrap_or_default()
+    }
 }
 
 /// Middleware that resolves the scoped store for the session's political group.

--- a/src/router.rs
+++ b/src/router.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 pub fn create(state: AppState) -> Router<AppState> {
-    let router = Router::new()
+    let app_router = Router::new()
         .merge(common::router())
         .merge(persons::router())
         .merge(political_groups::router())
@@ -35,7 +35,11 @@ pub fn create(state: AppState) -> Router<AppState> {
         .expect("BAG_SERVICE_URL must be set in dev-features mode");
 
     #[cfg(feature = "dev-features")]
-    let router = router
+    let dev_router = Router::new()
+        .route(
+            crate::auth::dev_login::DEV_LOGIN_PATH,
+            get(crate::auth::dev_login::dev_login),
+        )
         .route(
             "/lookup",
             crate::utils::proxy::proxy_handler(&bag_service_url),
@@ -45,20 +49,28 @@ pub fn create(state: AppState) -> Router<AppState> {
             crate::utils::proxy::proxy_handler(&bag_service_url),
         );
 
-    let router = router
+    let app_router = app_router
         .fallback(get(common::not_found))
         .layer(middleware::from_fn_with_state(
             state.clone(),
             render_error_pages,
         ))
-                .layer(middleware::from_fn_with_state(
+        .layer(middleware::from_fn_with_state(
             state.clone(),
             store_middleware,
         ))
-                .layer(middleware::from_fn_with_state(
+        .layer(middleware::from_fn_with_state(
             state.clone(),
             session_middleware,
-        ))
+        ));
+
+    #[cfg(feature = "dev-features")]
+    let router = Router::new().merge(dev_router).merge(app_router);
+
+    #[cfg(not(feature = "dev-features"))]
+    let router = app_router;
+
+    let router = router
         .layer(SetResponseHeaderLayer::if_not_present(
             header::CONTENT_SECURITY_POLICY,
             HeaderValue::from_static("default-src 'none'; base-uri 'none'; connect-src 'self'; form-action 'self'; script-src 'self'; style-src 'self'; font-src 'self'; img-src 'self'; frame-ancestors 'none';"),


### PR DESCRIPTION
# [DOD](/docs/definition-of-done.md) checklist

Fixes #452 

## For PR maintainer

- [x] I have linked the PR to at least one issue.
- [x] I assigned the PR to myself.
- [x] I have added a description how to test this PR (see "Review Instructions").
- [x] I have added documentation where necessary.

## For reviewer

- [ ] I have read all code changes.
- [ ] I have audited the code quality.
- I have tested the changes...
  - [ ] locally
  - [ ] on the test environment (preferred)
- [ ] I have validated that the PR is functionally correct (use-cases, figma designs, etc.)

### Review instructions

Visit `/dev/login?name=<session-name>&fixtures=<true|false>` from any environment where the `dev-features` are enabled and validate this is a new session / user with or without fixture data.

## Using the dev login endpoint from Playwright

When `dev-features` is enabled, tests can create a session by visiting:

`/dev/login?name=<session-name>&fixtures=<true|false>`

### Query params

- `name`: stable identifier for the test user/session
- `fixtures`: whether fixture data should be loaded into that derived political-group stream

The endpoint will:

1. create or reuse the derived stream for that `name`
2. create a session
3. set the `EKS_SESSION_ID` cookie
4. redirect to `/`

### Playwright example

```ts
import { test, expect } from '@playwright/test';

test('login through dev endpoint', async ({ page }) => {
  // possibly add a utility function for this
  await page.goto('/dev/login?name=playwright-smoke&fixtures=true');

  await expect(page).toHaveURL(/\/$/);
  await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
});
