### PR TITLE
[#625] Order substitute submitters

### DIFF
--- a/src/app/audit_log/structs/event_payload.rs
+++ b/src/app/audit_log/structs/event_payload.rs
@@ -21,6 +21,20 @@ pub(super) fn extract_old_new(
             (old, new)
         }};
 
+        (Vec, $kind:ident, $id:expr) => {{
+            let old = state_before
+                .$kind
+                .iter()
+                .find(|data| data.id == $id)
+                .and_then(|data| serde_json::to_value(data).ok());
+            let new = state_after
+                .$kind
+                .iter()
+                .find(|data| data.id == $id)
+                .and_then(|data| serde_json::to_value(data).ok());
+            (old, new)
+        }};
+
         ($kind:ident, $id:expr) => {{
             let old = state_before
                 .$kind
@@ -49,12 +63,12 @@ pub(super) fn extract_old_new(
         AppEvent::CreatePersonPersonalData { person_id, .. } => update!(persons, person_id),
         AppEvent::CreateCandidateList(cl) => update!(candidate_lists, cl.id),
         AppEvent::CreateAuthorisedAgent(aa) => update!(authorised_agents, aa.id),
-        AppEvent::CreateSubstituteSubmitter(ss) => update!(substitute_submitters, ss.id),
+        AppEvent::CreateSubstituteSubmitter(ss) => update!(Vec, substitute_submitters, ss.id),
 
         AppEvent::UpdatePerson(person) => update!(persons, person.id),
         AppEvent::UpdateAuthorisedAgent(aa) => update!(authorised_agents, aa.id),
         AppEvent::UpdateListSubmitter(_) => update!(list_submitter),
-        AppEvent::UpdateSubstituteSubmitter(ss) => update!(substitute_submitters, ss.id),
+        AppEvent::UpdateSubstituteSubmitter(ss) => update!(Vec, substitute_submitters, ss.id),
         AppEvent::UpdatePoliticalGroup(_) => update!(political_group),
 
         AppEvent::UpdatePersonPersonalData { person_id, .. }
@@ -79,7 +93,7 @@ pub(super) fn extract_old_new(
         AppEvent::DeleteAuthorisedAgent(aa_id) => update!(authorised_agents, aa_id),
         AppEvent::DeleteSubstituteSubmitter {
             substitute_submitter_id: ss_id,
-        } => update!(substitute_submitters, ss_id),
+        } => update!(Vec, substitute_submitters, *ss_id),
 
         AppEvent::DeveloperLogin { stream_id } => event!({ stream_id: stream_id.to_string() }),
         AppEvent::DownloadFile {
@@ -163,9 +177,7 @@ mod tests {
         let submitter = sample_list_submitter(ListSubmitterId::new());
         let before = empty_state();
         let mut after = empty_state();
-        after
-            .substitute_submitters
-            .insert(submitter.id, submitter.clone());
+        after.substitute_submitters.push(submitter.clone());
 
         let (old, new) = extract_old_new(
             &AppEvent::CreateSubstituteSubmitter(submitter.clone()),

--- a/src/app/getters.rs
+++ b/src/app/getters.rs
@@ -132,3 +132,23 @@ impl AppStore {
         data.events.clone()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{AppStore, list_submitters::ListSubmitterId, test_utils::sample_list_submitter};
+
+    #[tokio::test]
+    async fn substitute_submitters_remain_in_order() {
+        let store = AppStore::new_for_test();
+
+        for i in 0..100 {
+            let mut sub_submitter = sample_list_submitter(ListSubmitterId::new());
+            sub_submitter.name.last_name = i.to_string().parse().unwrap();
+            sub_submitter.create_substitute(&store).await.unwrap();
+        }
+
+        for (i, s) in store.get_substitute_submitters().iter().enumerate() {
+            assert_eq!(s.name.last_name.to_string(), i.to_string());
+        }
+    }
+}

--- a/src/app/getters.rs
+++ b/src/app/getters.rs
@@ -55,7 +55,7 @@ impl AppStore {
     pub fn get_substitute_submitters(&self) -> Vec<ListSubmitter> {
         let data = self.data.read();
 
-        data.substitute_submitters.values().cloned().collect()
+        data.substitute_submitters.clone()
     }
 
     pub fn get_person_count(&self) -> usize {
@@ -112,7 +112,11 @@ impl AppStore {
     ) -> Result<ListSubmitter, AppError> {
         let data = self.data.read();
 
-        match data.substitute_submitters.get(&substitute_submitter_id) {
+        match data
+            .substitute_submitters
+            .iter()
+            .find(|submitter| submitter.id == substitute_submitter_id)
+        {
             Some(submitter) => Ok(submitter.clone()),
             None => Err(AppError::GenericNotFound),
         }

--- a/src/app/store.rs
+++ b/src/app/store.rs
@@ -6,7 +6,7 @@ use crate::{
     authorised_agents::{AuthorisedAgent, AuthorisedAgentId},
     candidate_lists::{CandidateList, CandidateListId},
     common::UtcDateTime,
-    list_submitters::{ListSubmitter, ListSubmitterId},
+    list_submitters::ListSubmitter,
     persons::{Person, PersonId},
     political_groups::PoliticalGroup,
     store::{StoreData, StoreEvent},
@@ -20,7 +20,7 @@ pub struct AppStoreData {
     pub(crate) candidate_lists: HashMap<CandidateListId, CandidateList>,
     pub(crate) authorised_agents: HashMap<AuthorisedAgentId, AuthorisedAgent>,
     pub(crate) list_submitter: ListSubmitter,
-    pub(crate) substitute_submitters: HashMap<ListSubmitterId, ListSubmitter>,
+    pub(crate) substitute_submitters: Vec<ListSubmitter>,
 
     // Download path, file name, downloader id
     pub(crate) downloaded_files: Vec<(String, String, CandidateListId)>,
@@ -153,20 +153,23 @@ impl StoreData for AppStoreData {
                 self.list_submitter = ls;
             }
             AppEvent::CreateSubstituteSubmitter(ss) => {
-                self.substitute_submitters.insert(ss.id, ss);
+                self.substitute_submitters.push(ss);
             }
             AppEvent::UpdateSubstituteSubmitter(ss) => {
                 let ss_id = ss.id;
-                self.substitute_submitters
-                    .entry(ss_id)
-                    .and_modify(|existing| {
-                        *existing = ss;
-                    });
+                if let Some(existing) = self
+                    .substitute_submitters
+                    .iter_mut()
+                    .find(|existing| existing.id == ss_id)
+                {
+                    *existing = ss;
+                }
             }
             AppEvent::DeleteSubstituteSubmitter {
                 substitute_submitter_id: ss_id,
             } => {
-                self.substitute_submitters.remove(&ss_id);
+                self.substitute_submitters
+                    .retain(|submitter| submitter.id != ss_id);
             }
 
             AppEvent::DeveloperLogin { .. }


### PR DESCRIPTION
Closes #625

# [DOD](/docs/definition-of-done.md) checklist

## For PR maintainer

Perform these checks before marking the PR as ready:

- [x] I have linked the PR to at least one issue.
- [x] I assigned the PR to myself.
- [x] I have added a description how to test this PR (see "Review Instructions").
- [x] [For bug fixes only] I have added a regression test for the fixed bug.
- [x] I have added documentation where necessary.

## For reviewer

- I have read all code changes.
- I have audited the code quality.
- I have tested the changes either or both:
  - locally
  - on the test environment (preferred)
- I have validated that the PR is functionally correct (use-cases, figma designs, etc.)

### Review instructions

Exporting the H1 with multiple substitute submitters should always be in order of creation.