### PR TITLE
[#475] Make displaying of add list submitter button condtional

### DIFF
--- a/src/app/audit_log/pages/detail.html
+++ b/src/app/audit_log/pages/detail.html
@@ -46,38 +46,37 @@
             <tr class="{{ change.change_kind() }}">
               {% match change %}
               {% when FieldChange::Regular with { field, old_value, new_value } %}
-                <td>{{ field }}</td>
-                <td>{{ old_value }}</td>
-                <td>{{ new_value }}</td>
-
+              <td>{{ field }}</td>
+              <td>{{ old_value }}</td>
+              <td>{{ new_value }}</td>
               {% when FieldChange::Entities with { field, old_refs, new_refs } %}
-                <td>{{ field }}</td>
-                <td>
-                  {% for entity_ref in old_refs %}
-                    <div class="entity-ref">
-                      <a href="/audit-log?search={{ entity_ref.id_full }}">
-                        <abbr title="{{ entity_ref.id_full }}">{{ entity_ref.id_full|abbreviate_str }}</abbr>
-                      </a>
-                      {% if !entity_ref.description.is_empty() %}<span>{{ entity_ref.description }}</span>{% endif %}
-                    </div>
-                  {% endfor %}
-                </td>
-                <td>
-                  {% for entity_ref in new_refs %}
-                    <div class="entity-ref">
-                      <a href="/audit-log?search={{ entity_ref.id_full }}">
-                        <abbr title="{{ entity_ref.id_full }}">{{ entity_ref.id_full|abbreviate_str }}</abbr>
-                      </a>
-                      {% if !entity_ref.description.is_empty() %}<span>{{ entity_ref.description }}</span>{% endif %}
-                    </div>
-                  {% endfor %}
-                </td>
-              {% endmatch %}
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    {% endif %}
-  </div>
+              <td>{{ field }}</td>
+              <td>
+                {% for entity_ref in old_refs %}
+                  <div class="entity-ref">
+                    <a href="/audit-log?search={{ entity_ref.id_full }}">
+                      <abbr title="{{ entity_ref.id_full }}">{{ entity_ref.id_full|abbreviate_str }}</abbr>
+                    </a>
+                    {% if !entity_ref.description.is_empty() %}<span>{{ entity_ref.description }}</span>{% endif %}
+                  </div>
+                {% endfor %}
+              </td>
+              <td>
+                {% for entity_ref in new_refs %}
+                  <div class="entity-ref">
+                    <a href="/audit-log?search={{ entity_ref.id_full }}">
+                      <abbr title="{{ entity_ref.id_full }}">{{ entity_ref.id_full|abbreviate_str }}</abbr>
+                    </a>
+                    {% if !entity_ref.description.is_empty() %}<span>{{ entity_ref.description }}</span>{% endif %}
+                  </div>
+                {% endfor %}
+              </td>
+            {% endmatch %}
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% endif %}
+</div>
 {% endblock %}
 {% block overlay_actions %}{% endblock %}

--- a/src/app/list_submitters/pages/view.html
+++ b/src/app/list_submitters/pages/view.html
@@ -23,12 +23,17 @@
           {% endfor %}
         </div>
       {% endif %}
-      <p class="mt-lg">
-        <a href="{{ ListSubmitter::create_path() }}"
-           class="button secondary icon-plus"
-           type="button">{{ "political_group.add_list_submitter"|trans }}</a>
-      </p>
-      <div class="alert alert-info">{{ "political_group.multiple_submitter_info"|trans }}</div>
+      {% let election = "election"|election_value %}
+      {% if !election.has_only_one_district() || list_submitters.len() == 0 %}
+        <p class="mt-lg">
+          <a href="{{ ListSubmitter::create_path() }}"
+             class="button secondary icon-plus"
+             type="button">{{ "political_group.add_list_submitter"|trans }}</a>
+        </p>
+      {% endif %}
+      {% if !election.has_only_one_district() %}
+        <div class="alert alert-info">{{ "political_group.multiple_submitter_info"|trans }}</div>
+      {% endif %}
       <h2 class="mt-lg">{{ "political_group.substitute_submitter_data"|trans }}</h2>
       <p class="info">{{ "political_group.substitute_submitters_info"|trans }}</p>
       {% if substitute_submitters.is_empty() %}


### PR DESCRIPTION
Closes #475

# [DOD](/docs/definition-of-done.md) checklist

## For PR maintainer

Perform these checks before marking the PR as ready:

- [x] I have linked the PR to at least one issue.
- [x] I assigned the PR to myself.
- [x] I have added a description how to test this PR (see "Review Instructions").
- [x] ~~[For bug fixes only] I have added a regression test for the fixed bug.~~
- [x] I have added documentation where necessary.

## For reviewer

- I have read all code changes.
- I have audited the code quality.
- I have tested the changes either or both:
  - locally
  - on the test environment (preferred)
- I have validated that the PR is functionally correct (use-cases, figma designs, etc.)

### Review instructions

- load EK27 and add multiple list submitters
- load WS27(_) and add a list submitter
- observe that:
  - in WS27, there is no info box with multiple list submitter explanation
  - the "add list submitter" button disappears after adding a single list submitter
