### PR TITLE
[#568] Make FieldChange an enum between entity and non-entity

### DIFF
--- a/src/app/audit_log/mod.rs
+++ b/src/app/audit_log/mod.rs
@@ -3,4 +3,4 @@ mod pages;
 mod structs;
 
 pub use pages::{AuditLogDetailPath, AuditLogPath, router};
-pub use structs::{AuditLogDetail, AuditLogEntry};
+pub use structs::{AuditLogDetail, AuditLogEntry, abbreviate_str};

--- a/src/app/audit_log/pages/detail.html
+++ b/src/app/audit_log/pages/detail.html
@@ -43,13 +43,17 @@
         </thead>
         <tbody>
           {% for change in detail.changes %}
-            <tr class="{% if change.old_value.is_empty() %}added{% elif change.new_value.is_empty() %}removed{% else %}changed{% endif %}">
-              <td>{{ change.field }}</td>
-              <td>
-                {% if change.old_refs.is_empty() %}
-                  {{ change.old_value }}
-                {% else %}
-                  {% for entity_ref in change.old_refs %}
+            <tr class="{{ change.change_kind() }}">
+              {% match change %}
+              {% when FieldChange::Regular with { field, old_value, new_value } %}
+                <td>{{ field }}</td>
+                <td>{{ old_value }}</td>
+                <td>{{ new_value }}</td>
+
+              {% when FieldChange::Entities with { field, old_refs, new_refs } %}
+                <td>{{ field }}</td>
+                <td>
+                  {% for entity_ref in old_refs %}
                     <div class="entity-ref">
                       <a href="/audit-log?search={{ entity_ref.id_full }}">
                         <abbr title="{{ entity_ref.id_full }}">{{ entity_ref.id_full|abbreviate_str }}</abbr>
@@ -57,13 +61,9 @@
                       {% if !entity_ref.description.is_empty() %}<span>{{ entity_ref.description }}</span>{% endif %}
                     </div>
                   {% endfor %}
-                {% endif %}
-              </td>
-              <td>
-                {% if change.new_refs.is_empty() %}
-                  {{ change.new_value }}
-                {% else %}
-                  {% for entity_ref in change.new_refs %}
+                </td>
+                <td>
+                  {% for entity_ref in new_refs %}
                     <div class="entity-ref">
                       <a href="/audit-log?search={{ entity_ref.id_full }}">
                         <abbr title="{{ entity_ref.id_full }}">{{ entity_ref.id_full|abbreviate_str }}</abbr>
@@ -71,8 +71,8 @@
                       {% if !entity_ref.description.is_empty() %}<span>{{ entity_ref.description }}</span>{% endif %}
                     </div>
                   {% endfor %}
-                {% endif %}
-              </td>
+                </td>
+              {% endmatch %}
             </tr>
           {% endfor %}
         </tbody>

--- a/src/app/audit_log/pages/detail.html
+++ b/src/app/audit_log/pages/detail.html
@@ -52,7 +52,7 @@
                   {% for entity_ref in change.old_refs %}
                     <div class="entity-ref">
                       <a href="/audit-log?search={{ entity_ref.id_full }}">
-                        <abbr title="{{ entity_ref.id_full }}">{{ entity_ref.id_abbreviated }}</abbr>
+                        <abbr title="{{ entity_ref.id_full }}">{{ entity_ref.id_full|abbreviate_str }}</abbr>
                       </a>
                       {% if !entity_ref.description.is_empty() %}<span>{{ entity_ref.description }}</span>{% endif %}
                     </div>
@@ -66,7 +66,7 @@
                   {% for entity_ref in change.new_refs %}
                     <div class="entity-ref">
                       <a href="/audit-log?search={{ entity_ref.id_full }}">
-                        <abbr title="{{ entity_ref.id_full }}">{{ entity_ref.id_abbreviated }}</abbr>
+                        <abbr title="{{ entity_ref.id_full }}">{{ entity_ref.id_full|abbreviate_str }}</abbr>
                       </a>
                       {% if !entity_ref.description.is_empty() %}<span>{{ entity_ref.description }}</span>{% endif %}
                     </div>

--- a/src/app/audit_log/pages/detail.rs
+++ b/src/app/audit_log/pages/detail.rs
@@ -3,7 +3,7 @@ use axum::response::IntoResponse;
 
 use crate::{
     AppError, AppStore, Context, HtmlTemplate,
-    audit_log::{AuditLogDetail, AuditLogPath, pages::AuditLogDetailPath},
+    audit_log::{AuditLogDetail, AuditLogPath, pages::AuditLogDetailPath, structs::FieldChange},
     filters,
 };
 

--- a/src/app/audit_log/pages/list.html
+++ b/src/app/audit_log/pages/list.html
@@ -59,7 +59,7 @@
               <td>{{ entry.details }}</td>
               <td class="subject-id">
                 <a href="/audit-log?search={{ entry.subject_id_full }}">
-                  <abbr title="{{ entry.subject_id_full }}">{{ entry.subject_id }}</abbr>
+                  <abbr title="{{ entry.subject_id_full }}">{{ entry.subject_id_full|abbreviate_str }}</abbr>
                 </a>
               </td>
               <td>

--- a/src/app/audit_log/structs/audit_log_detail.rs
+++ b/src/app/audit_log/structs/audit_log_detail.rs
@@ -43,7 +43,6 @@ pub struct AuditLogDetail {
     pub event_id: usize,
     pub description: String,
     pub details: String,
-    pub subject_id: String,
     pub subject_id_full: String,
     pub subject_path: String,
     pub created_at: DateTime<Utc>,
@@ -83,7 +82,6 @@ impl AuditLogDetail {
             event_id: entry.event_id,
             description: entry.description,
             details: entry.details,
-            subject_id: entry.subject_id,
             subject_id_full: entry.subject_id_full,
             subject_path: entry.subject_path,
             created_at: entry.created_at,
@@ -522,7 +520,6 @@ mod tests {
 
         assert_eq!(change.old_refs.len(), 1);
         assert_eq!(change.old_refs[0].id_full, old_submitter_id.to_string());
-        assert_eq!(change.old_refs[0].id_abbreviated.len(), 8);
         assert_eq!(change.old_refs[0].description, old_submitter_name);
 
         assert_eq!(change.new_refs.len(), 1);

--- a/src/app/audit_log/structs/audit_log_detail.rs
+++ b/src/app/audit_log/structs/audit_log_detail.rs
@@ -16,7 +16,7 @@ use crate::{
 
 use super::{
     audit_log_entry::AuditLogEntry,
-    entity_refs::{EntityRef, build_refs_for_key},
+    entity_refs::{EntityRef, build_ref_diffs_for_key},
     event_payload::extract_old_new,
     json_flatten::flatten,
 };
@@ -30,12 +30,32 @@ const EXCLUDED_FIELDS: &[&str] = &["id", "updated_at", "created_at"];
 /// carry resolved references so the template can render abbreviated clickable
 /// links plus a human-readable description. Otherwise the raw `old_value` /
 /// `new_value` strings are rendered.
-pub struct FieldChange {
-    pub field: String,
-    pub old_value: String,
-    pub new_value: String,
-    pub old_refs: Vec<EntityRef>,
-    pub new_refs: Vec<EntityRef>,
+#[cfg_attr(test, derive(Debug, PartialEq))]
+pub enum FieldChange {
+    Regular {
+        field: String,
+        old_value: String,
+        new_value: String,
+    },
+    Entities {
+        field: String,
+        old_refs: Vec<EntityRef>,
+        new_refs: Vec<EntityRef>,
+    },
+}
+
+impl FieldChange {
+    pub fn change_kind(&self) -> &'static str {
+        match self {
+            FieldChange::Regular { old_value, .. } if old_value.is_empty() => "added",
+            FieldChange::Regular { new_value, .. } if new_value.is_empty() => "removed",
+            FieldChange::Regular { .. } => "changed",
+
+            FieldChange::Entities { old_refs, .. } if old_refs.is_empty() => "added",
+            FieldChange::Entities { new_refs, .. } if new_refs.is_empty() => "removed",
+            FieldChange::Entities { .. } => "changed",
+        }
+    }
 }
 
 /// Detailed view of an audit log event, including field-level changes.
@@ -127,15 +147,21 @@ fn diff(
             continue;
         }
 
-        let old_refs = build_refs_for_key(key, &old_val, state_before);
-        let new_refs = build_refs_for_key(key, &new_val, state_after);
-        changes.push(FieldChange {
-            field: translate_field_name(key, locale),
-            old_value: old_val,
-            new_value: new_val,
-            old_refs,
-            new_refs,
-        });
+        if let Some((old_refs, new_refs)) =
+            build_ref_diffs_for_key(key, &old_val, state_before, &new_val, state_after)
+        {
+            changes.push(FieldChange::Entities {
+                field: translate_field_name(key, locale),
+                old_refs,
+                new_refs,
+            });
+        } else {
+            changes.push(FieldChange::Regular {
+                field: translate_field_name(key, locale),
+                old_value: old_val,
+                new_value: new_val,
+            });
+        }
     }
 
     changes
@@ -219,6 +245,56 @@ mod tests {
         },
     };
 
+    impl FieldChange {
+        fn field(&self) -> &str {
+            match self {
+                FieldChange::Regular { field, .. } | FieldChange::Entities { field, .. } => field,
+            }
+        }
+
+        fn assert_no_old(&self) {
+            match self {
+                FieldChange::Regular { old_value, .. } => assert!(old_value.is_empty()),
+                FieldChange::Entities { old_refs, .. } => assert!(old_refs.is_empty()),
+            }
+        }
+
+        fn assert_no_new(&self) {
+            match self {
+                FieldChange::Regular { new_value, .. } => assert!(new_value.is_empty()),
+                FieldChange::Entities { new_refs, .. } => assert!(new_refs.is_empty()),
+            }
+        }
+
+        fn old_value(&self) -> &str {
+            match self {
+                FieldChange::Regular { old_value, .. } => old_value,
+                FieldChange::Entities { .. } => unreachable!(),
+            }
+        }
+
+        fn new_value(&self) -> &str {
+            match self {
+                FieldChange::Regular { new_value, .. } => new_value,
+                FieldChange::Entities { .. } => unreachable!(),
+            }
+        }
+
+        fn old_refs(&self) -> &[EntityRef] {
+            match self {
+                FieldChange::Regular { .. } => unreachable!(),
+                FieldChange::Entities { old_refs, .. } => old_refs,
+            }
+        }
+
+        fn new_refs(&self) -> &[EntityRef] {
+            match self {
+                FieldChange::Regular { .. } => unreachable!(),
+                FieldChange::Entities { new_refs, .. } => new_refs,
+            }
+        }
+    }
+
     const EN: Locale = Locale::En;
 
     fn empty_state() -> AppStoreData {
@@ -240,9 +316,9 @@ mod tests {
         let state = empty_state();
         let changes = diff(&old, &new, &state, &state, EN);
         assert_eq!(changes.len(), 1);
-        assert_eq!(changes[0].field, "name");
-        assert_eq!(changes[0].old_value, "Alice");
-        assert_eq!(changes[0].new_value, "Bob");
+        assert_eq!(changes[0].field(), "name");
+        assert_eq!(changes[0].old_value(), "Alice");
+        assert_eq!(changes[0].new_value(), "Bob");
     }
 
     #[test]
@@ -254,8 +330,8 @@ mod tests {
         let state = empty_state();
         let changes = diff(&old, &new, &state, &state, EN);
         assert_eq!(changes.len(), 1);
-        assert_eq!(changes[0].old_value, "");
-        assert_eq!(changes[0].new_value, "Alice");
+        changes[0].assert_no_old();
+        assert_eq!(changes[0].new_value(), "Alice");
     }
 
     #[test]
@@ -267,8 +343,8 @@ mod tests {
         let state = empty_state();
         let changes = diff(&old, &new, &state, &state, EN);
         assert_eq!(changes.len(), 1);
-        assert_eq!(changes[0].old_value, "Alice");
-        assert_eq!(changes[0].new_value, "");
+        assert_eq!(changes[0].old_value(), "Alice");
+        changes[0].assert_no_new();
     }
 
     #[test]
@@ -284,7 +360,7 @@ mod tests {
         let state = empty_state();
         let changes = diff(&old, &new, &state, &state, EN);
         assert_eq!(changes.len(), 1);
-        assert_eq!(changes[0].field, "name");
+        assert_eq!(changes[0].field(), "name");
     }
 
     #[test]
@@ -315,7 +391,7 @@ mod tests {
         let state = empty_state();
         let changes = diff(&old, &new, &state, &state, EN);
         assert_eq!(changes.len(), 1);
-        assert_eq!(changes[0].field, "person.name");
+        assert_eq!(changes[0].field(), "person.name");
     }
 
     #[test]
@@ -377,7 +453,7 @@ mod tests {
         assert_eq!(detail.description, "Created person");
         assert!(!detail.changes.is_empty());
         for change in &detail.changes {
-            assert!(change.old_value.is_empty());
+            change.assert_no_old();
         }
     }
 
@@ -400,9 +476,9 @@ mod tests {
         let first_name_change = detail
             .changes
             .iter()
-            .find(|c| c.field == "First name")
+            .find(|c| c.field() == "First name")
             .expect("should have first_name change");
-        assert_eq!(first_name_change.new_value, "Updated");
+        assert_eq!(first_name_change.new_value(), "Updated");
     }
 
     #[test]
@@ -418,7 +494,7 @@ mod tests {
         let detail = AuditLogDetail::compute(&events, 2, Locale::En).unwrap();
         assert!(!detail.changes.is_empty());
         for change in &detail.changes {
-            assert!(change.new_value.is_empty());
+            change.assert_no_new();
         }
     }
 
@@ -451,7 +527,7 @@ mod tests {
 
         let detail = AuditLogDetail::compute(&events, 1, Locale::En).unwrap();
         for change in &detail.changes {
-            assert!(change.old_value.is_empty());
+            change.assert_no_old();
         }
     }
 
@@ -476,12 +552,12 @@ mod tests {
         let districts: Vec<_> = detail
             .changes
             .iter()
-            .filter(|c| c.field == "Electoral districts")
+            .filter(|c| c.field() == "Electoral districts")
             .collect();
 
         assert_eq!(districts.len(), 1);
-        assert_eq!(districts[0].old_value, "GR");
-        assert_eq!(districts[0].new_value, "GR, FR");
+        assert_eq!(districts[0].old_value(), "GR");
+        assert_eq!(districts[0].new_value(), "GR, FR");
     }
 
     #[test]
@@ -515,16 +591,23 @@ mod tests {
         let change = detail
             .changes
             .iter()
-            .find(|c| c.field == "List submitter")
+            .find(|c| c.field() == "List submitter")
             .expect("list_submitter_id change");
 
-        assert_eq!(change.old_refs.len(), 1);
-        assert_eq!(change.old_refs[0].id_full, old_submitter_id.to_string());
-        assert_eq!(change.old_refs[0].description, old_submitter_name);
-
-        assert_eq!(change.new_refs.len(), 1);
-        assert_eq!(change.new_refs[0].id_full, new_submitter_id.to_string());
-        assert_eq!(change.new_refs[0].description, new_submitter_name);
+        assert_eq!(
+            change,
+            &FieldChange::Entities {
+                field: "List submitter".to_owned(),
+                old_refs: vec![EntityRef {
+                    id_full: old_submitter_id.to_string(),
+                    description: old_submitter_name
+                }],
+                new_refs: vec![EntityRef {
+                    id_full: new_submitter_id.to_string(),
+                    description: new_submitter_name
+                }]
+            }
+        );
     }
 
     #[test]
@@ -559,27 +642,27 @@ mod tests {
         let candidate_changes: Vec<_> = detail
             .changes
             .iter()
-            .filter(|c| c.field.starts_with("Candidates #"))
+            .filter(|c| c.field().starts_with("Candidates #"))
             .collect();
 
         assert_eq!(candidate_changes.len(), 2);
 
         let pos_1 = candidate_changes
             .iter()
-            .find(|c| c.field == "Candidates #1")
+            .find(|c| c.field() == "Candidates #1")
             .expect("position #1 change");
-        assert_eq!(pos_1.old_refs[0].description, p1_name);
-        assert_eq!(pos_1.new_refs[0].description, p2_name);
+        assert_eq!(pos_1.old_refs()[0].description, p1_name);
+        assert_eq!(pos_1.new_refs()[0].description, p2_name);
 
         let pos_2 = candidate_changes
             .iter()
-            .find(|c| c.field == "Candidates #2")
+            .find(|c| c.field() == "Candidates #2")
             .expect("position #2 change");
-        assert_eq!(pos_2.old_refs[0].description, p2_name);
-        assert_eq!(pos_2.new_refs[0].description, p1_name);
+        assert_eq!(pos_2.old_refs()[0].description, p2_name);
+        assert_eq!(pos_2.new_refs()[0].description, p1_name);
 
         assert!(
-            !detail.changes.iter().any(|c| c.field == "Candidates #3"),
+            !detail.changes.iter().any(|c| c.field() == "Candidates #3"),
             "unchanged position should not appear"
         );
     }
@@ -603,10 +686,12 @@ mod tests {
         let change = detail
             .changes
             .iter()
-            .find(|c| c.field == "First name")
+            .find(|c| c.field() == "First name")
             .expect("first name change");
-        assert!(change.old_refs.is_empty());
-        assert!(change.new_refs.is_empty());
+        match change {
+            FieldChange::Regular { .. } => {}
+            FieldChange::Entities { .. } => panic!(),
+        }
     }
 
     #[test]
@@ -632,10 +717,10 @@ mod tests {
         let change = detail
             .changes
             .iter()
-            .find(|c| c.field == "Person ID")
+            .find(|c| c.field() == "Person ID")
             .expect("person_id change");
-        assert_eq!(change.old_refs.len(), 1);
-        assert_eq!(change.old_refs[0].description, person_name);
-        assert!(change.new_refs.is_empty());
+        assert_eq!(change.old_refs().len(), 1);
+        assert_eq!(change.old_refs()[0].description, person_name);
+        change.assert_no_new();
     }
 }

--- a/src/app/audit_log/structs/audit_log_entry.rs
+++ b/src/app/audit_log/structs/audit_log_entry.rs
@@ -3,9 +3,7 @@ use chrono::{DateTime, Utc};
 
 use crate::{AppEvent, Locale, audit_log::AuditLogDetailPath, store::StoreEvent};
 
-use super::event_info::{
-    abbreviate_str, event_description, event_details, subject_id_full, subject_path,
-};
+use super::event_info::{event_description, event_details, subject_id_full, subject_path};
 
 /// A single entry in the audit log, representing one application event.
 pub struct AuditLogEntry {
@@ -13,7 +11,6 @@ pub struct AuditLogEntry {
     pub event_type: &'static str,
     pub description: String,
     pub details: String,
-    pub subject_id: String,
     pub subject_id_full: String,
     pub subject_path: String,
     pub created_at: DateTime<Utc>,
@@ -27,7 +24,6 @@ impl AuditLogEntry {
             event_type: event.payload.event_category(),
             description: event_description(&event.payload, locale),
             details: event_details(&event.payload),
-            subject_id: abbreviate_str(&full_id),
             subject_id_full: full_id,
             subject_path: subject_path(&event.payload),
             created_at: event.created_at,
@@ -46,7 +42,6 @@ impl AuditLogEntry {
         let query = query.to_lowercase();
         self.details.to_lowercase().contains(&query)
             || self.subject_id_full.to_lowercase().contains(&query)
-            || self.subject_id.to_lowercase().contains(&query)
             || self.description.to_lowercase().contains(&query)
     }
 }
@@ -56,6 +51,7 @@ mod tests {
     use super::{super::event_info::DEFAULT_DETAILS, *};
     use crate::{
         Locale, StreamId,
+        audit_log::abbreviate_str,
         authorised_agents::AuthorisedAgentId,
         candidate_lists::CandidateListId,
         list_submitters::ListSubmitterId,
@@ -232,7 +228,7 @@ mod tests {
         let event = StoreEvent::new(1, AppEvent::CreatePerson(person));
         let entry = AuditLogEntry::new(event, EN);
 
-        assert!(entry.matches_search(&entry.subject_id));
+        assert!(entry.matches_search(&abbreviate_str(&entry.subject_id_full)));
         assert!(entry.matches_search(&entry.subject_id_full));
     }
 

--- a/src/app/audit_log/structs/entity_refs.rs
+++ b/src/app/audit_log/structs/entity_refs.rs
@@ -53,9 +53,8 @@ pub(super) fn build_ref_diffs_for_key(
     new_value: &str,
     state_after: &AppStoreData,
 ) -> Option<(Vec<EntityRef>, Vec<EntityRef>)> {
-    let Some(kind) = entity_kind_for_key(key) else {
-        return None;
-    };
+    let kind = entity_kind_for_key(key)?;
+
     let old_refs = old_value
         .split(", ")
         .filter(|s| !s.is_empty())

--- a/src/app/audit_log/structs/entity_refs.rs
+++ b/src/app/audit_log/structs/entity_refs.rs
@@ -7,13 +7,10 @@ use crate::{
     persons::PersonId,
 };
 
-use super::event_info::abbreviate_str;
-
 /// A reference to another entity mentioned inside a diff value. Rendered in
 /// the template as an abbreviated link + the entity's description.
 pub struct EntityRef {
     pub id_full: String,
-    pub id_abbreviated: String,
     pub description: String,
 }
 
@@ -60,7 +57,6 @@ pub(super) fn build_refs_for_key(key: &str, value: &str, state: &AppStoreData) -
         .filter(|s| !s.is_empty())
         .map(|id_str| EntityRef {
             id_full: id_str.to_string(),
-            id_abbreviated: abbreviate_str(id_str),
             description: describe_entity(&kind, id_str, state),
         })
         .collect()

--- a/src/app/audit_log/structs/entity_refs.rs
+++ b/src/app/audit_log/structs/entity_refs.rs
@@ -9,6 +9,7 @@ use crate::{
 
 /// A reference to another entity mentioned inside a diff value. Rendered in
 /// the template as an abbreviated link + the entity's description.
+#[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct EntityRef {
     pub id_full: String,
     pub description: String,
@@ -45,21 +46,33 @@ fn entity_kind_for_key(key: &str) -> Option<EntityKind> {
 /// Build `EntityRef`s for a diff cell value, if the key references known
 /// entities. The value may be a single UUID or a comma-separated list of
 /// UUIDs (from the scalar-array CSV collapsing performed in `flatten`).
-pub(super) fn build_refs_for_key(key: &str, value: &str, state: &AppStoreData) -> Vec<EntityRef> {
+pub(super) fn build_ref_diffs_for_key(
+    key: &str,
+    old_value: &str,
+    state_before: &AppStoreData,
+    new_value: &str,
+    state_after: &AppStoreData,
+) -> Option<(Vec<EntityRef>, Vec<EntityRef>)> {
     let Some(kind) = entity_kind_for_key(key) else {
-        return Vec::new();
+        return None;
     };
-    if value.is_empty() {
-        return Vec::new();
-    }
-    value
+    let old_refs = old_value
         .split(", ")
         .filter(|s| !s.is_empty())
         .map(|id_str| EntityRef {
             id_full: id_str.to_string(),
-            description: describe_entity(&kind, id_str, state),
+            description: describe_entity(&kind, id_str, state_before),
         })
-        .collect()
+        .collect();
+    let new_refs = new_value
+        .split(", ")
+        .filter(|s| !s.is_empty())
+        .map(|id_str| EntityRef {
+            id_full: id_str.to_string(),
+            description: describe_entity(&kind, id_str, state_after),
+        })
+        .collect();
+    Some((old_refs, new_refs))
 }
 
 fn describe_entity(kind: &EntityKind, id_str: &str, state: &AppStoreData) -> String {

--- a/src/app/audit_log/structs/event_info.rs
+++ b/src/app/audit_log/structs/event_info.rs
@@ -15,7 +15,7 @@ use crate::{
 pub(super) const DEFAULT_DETAILS: &str = "-";
 
 /// Abbreviate a string to its first 8 characters (used for UUID previews).
-pub(super) fn abbreviate_str(s: &str) -> String {
+pub fn abbreviate_str(s: &str) -> String {
     s[..8.min(s.len())].to_string()
 }
 

--- a/src/app/audit_log/structs/mod.rs
+++ b/src/app/audit_log/structs/mod.rs
@@ -5,6 +5,6 @@ mod event_info;
 mod event_payload;
 mod json_flatten;
 
-pub use audit_log_detail::AuditLogDetail;
+pub use audit_log_detail::{AuditLogDetail, FieldChange};
 pub use audit_log_entry::AuditLogEntry;
 pub use event_info::abbreviate_str;

--- a/src/app/audit_log/structs/mod.rs
+++ b/src/app/audit_log/structs/mod.rs
@@ -7,3 +7,4 @@ mod json_flatten;
 
 pub use audit_log_detail::AuditLogDetail;
 pub use audit_log_entry::AuditLogEntry;
+pub use event_info::abbreviate_str;

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -3,7 +3,7 @@
 use chrono::{DateTime, Utc};
 
 use crate::{
-    ElectionConfig, ElectoralDistrict, Locale,
+    ElectionConfig, ElectoralDistrict, Locale, audit_log,
     constants::DEFAULT_DATE_TIME_FORMAT,
     core::AnyLocale,
     form::{FormData, WithCsrfToken},
@@ -184,6 +184,11 @@ pub fn error<T: WithCsrfToken>(
     let locale: Locale = *askama::get_value(values, "locale")?;
 
     Ok(form.error(name, locale))
+}
+
+#[askama::filter_fn]
+pub fn abbreviate_str(s: &str, _: &dyn askama::Values) -> askama::Result<String> {
+    Ok(audit_log::abbreviate_str(s))
 }
 
 /// Returns a cache buster string based on the current git commit hash (set during build on github).


### PR DESCRIPTION
Closes #568

# [DOD](/docs/definition-of-done.md) checklist

Make FieldChange an enum between entity and non-entity

This way it is always clear whether to use the old/new_value or
old/new_refs. In addition it will allow us to stop constructing a string
for entity lists entirely in the future.

## For PR maintainer

Perform these checks before marking the PR as ready:

- [x] I have linked the PR to at least one issue.
- [x] I assigned the PR to myself.
- [x] I have added a description how to test this PR (see "Review Instructions").
- [x] I have added documentation where necessary.

## For reviewer

- I have read all code changes.
- I have audited the code quality.
- I have tested the changes either or both:
  - locally
  - on the test environment (preferred)
- I have validated that the PR is functionally correct (use-cases, figma designs, etc.)

### Review instructions

The audit log should have the same functionality
