### PR TITLE
[#674] Check if list submitter is empty before showing warnings

### DIFF
--- a/src/app/list_submitters/pages/update.html
+++ b/src/app/list_submitters/pages/update.html
@@ -3,7 +3,6 @@
 {% block overlay_title %}{{ "political_group.edit_list_submitter"|trans }}{% endblock %}
 {% block overlay_steps %}<div class="steps-nav"></div>{% endblock %}
 {% block overlay_form %}
-  {% set should_warn = true %}
   <fieldset>
     {% include "list_submitters/components/name_fields.html" %}
     <h3>{{ "person.correspondence_address"|trans }}</h3>

--- a/src/app/list_submitters/pages/update.rs
+++ b/src/app/list_submitters/pages/update.rs
@@ -14,6 +14,7 @@ use super::ListSubmitterUpdatePath;
 #[template(path = "list_submitters/pages/update.html")]
 struct ListSubmitterUpdateTemplate {
     form: FormData<ListSubmitterForm>,
+    should_warn: bool,
 }
 
 pub async fn update_list_submitter(
@@ -22,9 +23,11 @@ pub async fn update_list_submitter(
     store: AppStore,
 ) -> Result<Response, AppError> {
     let list_submitter = store.get_list_submitter();
+    let should_warn = !list_submitter.is_empty();
     Ok(HtmlTemplate(
         ListSubmitterUpdateTemplate {
             form: FormData::new_with_data(list_submitter.into(), &context.session.csrf_token),
+            should_warn,
         },
         context,
     )
@@ -43,7 +46,10 @@ pub async fn update_list_submitter_submit(
         &context.session.csrf_token,
     ) {
         Err(form_data) => Ok(HtmlTemplate(
-            ListSubmitterUpdateTemplate { form: form_data },
+            ListSubmitterUpdateTemplate {
+                form: form_data,
+                should_warn: true,
+            },
             context,
         )
         .into_response()),

--- a/src/app/political_groups/steps.rs
+++ b/src/app/political_groups/steps.rs
@@ -38,12 +38,13 @@ impl PoliticalGroupSteps {
             } else {
                 "warning"
             },
-            submitters_state: if list_submitter.is_all_good()
+            submitters_state: if list_submitter.is_empty() && political_group.is_basic_info_empty()
+            {
+                "empty"
+            } else if list_submitter.is_all_good()
                 && substitute_submitters.iter().all(ListSubmitter::is_all_good)
             {
                 "ok"
-            } else if list_submitter.is_empty() && political_group.is_basic_info_empty() {
-                "empty"
             } else {
                 "warning"
             },


### PR DESCRIPTION
# [DOD](/docs/definition-of-done.md) checklist

Closes #674 
Also discovered an issue where the list submitter receives a checkmark even though nothing is filled in. This pr additionally fixes this problem. 

<img width="368" height="311" alt="image" src="https://github.com/user-attachments/assets/b0fd8ee8-9947-4593-afd6-f7a060f1cd18" />

## For PR maintainer

Perform these checks before marking the PR as ready:

- [x] I have linked the PR to at least one issue.
- [x] I assigned the PR to myself.
- [x] I have added a description how to test this PR (see "Review Instructions").
- [x] I have added documentation where necessary.

## For reviewer

- I have read all code changes.
- I have audited the code quality.
- I have tested the changes either or both:
  - locally
  - on the test environment (preferred)
- I have validated that the PR is functionally correct (use-cases, figma designs, etc.)

### Review instructions

- Without loading fixtures, navigate to the general information (basisgegevens) page.
- Observe that there is no checkmark for the list submitter in the side menu
- Add a list submitter
- Observe that there are no warnings for this empty list submitter
- Add initials and name, then click save
- Observe that a warning _is_ shown now
- Fill in the remaining fields for the submitter, then click save
- The warnings are now gone