### PR TITLE
[#323] Add UTC time indication in UI for clarity

### DIFF
--- a/src/app/audit_log/pages/detail.html
+++ b/src/app/audit_log/pages/detail.html
@@ -11,7 +11,7 @@
       </dd>
       <dt>{{ "audit_log.fields.timestamp"|trans }}</dt>
       <dd>
-        {{ detail.created_at|datetime_seconds }}
+        {{ detail.created_at|datetime_seconds }} (UTC)
       </dd>
       {% if !detail.details.is_empty() %}
         <dt>{{ "audit_log.fields.details"|trans }}</dt>

--- a/src/app/audit_log/pages/list.html
+++ b/src/app/audit_log/pages/list.html
@@ -43,7 +43,7 @@
         <thead>
           <tr>
             <th scope="col">{{ "audit_log.fields.event_id"|trans }}</th>
-            <th scope="col">{{ "audit_log.fields.timestamp"|trans }}</th>
+            <th scope="col">{{ "audit_log.fields.timestamp"|trans }} (UTC)</th>
             <th scope="col">{{ "audit_log.fields.event"|trans }}</th>
             <th scope="col">{{ "audit_log.fields.details"|trans }}</th>
             <th scope="col">{{ "audit_log.fields.subject_id"|trans }}</th>

--- a/src/app/persons/components/person_table.html
+++ b/src/app/persons/components/person_table.html
@@ -34,7 +34,7 @@
       </th>
       <th scope="col">
         <a href="{{ pagination.sort_link(PersonSort::UpdatedAt) }}">
-          {{ "person.fields.updated_at"|trans }}
+          {{ "person.fields.updated_at"|trans }} (UTC)
           {{ pagination.dir_icon(PersonSort::UpdatedAt) }}
         </a>
       </th>


### PR DESCRIPTION
Closes #323

# [DOD](/docs/definition-of-done.md) checklist

## For PR maintainer

Perform these checks before marking the PR as ready:

- [x] I have linked the PR to at least one issue.
- [x] I assigned the PR to myself.
- [x] I have added a description how to test this PR (see "Review Instructions").
- [x] ~~[For bug fixes only] I have added a regression test for the fixed bug.~~
- [x] I have added documentation where necessary.

## For reviewer

- I have read all code changes.
- I have audited the code quality.
- I have tested the changes either or both:
  - locally
  - on the test environment (preferred)
- I have validated that the PR is functionally correct (use-cases, figma designs, etc.)

### Review instructions

Check out the different spots that display date times.

**N.B.** I opted to not add the UTC indication to the datetime filters but to display it in the templates themselves. I chose this solution because in table views adding "(UTC)" in every entry of a column looked a bit cluttered to me.