### PR TITLE
[#649] Horizontal scaling and CDN features

### DIFF
--- a/src/app/candidate_lists/extractors/candidate_list.rs
+++ b/src/app/candidate_lists/extractors/candidate_list.rs
@@ -1,14 +1,10 @@
 use axum::extract::{FromRequestParts, Path};
 
-use crate::{AppError, AppStore, Context, candidate_lists::CandidateList, trans};
+use crate::{AppError, AppRequestState, AppStore, Context, candidate_lists::CandidateList, trans};
 
 use super::CandidateListPathParams;
 
-impl<S> FromRequestParts<S> for CandidateList
-where
-    S: Clone + Send + Sync + 'static,
-    AppStore: FromRequestParts<S, Rejection = AppError>,
-{
+impl<S: AppRequestState> FromRequestParts<S> for CandidateList {
     type Rejection = AppError;
 
     async fn from_request_parts(

--- a/src/app/candidate_lists/extractors/full_candidate_list.rs
+++ b/src/app/candidate_lists/extractors/full_candidate_list.rs
@@ -1,14 +1,12 @@
 use axum::extract::{FromRequestParts, Path};
 
-use crate::{AppError, AppStore, Context, candidate_lists::FullCandidateList, trans};
+use crate::{
+    AppError, AppRequestState, AppStore, Context, candidate_lists::FullCandidateList, trans,
+};
 
 use super::CandidateListPathParams;
 
-impl<S> FromRequestParts<S> for FullCandidateList
-where
-    S: Clone + Send + Sync + 'static,
-    AppStore: FromRequestParts<S, Rejection = AppError>,
-{
+impl<S: AppRequestState> FromRequestParts<S> for FullCandidateList {
     type Rejection = AppError;
 
     async fn from_request_parts(

--- a/src/app/candidates/extractors/candidate.rs
+++ b/src/app/candidates/extractors/candidate.rs
@@ -1,14 +1,10 @@
 use axum::extract::{FromRequestParts, Path};
 
-use crate::{AppError, AppStore, Context, candidates::Candidate, trans};
+use crate::{AppError, AppRequestState, AppStore, Context, candidates::Candidate, trans};
 
 use super::CandidateListAndPersonPathParams;
 
-impl<S> FromRequestParts<S> for Candidate
-where
-    S: Clone + Send + Sync + 'static,
-    AppStore: FromRequestParts<S, Rejection = AppError>,
-{
+impl<S: AppRequestState> FromRequestParts<S> for Candidate {
     type Rejection = AppError;
 
     async fn from_request_parts(

--- a/src/app/common/components/layout.html
+++ b/src/app/common/components/layout.html
@@ -63,7 +63,10 @@
   </main>
   <footer>
     <span>{{ "common.title"|trans }}</span>
-    <span>{{ "common.version"|trans }} <strong>{{ env!("CARGO_PKG_VERSION") }}</strong></span>
+    <span>
+      {{ "common.version"|trans }} <strong>{{ env!("CARGO_PKG_VERSION") }}</strong>
+      {% if let Some(server) = "server_name"|optional_str_value %}· <strong>{{ server }}</strong>{% endif %}
+    </span>
   </footer>
   {% block overlay %}{% endblock %}
   {% if "show_success_alert"|value_true %}

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -4,8 +4,7 @@
 use axum::{extract::FromRequestParts, http::request::Parts};
 
 use crate::{
-    AppError, AppRequestState, AppStore, ElectionConfig, Session,
-    political_groups::PoliticalGroup,
+    AppError, AppRequestState, AppStore, ElectionConfig, Session, political_groups::PoliticalGroup,
 };
 
 #[cfg(test)]

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -3,7 +3,10 @@
 
 use axum::{extract::FromRequestParts, http::request::Parts};
 
-use crate::{AppError, AppStore, ElectionConfig, Session, political_groups::PoliticalGroup};
+use crate::{
+    AppError, AppRequestState, AppStore, ElectionConfig, Session,
+    political_groups::PoliticalGroup,
+};
 
 #[cfg(test)]
 use crate::Locale;
@@ -25,6 +28,9 @@ pub struct Context {
     pub overlay_referrer: bool,
     /// Session data for locale and CSRF.
     pub session: Session,
+    /// Short identifier of the server this instance runs on (e.g. "S1"),
+    /// rendered next to the version in the layout footer when set.
+    pub server_name: Option<&'static str>,
 }
 
 impl Context {
@@ -42,6 +48,7 @@ impl Context {
             show_success_alert: false,
             overlay_referrer: false,
             session,
+            server_name: None,
         }
     }
 
@@ -68,21 +75,21 @@ impl askama::Values for Context {
                 Some(&self.multiple_candidate_lists as &dyn std::any::Any)
             }
             "overlay_referrer" => Some(&self.overlay_referrer as &dyn std::any::Any),
+            "server_name" => Some(&self.server_name as &dyn std::any::Any),
             _ => None,
         }
     }
 }
 
-impl<S> FromRequestParts<S> for Context
-where
-    S: Clone + Send + Sync + 'static,
-{
+impl<S: AppRequestState> FromRequestParts<S> for Context {
     type Rejection = AppError;
 
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         let session = Session::from_request_parts(parts, state).await?;
         let store = AppStore::from_request_parts(parts, state).await?;
         let mut context = Context::new(&store, session);
+
+        context.server_name = state.config().server_name.as_deref();
 
         context.show_success_alert = parts
             .uri

--- a/src/auth/session_extractor.rs
+++ b/src/auth/session_extractor.rs
@@ -79,6 +79,11 @@ pub async fn store_middleware(
         Err(err) => return err.into_response(),
     };
 
+    // catch up with the latest events
+    if let Err(err) = store.load().await {
+        return err.into_response();
+    }
+
     request.extensions_mut().insert(store);
 
     next.run(request).await

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -53,7 +53,7 @@ pub struct TlsConfig {
 /// Runtime configuration loaded from environment variables.
 #[derive(Debug, Clone)]
 pub struct Config {
-    pub storage_url: String,
+    pub storage_url: SecretString,
     #[cfg(not(feature = "embed-typst"))]
     pub typst_url: String,
     pub id_derivation_key: SecretString,
@@ -62,6 +62,10 @@ pub struct Config {
     /// Short identifier of the server this instance runs on (e.g. "S1"),
     /// rendered next to the version in the layout footer.
     pub server_name: Option<String>,
+    /// When set, every request must carry an `x-eks-key` header whose value
+    /// matches this secret. Intended for gating the app behind a known
+    /// upstream (e.g. a load balancer that injects the header).
+    pub eks_key: Option<SecretString>,
 }
 
 /// Helper function to get environment variable or return an error
@@ -113,27 +117,34 @@ impl Config {
 
         let server_name = lookup("SERVER_NAME").ok().filter(|s| !s.is_empty());
 
+        let eks_key = lookup("EKS_KEY")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .map(SecretString::from);
+
         Ok(Self {
-            storage_url,
+            storage_url: SecretString::from(storage_url),
             #[cfg(not(feature = "embed-typst"))]
             typst_url,
             id_derivation_key: SecretString::from(id_derivation_key),
             encryption_derivation_key: SecretString::from(encryption_derivation_key),
             tls,
             server_name,
+            eks_key,
         })
     }
 
     #[cfg(test)]
     pub fn new_test() -> Self {
         Self {
-            storage_url: "memory://".to_string(),
+            storage_url: SecretString::from("memory://"),
             #[cfg(not(feature = "embed-typst"))]
             typst_url: "http://localhost:8080".to_string(),
             id_derivation_key: SecretString::from("test-secret-123"),
             encryption_derivation_key: SecretString::from("test-encryption-secret-123"),
             tls: None,
             server_name: None,
+            eks_key: None,
         }
     }
 }
@@ -141,6 +152,7 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use secrecy::ExposeSecret;
     use std::collections::HashMap;
 
     fn lookup_from(
@@ -175,7 +187,7 @@ mod tests {
 
         let config = Config::from_env_with(lookup).expect("config");
 
-        assert_eq!(config.storage_url, "memory://test");
+        assert_eq!(config.storage_url.expose_secret(), "memory://test");
         assert_eq!(config.typst_url, "http://typst.test");
     }
 
@@ -190,7 +202,7 @@ mod tests {
 
         let config = Config::from_env_with(lookup).expect("config");
 
-        assert_eq!(config.storage_url, "memory://test");
+        assert_eq!(config.storage_url.expose_secret(), "memory://test");
     }
 
     #[cfg(feature = "dev-features")]
@@ -226,7 +238,10 @@ mod tests {
 
         let config = Config::from_env_with(lookup).expect("dev defaults");
 
-        assert_eq!(config.storage_url, dev_defaults::STORAGE_URL);
+        assert_eq!(
+            config.storage_url.expose_secret(),
+            dev_defaults::STORAGE_URL
+        );
         assert_eq!(config.typst_url, dev_defaults::TYPST_URL);
     }
 
@@ -238,7 +253,10 @@ mod tests {
 
         let config = Config::from_env_with(lookup).expect("dev defaults");
 
-        assert_eq!(config.storage_url, dev_defaults::STORAGE_URL);
+        assert_eq!(
+            config.storage_url.expose_secret(),
+            dev_defaults::STORAGE_URL
+        );
     }
 
     #[cfg(not(feature = "dev-features"))]

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -59,6 +59,9 @@ pub struct Config {
     pub id_derivation_key: SecretString,
     pub encryption_derivation_key: SecretString,
     pub tls: Option<TlsConfig>,
+    /// Short identifier of the server this instance runs on (e.g. "S1"),
+    /// rendered next to the version in the layout footer.
+    pub server_name: Option<String>,
 }
 
 /// Helper function to get environment variable or return an error
@@ -108,6 +111,8 @@ impl Config {
             }
         };
 
+        let server_name = lookup("SERVER_NAME").ok().filter(|s| !s.is_empty());
+
         Ok(Self {
             storage_url,
             #[cfg(not(feature = "embed-typst"))]
@@ -115,6 +120,7 @@ impl Config {
             id_derivation_key: SecretString::from(id_derivation_key),
             encryption_derivation_key: SecretString::from(encryption_derivation_key),
             tls,
+            server_name,
         })
     }
 
@@ -127,6 +133,7 @@ impl Config {
             id_derivation_key: SecretString::from("test-secret-123"),
             encryption_derivation_key: SecretString::from("test-encryption-secret-123"),
             tls: None,
+            server_name: None,
         }
     }
 }

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -62,6 +62,16 @@ pub fn integer_value(value_name: &str, values: &dyn askama::Values) -> askama::R
 }
 
 #[askama::filter_fn]
+pub fn optional_str_value(
+    value_name: &str,
+    values: &dyn askama::Values,
+) -> askama::Result<Option<&'static str>> {
+    let value = askama::get_value::<Option<&'static str>>(values, value_name)?;
+
+    Ok(*value)
+}
+
+#[askama::filter_fn]
 pub fn initials_as_printed_on_list(
     value: &Person,
     values: &dyn askama::Values,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ pub use core::{
 };
 pub use error::{AppError, AppResponse, ErrorResponse, render_error_pages};
 pub use form::{Form, TokenValue};
-pub use state::AppState;
+pub use state::{AppRequestState, AppState};
 pub use utils::{
     OptionAsStrExt, OptionStringExt, QueryParamState, id_newtype, redirect_success,
     transparent_string,

--- a/src/router.rs
+++ b/src/router.rs
@@ -90,6 +90,8 @@ pub fn create(state: AppState) -> Router<AppState> {
 
     let router = router.merge(auth_service::router());
 
+    let router = router.merge(crate::utils::health::health_router());
+
     let router = router
         .layer(SetResponseHeaderLayer::if_not_present(
             header::CONTENT_SECURITY_POLICY,
@@ -144,7 +146,10 @@ pub fn create(state: AppState) -> Router<AppState> {
         )),
     );
 
-    router
+    router.layer(middleware::from_fn_with_state(
+        state.clone(),
+        crate::utils::eks_key::eks_key_middleware,
+    ))
 }
 
 #[cfg(test)]

--- a/src/state.rs
+++ b/src/state.rs
@@ -29,6 +29,20 @@ pub struct AppState {
     pub typst_renderer: TypstRenderer,
 }
 
+/// Contract the application's request extractors expect from the router
+/// state. The supertrait bounds (`Send + Sync`) cover what `AppStore`'s
+/// extractor needs; `config()` replaces ad-hoc `FromRef` lookups so each
+/// extractor only has to write `S: AppRequestState`.
+pub trait AppRequestState: Clone + Send + Sync + 'static {
+    fn config(&self) -> &'static Config;
+}
+
+impl AppRequestState for AppState {
+    fn config(&self) -> &'static Config {
+        self.config
+    }
+}
+
 impl AppState {
     pub async fn new() -> Result<Self, AppError> {
         let config = Config::from_env()?;

--- a/src/state.rs
+++ b/src/state.rs
@@ -8,6 +8,7 @@ use axum::{
     response::{IntoResponse, Redirect, Response},
 };
 use axum_extra::extract::{CookieJar, cookie::Cookie};
+use secrecy::ExposeSecret;
 
 use crate::{
     AppError, AppStore, AppStoreData, Config, ElectionConfig, IdDeriver, Session, SessionStore,
@@ -52,8 +53,9 @@ impl AppState {
 
     pub async fn new_with_config(config: Config) -> Result<Self, AppError> {
         let encryption = EventEncryption::new(&config.encryption_derivation_key);
-        let store_registry = StoreRegistry::new(config.storage_url.to_string(), encryption).await?;
-        let sessions = SessionStore::from_storage_url(&config.storage_url)?;
+        let store_registry =
+            StoreRegistry::new(config.storage_url.expose_secret().to_string(), encryption).await?;
+        let sessions = SessionStore::from_storage_url(config.storage_url.expose_secret())?;
         let id_deriver = IdDeriver::new(&config.id_derivation_key);
         let typst_renderer = build_typst_renderer(&config);
 
@@ -129,14 +131,17 @@ impl AppState {
         let config = Config::new_test();
         let id_deriver = IdDeriver::new(&config.id_derivation_key);
         let encryption = EventEncryption::new(&config.encryption_derivation_key);
-        let sessions = SessionStore::from_storage_url(&config.storage_url)
+        let sessions = SessionStore::from_storage_url(config.storage_url.expose_secret())
             .expect("test SessionStore must initialize");
         let typst_renderer = build_typst_renderer(&config);
 
         Self {
-            store_registry: StoreRegistry::new(config.storage_url.to_string(), encryption)
-                .await
-                .expect("test StoreRegistry must initialize"),
+            store_registry: StoreRegistry::new(
+                config.storage_url.expose_secret().to_string(),
+                encryption,
+            )
+            .await
+            .expect("test StoreRegistry must initialize"),
             config: Box::leak(Box::new(config)),
             sessions,
             id_deriver,
@@ -210,7 +215,10 @@ mod tests {
         let state = AppState::new_for_tests().await;
         let config = Config::new_test();
 
-        assert_eq!(state.config.storage_url, config.storage_url);
+        assert_eq!(
+            state.config.storage_url.expose_secret(),
+            config.storage_url.expose_secret()
+        );
 
         Ok(())
     }

--- a/src/store/database.rs
+++ b/src/store/database.rs
@@ -28,28 +28,20 @@ impl<'r> sqlx::FromRow<'r, sqlx::postgres::PgRow> for StoreEvent<Vec<u8>> {
 /// Initialize the database schema for event and session persistence.
 #[cfg(feature = "migrations")]
 pub async fn migrate(pool: &sqlx::PgPool) -> Result<(), AppError> {
-    const MIGRATION_LOCK_KEY: i64 = 0x454B53544F52454E; // "EKSTOREN" advisory lock key
-
     let mut conn = pool.acquire().await?;
-    sqlx::query("SELECT pg_advisory_lock($1)")
-        .bind(MIGRATION_LOCK_KEY)
-        .execute(&mut *conn)
-        .await?;
 
-    let result = async {
+    if let Err(error) = async {
         create_streams_table(&mut conn).await?;
         create_events_table(&mut conn).await?;
         create_sessions_table(&mut conn).await?;
         Ok::<(), AppError>(())
     }
-    .await;
+    .await
+    {
+        tracing::warn!("Database migration failed, there might me a concurrent migration: {error}");
+    }
 
-    let _ = sqlx::query("SELECT pg_advisory_unlock($1)")
-        .bind(MIGRATION_LOCK_KEY)
-        .execute(&mut *conn)
-        .await;
-
-    result
+    Ok(())
 }
 
 #[cfg(feature = "migrations")]

--- a/src/store/persistence.rs
+++ b/src/store/persistence.rs
@@ -136,6 +136,31 @@ impl StorePersistence {
             StorePersistence::None => Ok(Vec::new()),
         }
     }
+
+    /// Verify the persistence backend is reachable. For the database backend
+    /// this acquires a connection and runs `SELECT 1`; for the local backend
+    /// it checks the storage directory still exists; the in-memory backend is
+    /// always reachable.
+    pub async fn health_check(&self) -> Result<(), AppError> {
+        match self {
+            #[cfg(feature = "database")]
+            StorePersistence::Database(pool) => {
+                sqlx::query("SELECT 1").execute(pool).await?;
+                Ok(())
+            }
+            StorePersistence::Local(dir) => {
+                if dir.is_dir() {
+                    Ok(())
+                } else {
+                    Err(AppError::ConfigLoadError(format!(
+                        "Local storage directory missing: {}",
+                        dir.display()
+                    )))
+                }
+            }
+            StorePersistence::None => Ok(()),
+        }
+    }
 }
 
 impl<D> Store<D>

--- a/src/utils/eks_key.rs
+++ b/src/utils/eks_key.rs
@@ -1,0 +1,160 @@
+//! Optional shared-secret gate. When `Config::eks_key` is set, every request
+//! must carry a matching `x-eks-key` header or it is rejected with 401.
+
+use axum::{
+    extract::{Request, State},
+    http::StatusCode,
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use secrecy::ExposeSecret;
+use sha2::{Digest, Sha256};
+
+use crate::AppState;
+
+pub const EKS_KEY_HEADER: &str = "x-eks-key";
+
+pub async fn eks_key_middleware(
+    State(state): State<AppState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let Some(expected) = state.config.eks_key.as_ref() else {
+        return next.run(request).await;
+    };
+
+    let provided = request
+        .headers()
+        .get(EKS_KEY_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("");
+
+    if keys_match(provided, expected.expose_secret()) {
+        next.run(request).await
+    } else {
+        StatusCode::UNAUTHORIZED.into_response()
+    }
+}
+
+/// Compare two secrets in a bit more constant time. Both inputs are first hashed with
+/// SHA-256 so the comparison always runs over fixed-length 32-byte digests,
+/// avoiding any length-based early exit.
+/// Note that this is not a perfect constant-time comparison, but it should be good enough to prevent trivial timing attacks in this context.
+fn keys_match(provided: &str, expected: &str) -> bool {
+    let provided_hash = Sha256::digest(provided.as_bytes());
+    let expected_hash = Sha256::digest(expected.as_bytes());
+
+    let mut diff = 0u8;
+    for (p, e) in provided_hash.iter().zip(expected_hash.iter()) {
+        diff |= p ^ e;
+    }
+
+    // black_box discourages the optimizer from short-circuiting the check.
+    std::hint::black_box(diff) == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{Router, body::Body, http::Request, middleware, routing::get};
+    use secrecy::SecretString;
+    use tower::ServiceExt;
+
+    use crate::{AppState, Config};
+
+    async fn app_with_key(eks_key: Option<&str>) -> Router {
+        let mut config = Config::new_test();
+        config.eks_key = eks_key.map(SecretString::from);
+        let state = AppState::new_with_config(config)
+            .await
+            .expect("state from config");
+
+        Router::new()
+            .route("/probe", get(|| async { "ok" }))
+            .layer(middleware::from_fn_with_state(
+                state.clone(),
+                eks_key_middleware,
+            ))
+            .with_state(state)
+    }
+
+    #[tokio::test]
+    async fn passes_through_when_unset() {
+        let app = app_with_key(None).await;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/probe")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn rejects_missing_header_when_set() {
+        let app = app_with_key(Some("s3cret")).await;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/probe")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn rejects_wrong_header_when_set() {
+        let app = app_with_key(Some("s3cret")).await;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/probe")
+                    .header(EKS_KEY_HEADER, "nope")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn keys_match_handles_equal_and_unequal_lengths() {
+        assert!(keys_match("s3cret", "s3cret"));
+        assert!(!keys_match("s3cret", "s3cre"));
+        assert!(!keys_match("s3cret", "s3crets"));
+        assert!(!keys_match("", "s3cret"));
+        assert!(!keys_match("s3cret", ""));
+        assert!(keys_match("", ""));
+    }
+
+    #[tokio::test]
+    async fn accepts_matching_header_when_set() {
+        let app = app_with_key(Some("s3cret")).await;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/probe")
+                    .header(EKS_KEY_HEADER, "s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+}

--- a/src/utils/health.rs
+++ b/src/utils/health.rs
@@ -1,0 +1,52 @@
+//! Health check endpoint reporting whether the app can reach its persistence
+//! backend (typically the configured database).
+
+use axum::{Router, extract::State, http::StatusCode, response::IntoResponse, routing::get};
+
+use crate::AppState;
+
+pub fn health_router() -> Router<AppState> {
+    Router::new().route("/health", get(health_handler))
+}
+
+async fn health_handler(State(state): State<AppState>) -> impl IntoResponse {
+    match state.store_registry.persistence().health_check().await {
+        Ok(()) => (StatusCode::OK, "healthy"),
+        Err(err) => {
+            tracing::warn!("health check failed: {err}");
+            (StatusCode::SERVICE_UNAVAILABLE, "unhealthy")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tower::ServiceExt;
+
+    use crate::{AppState, test_utils::response_body_string};
+
+    #[tokio::test]
+    async fn health_returns_ok_for_reachable_backend() {
+        let state = AppState::new_for_tests().await;
+        let app: Router = health_router().with_state(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_body_string(response).await;
+        assert_eq!(body, "healthy");
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,7 @@
 //! Utilities and small helpers shared across the application.
 mod bsn;
+pub mod eks_key;
+pub mod health;
 pub mod no_cache_headers;
 mod option_string_ext;
 mod query_param_state;


### PR DESCRIPTION
Closes #649

This PR adds:

- Health endpoint: used for load balancer / CDN to route traffic
- x-eks-key header gate: optional shared-secret middleware (enabled by EKS_KEY env var) that rejects unmatched requests, to only allow traffic from CDN (defence-in-depth measure, we also allow-list the IP of the CDN)
- Server name in footer: SERVER_NAME env var threaded through config and rendered next to the version, used to debug when scaling horizontally.
- AppRequestState trait: replaces ad-hoc bounds on request extractors and gives them typed access to the config
- The STORAGE_URL is now wrapped in SecretString.
- Per-request store catch-up: session middleware calls store.load() so each instance picks up events written by siblings.
- Removed migration advisory lock: concurrent migration failures are logged as warnings instead of bubbling up, allowing simultaneous boots.

# [DOD](/docs/definition-of-done.md) checklist

## For PR maintainer

Perform these checks before marking the PR as ready:

- [x] I have linked the PR to at least one issue.
- [x] I assigned the PR to myself.
- [x] I have added a description how to test this PR (see "Review Instructions").
- [x] I have added documentation where necessary.

## For reviewer

- I have read all code changes.
- I have audited the code quality.
- I have tested the changes either or both:
  - locally
  - on the test environment (preferred)
- I have validated that the PR is functionally correct (use-cases, figma designs, etc.)

### Review instructions

Setting the SERVER_NAME environment variable should be displayed on the bottom left. Setting EKS_KEY should only allow requests with the x-eks-header with the same value. Hit /health and expect 200 while the DB is up, 503 after stopping it. Test multi-server propagation by creating a candidate list on one instance of the application and immediately loading it on the other, the catch-up should make it visible without a restart.
