### PR TITLE
[#668] Address validation feedback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,9 +259,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -269,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -404,10 +404,10 @@ checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
 
 [[package]]
 name = "bag_address_lookup"
-version = "0.5.3"
-source = "git+https://github.com/tweedegolf/bag-address-lookup.git?tag=lib-v0.5.3#dc3f96a9c162e5c2f04a393d455680dfac7b6824"
+version = "0.7.0"
+source = "git+https://github.com/tweedegolf/bag-address-lookup.git?tag=lib-v0.7.0#86fd5546e1bc88489c212e300965783290366eeb"
 dependencies = [
- "flate2",
+ "zstd",
 ]
 
 [[package]]
@@ -575,9 +575,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1607,9 +1607,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -1865,9 +1865,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
@@ -2266,7 +2266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -3012,7 +3012,7 @@ checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64",
  "indexmap",
- "quick-xml 0.39.3",
+ "quick-xml 0.39.4",
  "serde",
  "time",
 ]
@@ -3163,9 +3163,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.3"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721da970c312655cde9b4ffe0547f20a8494866a4af5ff51f18b7c633d0c870b"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
@@ -4460,9 +4460,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -6061,9 +6061,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -6166,6 +6166,34 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "zune-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,8 +404,8 @@ checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
 
 [[package]]
 name = "bag_address_lookup"
-version = "0.7.0"
-source = "git+https://github.com/tweedegolf/bag-address-lookup.git?tag=lib-v0.7.0#86fd5546e1bc88489c212e300965783290366eeb"
+version = "0.8.0"
+source = "git+https://github.com/tweedegolf/bag-address-lookup.git?tag=lib-v0.8.0#f7d8f7bae410f8bfaca6c53eca279b351cc62c34"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ memory-serve = { version = "2.1.0", optional = true }
 validate = { path = "validate" }
 auth-service = { path = "auth-service" }
 typst-webservice = { git = "https://github.com/tweedegolf/typst-webservice.git", tag = "0.8.0", default-features = false, optional = true }
-bag_address_lookup = { git = "https://github.com/tweedegolf/bag-address-lookup.git", tag = "lib-v0.5.3", default-features = false, features = ["compressed_database"], optional = true }
+bag_address_lookup = { git = "https://github.com/tweedegolf/bag-address-lookup.git", tag = "lib-v0.7.0", default-features = false, features = ["compressed_database"], optional = true }
 
 # kiesraad
 eml-nl = { git = "https://github.com/kiesraad/rust-eml-nl.git" } # TODO: replace with crates.io version when the branch gets merged

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ memory-serve = { version = "2.1.0", optional = true }
 validate = { path = "validate" }
 auth-service = { path = "auth-service" }
 typst-webservice = { git = "https://github.com/tweedegolf/typst-webservice.git", tag = "0.8.0", default-features = false, optional = true }
-bag_address_lookup = { git = "https://github.com/tweedegolf/bag-address-lookup.git", tag = "lib-v0.7.0", default-features = false, features = ["compressed_database"], optional = true }
+bag_address_lookup = { git = "https://github.com/tweedegolf/bag-address-lookup.git", tag = "lib-v0.8.0", default-features = false, features = ["compressed_database"], optional = true }
 
 # kiesraad
 eml-nl = { git = "https://github.com/kiesraad/rust-eml-nl.git" } # TODO: replace with crates.io version when the branch gets merged

--- a/development/Cargo.lock
+++ b/development/Cargo.lock
@@ -584,7 +584,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "eks-development"
-version = "0.4.6"
+version = "0.4.9"
 dependencies = [
  "anyhow",
  "regex",

--- a/development/Cargo.toml
+++ b/development/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eks-development"
-version = "0.4.6"
+version = "0.4.9"
 edition = "2024"
 license = "EUPL-1.2"
 publish = false

--- a/development/setup.yml
+++ b/development/setup.yml
@@ -9,7 +9,7 @@ tools:
     base_url: "https://github.com/biomejs/biome/releases/download/@biomejs/biome@"
   - name: bag-service
     # https://github.com/tweedegolf/bag-address-lookup/releases
-    version: "0.7.0"
+    version: "0.8.0"
     base_url: "https://github.com/tweedegolf/bag-address-lookup/releases/download"
   - name: typst-webservice
     # https://github.com/tweedegolf/typst-webservice/releases

--- a/development/setup.yml
+++ b/development/setup.yml
@@ -9,7 +9,7 @@ tools:
     base_url: "https://github.com/biomejs/biome/releases/download/@biomejs/biome@"
   - name: bag-service
     # https://github.com/tweedegolf/bag-address-lookup/releases
-    version: "0.5.3"
+    version: "0.7.0"
     base_url: "https://github.com/tweedegolf/bag-address-lookup/releases/download"
   - name: typst-webservice
     # https://github.com/tweedegolf/typst-webservice/releases

--- a/frontend/scripts/form-inputs/locality-suggestions.ts
+++ b/frontend/scripts/form-inputs/locality-suggestions.ts
@@ -3,38 +3,11 @@
 // suggestion is rendered by clicking the element with id `locality-suggestion-name`,
 // which on click overwrites the input value and clears any warning state.
 //
-// The `/suggest` endpoint returns structured records. Field names mirror
-// the upstream Dutch postal API:
-//   wp  = "woonplaats" (place / city)
-//   gm  = "gemeente"   (municipality)
-//   pv  = "provincie"  (province)
-//   had_suffix = true when the source disambiguated a duplicate place name
-//                by appending a province suffix, so we must render "(pv)"
-//                alongside the name to keep the display unambiguous.
-//   alias      = alternate spelling/historical name that should also count
-//                as an exact match even though it's not what we display.
-type SuggestItem = {
-  wp?: string;
-  gm?: string;
-  pv: string;
-  had_suffix: boolean;
-  alias?: string;
-};
-
-// Prefer woonplaats over gemeente; append province only when the source
-// flagged this entry as a disambiguated duplicate.
-function displayName(item: SuggestItem): string {
-  const name = item.wp ?? item.gm ?? "";
-
-  return item.had_suffix && item.pv ? `${name} (${item.pv})` : name;
-}
-
-// Aliases are a separate match path: a user typing an alias should be treated
-// as having entered the canonical name, even though displayName() never returns
-// the alias itself.
-function aliasMatches(item: SuggestItem, query: string): boolean {
-  return item.alias?.toLowerCase() === query.toLowerCase();
-}
+// The `/suggest` endpoint returns a plain JSON array of suggestion names. A
+// name already carries a province suffix (e.g. "Bergen (LI)") when the source
+// disambiguated a duplicate place name. Frisian aliases, when requested, are
+// returned as names in their own right, so a user typing an alias gets an
+// exact match without any special handling here.
 
 export default function localitySuggestions() {
   const input = document.getElementById("locality") as HTMLInputElement | null;
@@ -53,6 +26,10 @@ export default function localitySuggestions() {
     "with-municipalities",
   );
 
+  // Frisian aliases are only offered as suggestions when the template adds
+  // `frisian-aliases-allowed` to the suggestion element (Frisian export forms).
+  const withAliases = suggestion.classList.contains("frisian-aliases-allowed");
+
   // `warn` distinguishes "user is actively typing" (false) from "user has
   // committed by blurring, or the form just loaded with a prefilled value"
   // (true). While typing we never add a warning — only remove one if it
@@ -67,18 +44,19 @@ export default function localitySuggestions() {
       return;
     }
 
-    const url = withMunicipalities
-      ? `/suggest?wp=${encodeURIComponent(q)}&municipalities=true&limit=1`
-      : `/suggest?wp=${encodeURIComponent(q)}&municipalities=false&limit=1`;
+    const url =
+      `/suggest?wp=${encodeURIComponent(q)}` +
+      `&municipalities=${withMunicipalities}` +
+      `&aliases=${withAliases}` +
+      `&limit=1`;
 
     const res = await fetch(url);
-    const suggestions: Array<SuggestItem> = await res.json();
+    const suggestions: Array<string> = await res.json();
 
-    // A value is considered valid when it matches either the canonical
-    // display form or a known alias of one of the returned suggestions.
+    // A value is valid when it matches one of the returned suggestion names
+    // (which already include any province suffix and requested aliases).
     const exactMatch = suggestions.some(
-      (s) =>
-        displayName(s).toLowerCase() === q.toLowerCase() || aliasMatches(s, q),
+      (s) => s.toLowerCase() === q.toLowerCase(),
     );
 
     if (warn) {
@@ -94,8 +72,7 @@ export default function localitySuggestions() {
       return;
     }
 
-    const first = suggestions[0];
-    const name = first ? displayName(first) : "";
+    const name = suggestions[0] ?? "";
     if (!name) {
       suggestion.classList.add("hidden");
       return;

--- a/frontend/scripts/form-inputs/locality-suggestions.ts
+++ b/frontend/scripts/form-inputs/locality-suggestions.ts
@@ -47,16 +47,6 @@ export default function localitySuggestions() {
 
   const field = input.closest(".form-field");
 
-  // Accept the suggestion: copy the displayed name into the input, clear
-  // the warning, and dispatch a change event so downstream listeners
-  // (validators, address lookup) see the corrected value.
-  suggestionName.addEventListener("click", () => {
-    input.value = suggestionName.textContent ?? "";
-    suggestion.classList.add("hidden");
-    field?.classList.remove("warning");
-    input.dispatchEvent(new Event("change", { bubbles: true }));
-  });
-
   // The template opts in to municipality results by adding `with-municipalities`
   // to the suggestion element. Forms that only accept actual places leave it off.
   const withMunicipalities = suggestion.classList.contains(
@@ -67,27 +57,20 @@ export default function localitySuggestions() {
   // committed by blurring, or the form just loaded with a prefilled value"
   // (true). While typing we never add a warning — only remove one if it
   // turns out the value is now valid — to avoid flashing red on every keystroke.
-  const update = async (warn: boolean) => {
+  const runUpdate = async (warn: boolean) => {
     const q = input.value;
-
-    if (q.length === 0) {
-      suggestion.classList.add("hidden");
-      return;
-    }
 
     // Below 3 characters the backend won't return useful results; treat
     // a too-short value as a warning on blur but stay silent while typing.
     if (q.length < 3) {
       suggestion.classList.add("hidden");
-      if (warn) {
-        field?.classList.add("warning");
-      }
       return;
     }
 
     const url = withMunicipalities
       ? `/suggest?wp=${encodeURIComponent(q)}&municipalities=true&limit=1`
       : `/suggest?wp=${encodeURIComponent(q)}&municipalities=false&limit=1`;
+
     const res = await fetch(url);
     const suggestions: Array<SuggestItem> = await res.json();
 
@@ -97,6 +80,7 @@ export default function localitySuggestions() {
       (s) =>
         displayName(s).toLowerCase() === q.toLowerCase() || aliasMatches(s, q),
     );
+
     if (warn) {
       field?.classList.toggle("warning", !exactMatch);
     } else if (exactMatch) {
@@ -121,8 +105,27 @@ export default function localitySuggestions() {
     suggestion.classList.remove("hidden");
   };
 
+  let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+  const update = (warn: boolean) => {
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      void runUpdate(warn);
+    }, 300);
+  };
+
+  // Accept the suggestion: copy the displayed name into the input, clear
+  // the warning, and dispatch a change event so downstream listeners
+  // (validators, address lookup) see the corrected value.
+  suggestionName.addEventListener("click", () => {
+    input.value = suggestionName.textContent ?? "";
+    suggestion.classList.add("hidden");
+    field?.classList.remove("warning");
+    runUpdate(true);
+  });
+
   input.addEventListener("input", () => update(false));
   input.addEventListener("blur", () => update(true));
+
   // Initial pass: validate any prefilled value (e.g. when the form is
   // re-rendered with server-side state) and surface a warning if invalid.
   update(true);

--- a/frontend/scripts/form-inputs/locality-suggestions.ts
+++ b/frontend/scripts/form-inputs/locality-suggestions.ts
@@ -1,27 +1,129 @@
-// Fetch and populate locality suggestions as the user types.
+// Fetches and shows a single clickable locality suggestion under the input
+// when the user's value doesn't exactly match a known Dutch locality. The
+// suggestion is rendered by clicking the element with id `locality-suggestion-name`,
+// which on click overwrites the input value and clears any warning state.
+//
+// The `/suggest` endpoint returns structured records. Field names mirror
+// the upstream Dutch postal API:
+//   wp  = "woonplaats" (place / city)
+//   gm  = "gemeente"   (municipality)
+//   pv  = "provincie"  (province)
+//   had_suffix = true when the source disambiguated a duplicate place name
+//                by appending a province suffix, so we must render "(pv)"
+//                alongside the name to keep the display unambiguous.
+//   alias      = alternate spelling/historical name that should also count
+//                as an exact match even though it's not what we display.
+type SuggestItem = {
+  wp?: string;
+  gm?: string;
+  pv: string;
+  had_suffix: boolean;
+  alias?: string;
+};
+
+// Prefer woonplaats over gemeente; append province only when the source
+// flagged this entry as a disambiguated duplicate.
+function displayName(item: SuggestItem): string {
+  const name = item.wp ?? item.gm ?? "";
+
+  return item.had_suffix && item.pv ? `${name} (${item.pv})` : name;
+}
+
+// Aliases are a separate match path: a user typing an alias should be treated
+// as having entered the canonical name, even though displayName() never returns
+// the alias itself.
+function aliasMatches(item: SuggestItem, query: string): boolean {
+  return item.alias?.toLowerCase() === query.toLowerCase();
+}
+
 export default function localitySuggestions() {
   const input = document.getElementById("locality") as HTMLInputElement | null;
-  const datalist = document.getElementById("locality-suggestions");
+  const suggestion = document.getElementById("locality-suggestion");
+  const suggestionName = document.getElementById("locality-suggestion-name");
 
-  if (!input || !datalist) {
+  if (!input || !suggestion || !suggestionName) {
     return;
   }
 
-  input.addEventListener("input", async () => {
+  const field = input.closest(".form-field");
+
+  // Accept the suggestion: copy the displayed name into the input, clear
+  // the warning, and dispatch a change event so downstream listeners
+  // (validators, address lookup) see the corrected value.
+  suggestionName.addEventListener("click", () => {
+    input.value = suggestionName.textContent ?? "";
+    suggestion.classList.add("hidden");
+    field?.classList.remove("warning");
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+
+  // The template opts in to municipality results by adding `with-municipalities`
+  // to the suggestion element. Forms that only accept actual places leave it off.
+  const withMunicipalities = suggestion.classList.contains(
+    "with-municipalities",
+  );
+
+  // `warn` distinguishes "user is actively typing" (false) from "user has
+  // committed by blurring, or the form just loaded with a prefilled value"
+  // (true). While typing we never add a warning — only remove one if it
+  // turns out the value is now valid — to avoid flashing red on every keystroke.
+  const update = async (warn: boolean) => {
     const q = input.value;
 
-    if (q.length < 3) {
+    if (q.length === 0) {
+      suggestion.classList.add("hidden");
       return;
     }
 
-    const res = await fetch(`/suggest?wp=${encodeURIComponent(q)}`);
-    const suggestions: Array<string> = await res.json();
+    // Below 3 characters the backend won't return useful results; treat
+    // a too-short value as a warning on blur but stay silent while typing.
+    if (q.length < 3) {
+      suggestion.classList.add("hidden");
+      if (warn) {
+        field?.classList.add("warning");
+      }
+      return;
+    }
 
-    datalist.innerHTML = "";
-    suggestions.forEach((item) => {
-      const option = document.createElement("option");
-      option.value = item;
-      datalist.appendChild(option);
-    });
-  });
+    const url = withMunicipalities
+      ? `/suggest?wp=${encodeURIComponent(q)}&municipalities=true&limit=1`
+      : `/suggest?wp=${encodeURIComponent(q)}&municipalities=false&limit=1`;
+    const res = await fetch(url);
+    const suggestions: Array<SuggestItem> = await res.json();
+
+    // A value is considered valid when it matches either the canonical
+    // display form or a known alias of one of the returned suggestions.
+    const exactMatch = suggestions.some(
+      (s) =>
+        displayName(s).toLowerCase() === q.toLowerCase() || aliasMatches(s, q),
+    );
+    if (warn) {
+      field?.classList.toggle("warning", !exactMatch);
+    } else if (exactMatch) {
+      // Typing path: never add a warning here, but do clear one the moment
+      // the value becomes valid so the user gets immediate positive feedback.
+      field?.classList.remove("warning");
+    }
+
+    if (exactMatch) {
+      suggestion.classList.add("hidden");
+      return;
+    }
+
+    const first = suggestions[0];
+    const name = first ? displayName(first) : "";
+    if (!name) {
+      suggestion.classList.add("hidden");
+      return;
+    }
+
+    suggestionName.textContent = name;
+    suggestion.classList.remove("hidden");
+  };
+
+  input.addEventListener("input", () => update(false));
+  input.addEventListener("blur", () => update(true));
+  // Initial pass: validate any prefilled value (e.g. when the form is
+  // re-rendered with server-side state) and surface a warning if invalid.
+  update(true);
 }

--- a/frontend/scripts/form-inputs/locality-suggestions.ts
+++ b/frontend/scripts/form-inputs/locality-suggestions.ts
@@ -65,6 +65,7 @@ export default function localitySuggestions() {
       // Typing path: never add a warning here, but do clear one the moment
       // the value becomes valid so the user gets immediate positive feedback.
       field?.classList.remove("warning");
+      field?.classList.remove("error");
     }
 
     if (exactMatch) {
@@ -97,6 +98,7 @@ export default function localitySuggestions() {
     input.value = suggestionName.textContent ?? "";
     suggestion.classList.add("hidden");
     field?.classList.remove("warning");
+    field?.classList.remove("error");
     runUpdate(true);
   });
 

--- a/frontend/scripts/form-inputs/lookup.ts
+++ b/frontend/scripts/form-inputs/lookup.ts
@@ -23,8 +23,33 @@ export default function addressLookup() {
     return;
   }
 
+  // `warning` is only meaningful on the lookup-driving inputs; locality and
+  // street are user-editable when no match is found, so they never get warned.
+  const allInputs = [
+    postalCodeInput,
+    houseNumberInput,
+    localityInput,
+    streetNameInput,
+  ];
+  const lookupInputs = [postalCodeInput, houseNumberInput];
+
+  const setHighlight = (
+    inputs: HTMLInputElement[],
+    className: string,
+    on: boolean,
+  ) => {
+    for (const input of inputs) {
+      input.closest(".form-field")?.classList.toggle(className, on);
+    }
+  };
+
+  function resetHighlights() {
+    setHighlight(allInputs, "success", false);
+    setHighlight(allInputs, "warning", false);
+  }
+
   const lookup = async () => {
-    resetSuccessHighlight();
+    resetHighlights();
 
     postalCodeInput.value = postalCodeInput.value
       .replaceAll(/\s/g, "")
@@ -36,7 +61,7 @@ export default function addressLookup() {
     }
 
     // fetch address data from backend
-    const url = `/lookup?pc=${postalCodeInput.value}&n=${houseNumberInput.value}`;
+    const url = `/lookup?pc=${encodeURIComponent(postalCodeInput.value)}&n=${encodeURIComponent(houseNumberInput.value)}`;
     const response = await fetch(url, {
       method: "GET",
       headers: {
@@ -44,31 +69,22 @@ export default function addressLookup() {
       },
     });
 
-    if (response.ok) {
-      const data = await response.json();
-      // fill in locality and street name if data is available
-      if (data.wp && data.pr) {
-        localityInput.value = data.wp;
-        streetNameInput.value = data.pr;
+    const data = response.ok ? await response.json() : null;
+    if (data?.wp && data?.pr) {
+      localityInput.value = data.wp;
+      streetNameInput.value = data.pr;
 
-        // highlight the address fields to indicate they were auto-filled
-        postalCodeInput.closest(".form-field")?.classList.add("success");
-        houseNumberInput.closest(".form-field")?.classList.add("success");
-        localityInput.closest(".form-field")?.classList.add("success");
-        streetNameInput.closest(".form-field")?.classList.add("success");
-      }
+      // highlight the address fields to indicate they were auto-filled
+      setHighlight(allInputs, "success", true);
+    } else {
+      // No usable match — flag the inputs that drive the lookup so the user
+      // knows the combination is unrecognised.
+      setHighlight(lookupInputs, "warning", true);
     }
   };
 
-  function resetSuccessHighlight() {
-    postalCodeInput?.closest(".form-field")?.classList.remove("success");
-    houseNumberInput?.closest(".form-field")?.classList.remove("success");
-    localityInput?.closest(".form-field")?.classList.remove("success");
-    streetNameInput?.closest(".form-field")?.classList.remove("success");
-  }
-
   postalCodeInput.addEventListener("change", lookup);
   houseNumberInput.addEventListener("change", lookup);
-  localityInput.addEventListener("change", resetSuccessHighlight);
-  streetNameInput.addEventListener("change", resetSuccessHighlight);
+  localityInput.addEventListener("change", resetHighlights);
+  streetNameInput.addEventListener("change", resetHighlights);
 }

--- a/frontend/scripts/poll.js
+++ b/frontend/scripts/poll.js
@@ -1,10 +1,10 @@
 // setup abort controller to clean up fetches when navigating to another page
 const controller = new AbortController();
-const esbuildEventSource = new EventSource('/static/esbuild');
+let esbuildEventSource;
 
 window.addEventListener("beforeunload", () => {
   controller.abort();
-  esbuildEventSource.close();
+  esbuildEventSource?.close();
 });
 
 // long polling, when the server is up we get a 200 response every 30s
@@ -50,15 +50,19 @@ const shortPoll = () => {
     });
 };
 
-// start with long polling when document is loaded
-document.addEventListener("DOMContentLoaded", () => {
-  // start long polling
-  longPoll();
+// Safari keeps the tab in a "loading" state while any fetch/EventSource that
+// was started before window 'load' is still pending. Defer both the long poll
+// and the esbuild EventSource until after 'load' (plus a setTimeout to push
+// them out of the load task entirely) so Safari stops the loading indicator.
+window.addEventListener("load", () => {
+  setTimeout(() => {
+    longPoll();
 
-  // also setup esbuild event source for instant reloads on frontend changes
-  esbuildEventSource.addEventListener('change', () => {
-    location.reload();
-  });
+    esbuildEventSource = new EventSource("/static/esbuild");
+    esbuildEventSource.addEventListener("change", () => {
+      location.reload();
+    });
 
-  console.log("[livereload] running");
+    console.log("[livereload] running");
+  }, 0);
 });

--- a/frontend/styles/form.css
+++ b/frontend/styles/form.css
@@ -99,6 +99,13 @@
       }
     }
 
+    &.success {
+      input {
+        border-color: var(--green-300);
+        background-color: var(--green-50);
+      }
+    }
+
     .autoformat,
     .no_bsn_confirmed {
       font-size: var(--font-size-sm);

--- a/frontend/styles/form.css
+++ b/frontend/styles/form.css
@@ -69,7 +69,7 @@
     }
 
     &.warning {
-      input:placeholder-shown:not(.date-separate input),
+      input:not(.date-separate input),
       .date-separate {
         border-color: var(--color-warning-darker);
         background-image: url("../icons/warning.svg");
@@ -89,13 +89,6 @@
         background-position: right 1em center;
         background-size: 1.5em;
         padding-right: 3em;
-      }
-    }
-
-    &.success {
-      input {
-        border-color: var(--green-300);
-        background-color: var(--green-50);
       }
     }
 
@@ -180,6 +173,29 @@
     font-size: var(--font-size-sm);
     color: var(--color-help-text);
     font-weight: normal;
+  }
+
+  span.suggestion {
+    font-size: var(--font-size-sm);
+    color: var(--color-help-text);
+
+    button {
+      background: none;
+      border: none;
+      padding: 0;
+      font: inherit;
+      color: var(--link-default);
+      text-decoration: underline;
+      cursor: pointer;
+
+      &:hover {
+        color: var(--link-hover);
+      }
+
+      &:active {
+        color: var(--link-active);
+      }
+    }
   }
 
   details.hint {

--- a/locales/en/person.yml
+++ b/locales/en/person.yml
@@ -17,6 +17,7 @@ fields:
   last_name_info: "Candidates can choose whether they want to be listed with: <ol> <li>Their own last name;</li> <li>The last name of their (ex) spouse, or (ex) registered partner;</li> <li>Both last names, first their own last name followed by (connected with a hyphen) the last name of their (ex) spouse, or (ex) registered partner;</li> <li>Both last names, first the last name of their (ex) spouse, or (ex) registered partner followed by (connected with a hyphen) their own last name.</li> </ol> The candidate must be authorised to use the name of their (ex) spouse, or (ex) registered partner (article 1:9 BW)."
   last_name_prefix: Last name prefix
   locality: Locality
+  locality_suggestion: "Did you mean:"
   name: Name
   place_of_residence: Place of residence
   postal_code: Postal code

--- a/locales/nl/person.yml
+++ b/locales/nl/person.yml
@@ -17,6 +17,7 @@ fields:
   last_name_info: "Kandidaten kunnen zelf kiezen vermeld te worden met: <ol> <li>De eigen achternaam;</li> <li>De achternaam van de (ex) echtgenoot, (ex) echtgenote, of (ex) geregistreerde partner;</li> <li>Beide achternamen, eerst de eigen achternaam en dan (verbonden door een koppelteken) de achternaam van de (ex) echtgenoot, (ex) echtgenote, of (ex) geregistreerde partner;</li> <li> Beide achternamen, eerst de achternaam van de (ex) echtgenoot, (ex) echtgenote of (ex) geregistreerde partner en dan (verbonden door een koppelteken) de eigen achternaam.</li> </ol> Wel moet de kandidaat bevoegd zijn om de naam van de (ex) echtgenoot, (ex) echtgenote of (ex) geregistreerde partner te voeren (artikel 1:9 BW)."
   last_name_prefix: Voorvoegsel
   locality: Woonplaats
+  locality_suggestion: "Bedoel je:"
   name: Naam
   place_of_residence: Woonplaats
   postal_code: Postcode

--- a/playwright/tests/fixtures.ts
+++ b/playwright/tests/fixtures.ts
@@ -50,7 +50,10 @@ export const test = base.extend<Fixtures>({
     await selectElectionPage.dropdownElections.selectOption("PS27");
     await selectElectionPage.dropdownProvinces.selectOption("NH");
     await selectElectionPage.checkboxFixtures.check();
-    await selectElectionPage.buttonContinue.click();
+    await Promise.all([
+      page.waitForURL("/"),
+      selectElectionPage.buttonContinue.click(),
+    ]);
 
     await use(page);
   },
@@ -61,7 +64,10 @@ export const test = base.extend<Fixtures>({
     await selectElectionPage.dropdownElections.selectOption("PS27");
     await selectElectionPage.dropdownProvinces.selectOption("FR");
     await selectElectionPage.checkboxFixtures.check();
-    await selectElectionPage.buttonContinue.click();
+    await Promise.all([
+      page.waitForURL("/"),
+      selectElectionPage.buttonContinue.click(),
+    ]);
 
     await use(page);
   },
@@ -76,7 +82,10 @@ export const test = base.extend<Fixtures>({
       "Amstel, Gooi en Vecht",
     );
     await selectElectionPage.checkboxFixtures.uncheck();
-    await selectElectionPage.buttonContinue.click();
+    await Promise.all([
+      page.waitForURL("/"),
+      selectElectionPage.buttonContinue.click(),
+    ]);
 
     await use(page);
   },

--- a/playwright/tests/pages/authorisedPersonPage.ts
+++ b/playwright/tests/pages/authorisedPersonPage.ts
@@ -30,7 +30,7 @@ export class AuthorisedPersonPage {
     this.textfieldStreetName = this.page.getByRole("textbox", {
       name: "Straatnaam",
     });
-    this.selectLocality = this.page.getByRole("combobox", {
+    this.selectLocality = this.page.getByRole("textbox", {
       name: "Woonplaats",
     });
     this.buttonAdd = this.page.getByRole("button", { name: "Toevoegen" });

--- a/playwright/tests/pages/correspondenceAddressPage.ts
+++ b/playwright/tests/pages/correspondenceAddressPage.ts
@@ -24,7 +24,7 @@ export class CorrespondenceAddressPage {
     this.textfieldStreetName = this.page.getByRole("textbox", {
       name: "Straatnaam",
     });
-    this.selectLocality = this.page.getByRole("combobox", {
+    this.selectLocality = this.page.getByRole("textbox", {
       name: "Woonplaats",
     });
     this.buttonAdd = this.page.getByRole("button", { name: "Toevoegen" });

--- a/playwright/tests/pages/manageCandidateListPage.ts
+++ b/playwright/tests/pages/manageCandidateListPage.ts
@@ -82,6 +82,7 @@ export class ManageCandidateListPage {
       await this.buttonNext.click();
       await this.textfieldLocality.fill(candidate.locality ?? "");
       await this.buttonAdd.click();
+      await this.headingCandidateList.waitFor();
     }
   }
 

--- a/src/app/candidate_lists/structs/candidate_record.rs
+++ b/src/app/candidate_lists/structs/candidate_record.rs
@@ -384,7 +384,7 @@ mod tests {
                 .locality
                 .as_ref()
                 .map(|v| v.to_string()),
-            Some("Den Haag".to_string())
+            Some("'s-Gravenhage".to_string())
         );
     }
 }

--- a/src/app/common/components/address_fields.html
+++ b/src/app/common/components/address_fields.html
@@ -42,9 +42,12 @@
            placeholder=" "
            name="locality"
            id="locality"
-           value="{{ form.data.address.locality }}"
-           list="locality-suggestions" />
-    <datalist id="locality-suggestions"></datalist>
+           autocomplete="off"
+           value="{{ form.data.address.locality }}" />
+    <span id="locality-suggestion" class="suggestion hidden">
+      {{ "person.fields.locality_suggestion"|trans }}
+      <button type="button" id="locality-suggestion-name"></button>
+    </span>
     {% for error in form|error("address.locality") %}<span class="error">{{ error }}</span>{% endfor %}
   </p>
 </div>

--- a/src/app/common/structs/constrained_string.rs
+++ b/src/app/common/structs/constrained_string.rs
@@ -10,8 +10,6 @@ use crate::{
 pub type FirstName = ConstrainedString;
 pub type LegalName = ConstrainedString;
 pub type StreetName = ConstrainedString;
-pub type Locality = ConstrainedString;
-pub type PlaceOfResidence = ConstrainedString;
 pub type StateOrProvince = ConstrainedString;
 
 transparent_string! {

--- a/src/app/common/structs/locality.rs
+++ b/src/app/common/structs/locality.rs
@@ -1,0 +1,59 @@
+//! Locality (place / city name).
+//!
+//! Validation rules (via `FromStr`):
+//! - Whitespace is trimmed; the value must be 2..=200 characters.
+//! - Only Teletex characters are allowed.
+//! - Known non-official names are replaced by their official counterpart
+//!   (see [`replace_locality_alias`]).
+use crate::{
+    form::{ValidationError, validate_length, validate_teletex_chars},
+    transparent_string,
+    utils::locality_aliases::replace_locality_alias,
+};
+
+transparent_string! {
+    pub struct Locality(String);
+}
+
+pub type PlaceOfResidence = Locality;
+
+impl std::str::FromStr for Locality {
+    type Err = ValidationError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let trimmed_value = validate_length(value, 2, 200)?;
+        validate_teletex_chars(&trimmed_value)?;
+
+        let normalized = replace_locality_alias(&trimmed_value).unwrap_or(trimmed_value);
+
+        Ok(Locality(normalized))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn keeps_official_name_unchanged() {
+        let locality = Locality::from_str("Amsterdam").expect("locality");
+
+        assert_eq!(locality.to_string(), "Amsterdam");
+    }
+
+    #[test]
+    fn replaces_known_alias_with_official_name() {
+        let locality = Locality::from_str("Den Haag").expect("locality");
+
+        assert_eq!(locality.to_string(), "'s-Gravenhage");
+    }
+
+    #[test]
+    fn rejects_too_short_values() {
+        assert_eq!(
+            Locality::from_str("A").expect_err("too short"),
+            ValidationError::ValueTooShort(1, 2)
+        );
+    }
+}

--- a/src/app/common/structs/mod.rs
+++ b/src/app/common/structs/mod.rs
@@ -12,6 +12,7 @@ mod house_number_addition;
 mod initials;
 mod last_name;
 mod last_name_prefix;
+mod locality;
 mod name;
 mod postal_code;
 mod previous_election_results;
@@ -19,9 +20,7 @@ mod utc_date_time;
 
 pub use address::{Address, DutchAddress, InternationalAddress};
 pub use bsn::{BSN_NONE_CONFIRMATION, Bsn, BsnOrNoneConfirmed};
-pub use constrained_string::{
-    FirstName, LegalName, Locality, PlaceOfResidence, StateOrProvince, StreetName,
-};
+pub use constrained_string::{FirstName, LegalName, StateOrProvince, StreetName};
 pub use countries::COUNTRY_CODES;
 pub use country_code::CountryCode;
 pub use date::DateOfBirth;
@@ -33,6 +32,7 @@ pub use house_number_addition::HouseNumberAddition;
 pub use initials::Initials;
 pub use last_name::LastName;
 pub use last_name_prefix::LastNamePrefix;
+pub use locality::{Locality, PlaceOfResidence};
 pub use name::FullName;
 pub use postal_code::{InternationalPostalCode, PostalCode};
 pub use previous_election_results::PreviousElectionResults;

--- a/src/app/persons/components/form.html
+++ b/src/app/persons/components/form.html
@@ -1,4 +1,5 @@
 {% include "common/components/name_fields.html" %}
+{% let election = "election"|election_value %}
 <div class="form-row">
   <p class="form-field {% if form.data.personal_data.place_of_residence.is_empty() && should_warn %}error{% endif %}">
     <label for="locality">{{ "person.fields.place_of_residence"|trans }}</label>
@@ -9,7 +10,7 @@
            autocomplete="off"
            value="{{ form.data.personal_data.place_of_residence }}" />
     <span id="locality-suggestion"
-          class="suggestion with-municipalities hidden">
+          class="suggestion with-municipalities{% if election.frisian_export_allowed() %} frisian-aliases-allowed{% endif %} hidden">
       {{ "person.fields.locality_suggestion"|trans }}
       <button type="button" id="locality-suggestion-name"></button>
     </span>

--- a/src/app/persons/components/form.html
+++ b/src/app/persons/components/form.html
@@ -6,9 +6,13 @@
            placeholder=" "
            name="place_of_residence"
            id="locality"
-           value="{{ form.data.personal_data.place_of_residence }}"
-           list="locality-suggestions" />
-    <datalist id="locality-suggestions"></datalist>
+           autocomplete="off"
+           value="{{ form.data.personal_data.place_of_residence }}" />
+    <span id="locality-suggestion"
+          class="suggestion with-municipalities hidden">
+      {{ "person.fields.locality_suggestion"|trans }}
+      <button type="button" id="locality-suggestion-name"></button>
+    </span>
     {% for error in form|error("personal_data.place_of_residence") %}<span class="error">{{ error }}</span>{% endfor %}
   </p>
   <div class="form-field form-field-md {% if form.data.personal_data.country.is_empty() && should_warn %}warning{% endif %}">

--- a/src/utils/embed_bag.rs
+++ b/src/utils/embed_bag.rs
@@ -13,7 +13,7 @@ use axum::{
 use bag_address_lookup::{
     DEFAULT_SUGGEST_LIMIT, DEFAULT_SUGGEST_THRESHOLD, DatabaseHandle, SuggestEntry,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 /// Lazily-decoded handle to the BAG database embedded in `bag-address-lookup`.
@@ -61,13 +61,23 @@ async fn lookup(Query(params): Query<LookupQuery>) -> impl IntoResponse {
 #[derive(Deserialize)]
 struct SuggestQuery {
     wp: Option<String>,
+    municipalities: Option<String>,
+    limit: Option<usize>,
+}
+
+/// Parse a boolean-ish query value. `false`, `0`, `no` (case-insensitive) are
+/// false; any other value — or a missing param — is true. Matches the upstream
+/// `bag-address-lookup` HTTP service.
+fn parse_bool(value: &str) -> bool {
+    !matches!(value.to_ascii_lowercase().as_str(), "false" | "0" | "no")
 }
 
 /// Fuzzy-match localities and municipalities against the `wp` query param.
 ///
-/// Returns a JSON array of display strings (see [`format_entry`]). An empty
-/// array is a successful response meaning no match. Missing `wp` yields
-/// `400 Bad Request` with an `{"error": "missing wp"}` body.
+/// Returns a JSON array of structured suggestion records matching the wire
+/// format of the upstream `bag-address-lookup` service (see [`SuggestResponse`]).
+/// An empty array is a successful response meaning no match. Missing `wp`
+/// yields `400 Bad Request` with an `{"error": "missing wp"}` body.
 async fn suggest(Query(params): Query<SuggestQuery>) -> impl IntoResponse {
     let Some(query) = params.wp else {
         return (
@@ -76,8 +86,16 @@ async fn suggest(Query(params): Query<SuggestQuery>) -> impl IntoResponse {
         );
     };
 
-    let entries = DATABASE.suggest(&query, DEFAULT_SUGGEST_THRESHOLD, DEFAULT_SUGGEST_LIMIT);
-    let body: Vec<String> = entries.iter().map(format_entry).collect();
+    let include_municipalities = params.municipalities.as_deref().is_none_or(parse_bool);
+    let limit = params.limit.unwrap_or(DEFAULT_SUGGEST_LIMIT);
+
+    let entries = DATABASE.suggest(
+        &query,
+        DEFAULT_SUGGEST_THRESHOLD,
+        limit,
+        include_municipalities,
+    );
+    let body: Vec<SuggestResponse<'_>> = entries.iter().map(SuggestResponse::from).collect();
     let Ok(body) = serde_json::to_value(body) else {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -88,25 +106,68 @@ async fn suggest(Query(params): Query<SuggestQuery>) -> impl IntoResponse {
     (StatusCode::OK, Json(body))
 }
 
-/// Render a suggestion as the string shown to the user in the datalist.
-///
-/// Plain name by default; when the source BAG name carried a stripped province
-/// suffix (`had_suffix`), the province is appended as `"Name (PV)"` to
-/// disambiguate localities/municipalities that share a name across provinces.
-fn format_entry(entry: &SuggestEntry) -> String {
-    let (name, had_suffix, pv) = match entry {
-        SuggestEntry::Locality {
-            wp, pv, had_suffix, ..
-        } => (wp, had_suffix, pv),
-        SuggestEntry::Municipality {
-            gm, pv, had_suffix, ..
-        } => (gm, had_suffix, pv),
-    };
+/// Wire format for a single `/suggest` result, matching the upstream
+/// `bag-address-lookup` HTTP service. `SuggestEntry` itself does not
+/// derive `Serialize`, so we project it into this borrowing view.
+#[derive(Serialize)]
+#[serde(untagged)]
+enum SuggestResponse<'a> {
+    Locality {
+        wp: &'a str,
+        wp_code: u16,
+        gm: &'a str,
+        gm_code: u16,
+        pv: &'a str,
+        unique: bool,
+        had_suffix: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        alias: Option<&'a str>,
+    },
+    Municipality {
+        gm: &'a str,
+        gm_code: u16,
+        pv: &'a str,
+        unique: bool,
+        had_suffix: bool,
+    },
+}
 
-    if *had_suffix {
-        format!("{} ({})", name, pv)
-    } else {
-        name.to_string()
+impl<'a> From<&'a SuggestEntry> for SuggestResponse<'a> {
+    fn from(entry: &'a SuggestEntry) -> Self {
+        match entry {
+            SuggestEntry::Locality {
+                wp,
+                wp_code,
+                gm,
+                gm_code,
+                pv,
+                unique,
+                had_suffix,
+                alias,
+            } => SuggestResponse::Locality {
+                wp,
+                wp_code: *wp_code,
+                gm,
+                gm_code: *gm_code,
+                pv,
+                unique: *unique,
+                had_suffix: *had_suffix,
+                alias: *alias,
+            },
+            SuggestEntry::Municipality {
+                gm,
+                gm_code,
+                pv,
+                unique,
+                had_suffix,
+            } => SuggestResponse::Municipality {
+                gm,
+                gm_code: *gm_code,
+                pv,
+                unique: *unique,
+                had_suffix: *had_suffix,
+            },
+        }
     }
 }
 
@@ -118,22 +179,28 @@ mod tests {
 
     use crate::test_utils::response_body_string;
 
-    fn locality(name: &str, pv: &str, had_suffix: bool) -> SuggestEntry {
+    fn locality(
+        name: &str,
+        pv: &str,
+        had_suffix: bool,
+        alias: Option<&'static str>,
+    ) -> SuggestEntry {
         SuggestEntry::Locality {
             wp: name.to_string(),
-            wp_code: 0,
+            wp_code: 1,
             gm: name.to_string(),
-            gm_code: 0,
+            gm_code: 2,
             pv: pv.to_string(),
             unique: true,
             had_suffix,
+            alias,
         }
     }
 
     fn municipality(name: &str, pv: &str, had_suffix: bool) -> SuggestEntry {
         SuggestEntry::Municipality {
             gm: name.to_string(),
-            gm_code: 0,
+            gm_code: 3,
             pv: pv.to_string(),
             unique: true,
             had_suffix,
@@ -141,32 +208,49 @@ mod tests {
     }
 
     #[test]
-    fn format_entry_locality_without_suffix_uses_bare_name() {
+    fn locality_serializes_full_fields_in_upstream_order() {
+        let entry = locality("Amsterdam", "NH", false, None);
+        let json = serde_json::to_string(&SuggestResponse::from(&entry)).expect("serialize");
         assert_eq!(
-            format_entry(&locality("Amsterdam", "NH", false)),
-            "Amsterdam"
+            json,
+            r#"{"wp":"Amsterdam","wp_code":1,"gm":"Amsterdam","gm_code":2,"pv":"NH","unique":true,"had_suffix":false}"#
         );
     }
 
     #[test]
-    fn format_entry_locality_with_suffix_appends_province() {
-        assert_eq!(format_entry(&locality("Loo", "GE", true)), "Loo (GE)");
+    fn locality_with_alias_includes_alias_field() {
+        let entry = locality("Bolsward", "FR", false, Some("Boalsert"));
+        let json = serde_json::to_string(&SuggestResponse::from(&entry)).expect("serialize");
+        assert!(json.contains(r#""alias":"Boalsert""#));
     }
 
     #[test]
-    fn format_entry_municipality_without_suffix_uses_bare_name() {
+    fn locality_without_alias_omits_alias_field() {
+        let entry = locality("Amsterdam", "NH", true, None);
+        let json = serde_json::to_string(&SuggestResponse::from(&entry)).expect("serialize");
+        assert!(!json.contains("alias"));
+    }
+
+    #[test]
+    fn municipality_serializes_full_fields_in_upstream_order() {
+        let entry = municipality("Utrecht", "UT", false);
+        let json = serde_json::to_string(&SuggestResponse::from(&entry)).expect("serialize");
         assert_eq!(
-            format_entry(&municipality("Utrecht", "UT", false)),
-            "Utrecht"
+            json,
+            r#"{"gm":"Utrecht","gm_code":3,"pv":"UT","unique":true,"had_suffix":false}"#
         );
     }
 
     #[test]
-    fn format_entry_municipality_with_suffix_appends_province() {
-        assert_eq!(
-            format_entry(&municipality("Hengelo", "OV", true)),
-            "Hengelo (OV)"
-        );
+    fn had_suffix_is_a_flag_not_a_baked_in_name() {
+        // The upstream wire format exposes had_suffix as a boolean; the caller
+        // (frontend) is responsible for rendering "(PV)" when set. The name
+        // fields themselves must stay bare.
+        let entry = locality("Loo", "GE", true, None);
+        let json = serde_json::to_string(&SuggestResponse::from(&entry)).expect("serialize");
+        assert!(json.contains(r#""wp":"Loo""#));
+        assert!(json.contains(r#""had_suffix":true"#));
+        assert!(!json.contains("Loo (GE)"));
     }
 
     #[tokio::test]

--- a/src/utils/embed_bag.rs
+++ b/src/utils/embed_bag.rs
@@ -10,10 +10,8 @@ use axum::{
     response::{IntoResponse, Json},
     routing::get,
 };
-use bag_address_lookup::{
-    DEFAULT_SUGGEST_LIMIT, DEFAULT_SUGGEST_THRESHOLD, DatabaseHandle, SuggestEntry,
-};
-use serde::{Deserialize, Serialize};
+use bag_address_lookup::{DEFAULT_SUGGEST_LIMIT, DEFAULT_SUGGEST_THRESHOLD, DatabaseHandle};
+use serde::Deserialize;
 use serde_json::json;
 
 /// Lazily-decoded handle to the BAG database embedded in `bag-address-lookup`.
@@ -62,22 +60,28 @@ async fn lookup(Query(params): Query<LookupQuery>) -> impl IntoResponse {
 struct SuggestQuery {
     wp: Option<String>,
     municipalities: Option<String>,
+    aliases: Option<String>,
     limit: Option<usize>,
 }
 
 /// Parse a boolean-ish query value. `false`, `0`, `no` (case-insensitive) are
-/// false; any other value — or a missing param — is true. Matches the upstream
-/// `bag-address-lookup` HTTP service.
+/// false; any other value is true. Matches the upstream `bag-address-lookup`
+/// HTTP service.
 fn parse_bool(value: &str) -> bool {
     !matches!(value.to_ascii_lowercase().as_str(), "false" | "0" | "no")
 }
 
 /// Fuzzy-match localities and municipalities against the `wp` query param.
 ///
-/// Returns a JSON array of structured suggestion records matching the wire
-/// format of the upstream `bag-address-lookup` service (see [`SuggestResponse`]).
-/// An empty array is a successful response meaning no match. Missing `wp`
-/// yields `400 Bad Request` with an `{"error": "missing wp"}` body.
+/// Returns a JSON array of suggestion names, matching the wire format of the
+/// upstream `bag-address-lookup` service. A name already carries a province
+/// suffix (e.g. `Bergen (LI)`) when the source disambiguated a duplicate place
+/// name. An empty array is a successful response meaning no match; missing
+/// `wp` yields `400 Bad Request` with an `{"error": "missing wp"}` body.
+///
+/// `municipalities` (default true) toggles whether municipality names are
+/// offered; `aliases` (default false) toggles whether Frisian locality aliases
+/// are offered as suggestions in their own right.
 async fn suggest(Query(params): Query<SuggestQuery>) -> impl IntoResponse {
     let Some(query) = params.wp else {
         return (
@@ -87,88 +91,18 @@ async fn suggest(Query(params): Query<SuggestQuery>) -> impl IntoResponse {
     };
 
     let include_municipalities = params.municipalities.as_deref().is_none_or(parse_bool);
+    let include_aliases = params.aliases.as_deref().is_some_and(parse_bool);
     let limit = params.limit.unwrap_or(DEFAULT_SUGGEST_LIMIT);
 
-    let entries = DATABASE.suggest(
+    let names = DATABASE.suggest(
         &query,
         DEFAULT_SUGGEST_THRESHOLD,
         limit,
         include_municipalities,
+        include_aliases,
     );
-    let body: Vec<SuggestResponse<'_>> = entries.iter().map(SuggestResponse::from).collect();
-    let Ok(body) = serde_json::to_value(body) else {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": "failed to serialize response"})),
-        );
-    };
 
-    (StatusCode::OK, Json(body))
-}
-
-/// Wire format for a single `/suggest` result, matching the upstream
-/// `bag-address-lookup` HTTP service. `SuggestEntry` itself does not
-/// derive `Serialize`, so we project it into this borrowing view.
-#[derive(Serialize)]
-#[serde(untagged)]
-enum SuggestResponse<'a> {
-    Locality {
-        wp: &'a str,
-        wp_code: u16,
-        gm: &'a str,
-        gm_code: u16,
-        pv: &'a str,
-        unique: bool,
-        had_suffix: bool,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        alias: Option<&'a str>,
-    },
-    Municipality {
-        gm: &'a str,
-        gm_code: u16,
-        pv: &'a str,
-        unique: bool,
-        had_suffix: bool,
-    },
-}
-
-impl<'a> From<&'a SuggestEntry> for SuggestResponse<'a> {
-    fn from(entry: &'a SuggestEntry) -> Self {
-        match entry {
-            SuggestEntry::Locality {
-                wp,
-                wp_code,
-                gm,
-                gm_code,
-                pv,
-                unique,
-                had_suffix,
-                alias,
-            } => SuggestResponse::Locality {
-                wp,
-                wp_code: *wp_code,
-                gm,
-                gm_code: *gm_code,
-                pv,
-                unique: *unique,
-                had_suffix: *had_suffix,
-                alias: *alias,
-            },
-            SuggestEntry::Municipality {
-                gm,
-                gm_code,
-                pv,
-                unique,
-                had_suffix,
-            } => SuggestResponse::Municipality {
-                gm,
-                gm_code: *gm_code,
-                pv,
-                unique: *unique,
-                had_suffix: *had_suffix,
-            },
-        }
-    }
+    (StatusCode::OK, Json(json!(names)))
 }
 
 #[cfg(test)]
@@ -178,80 +112,6 @@ mod tests {
     use tower::ServiceExt;
 
     use crate::test_utils::response_body_string;
-
-    fn locality(
-        name: &str,
-        pv: &str,
-        had_suffix: bool,
-        alias: Option<&'static str>,
-    ) -> SuggestEntry {
-        SuggestEntry::Locality {
-            wp: name.to_string(),
-            wp_code: 1,
-            gm: name.to_string(),
-            gm_code: 2,
-            pv: pv.to_string(),
-            unique: true,
-            had_suffix,
-            alias,
-        }
-    }
-
-    fn municipality(name: &str, pv: &str, had_suffix: bool) -> SuggestEntry {
-        SuggestEntry::Municipality {
-            gm: name.to_string(),
-            gm_code: 3,
-            pv: pv.to_string(),
-            unique: true,
-            had_suffix,
-        }
-    }
-
-    #[test]
-    fn locality_serializes_full_fields_in_upstream_order() {
-        let entry = locality("Amsterdam", "NH", false, None);
-        let json = serde_json::to_string(&SuggestResponse::from(&entry)).expect("serialize");
-        assert_eq!(
-            json,
-            r#"{"wp":"Amsterdam","wp_code":1,"gm":"Amsterdam","gm_code":2,"pv":"NH","unique":true,"had_suffix":false}"#
-        );
-    }
-
-    #[test]
-    fn locality_with_alias_includes_alias_field() {
-        let entry = locality("Bolsward", "FR", false, Some("Boalsert"));
-        let json = serde_json::to_string(&SuggestResponse::from(&entry)).expect("serialize");
-        assert!(json.contains(r#""alias":"Boalsert""#));
-    }
-
-    #[test]
-    fn locality_without_alias_omits_alias_field() {
-        let entry = locality("Amsterdam", "NH", true, None);
-        let json = serde_json::to_string(&SuggestResponse::from(&entry)).expect("serialize");
-        assert!(!json.contains("alias"));
-    }
-
-    #[test]
-    fn municipality_serializes_full_fields_in_upstream_order() {
-        let entry = municipality("Utrecht", "UT", false);
-        let json = serde_json::to_string(&SuggestResponse::from(&entry)).expect("serialize");
-        assert_eq!(
-            json,
-            r#"{"gm":"Utrecht","gm_code":3,"pv":"UT","unique":true,"had_suffix":false}"#
-        );
-    }
-
-    #[test]
-    fn had_suffix_is_a_flag_not_a_baked_in_name() {
-        // The upstream wire format exposes had_suffix as a boolean; the caller
-        // (frontend) is responsible for rendering "(PV)" when set. The name
-        // fields themselves must stay bare.
-        let entry = locality("Loo", "GE", true, None);
-        let json = serde_json::to_string(&SuggestResponse::from(&entry)).expect("serialize");
-        assert!(json.contains(r#""wp":"Loo""#));
-        assert!(json.contains(r#""had_suffix":true"#));
-        assert!(!json.contains("Loo (GE)"));
-    }
 
     #[tokio::test]
     async fn suggest_missing_wp_returns_bad_request() {
@@ -325,5 +185,25 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         let body = response_body_string(response).await;
         assert_eq!(body.trim(), "[]");
+    }
+
+    #[tokio::test]
+    async fn suggest_returns_flat_array_of_names() {
+        let app = router::<()>();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/suggest?wp=Amsterdam&limit=1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_body_string(response).await;
+        // The body is a flat JSON array of strings, not structured records.
+        assert_eq!(body.trim(), r#"["Amsterdam"]"#);
     }
 }

--- a/src/utils/locality_aliases.rs
+++ b/src/utils/locality_aliases.rs
@@ -1,6 +1,6 @@
 //! Known non-official locality names and their official counterparts.
 
-/// This list is based on https://cuatro.sim-cdn.nl/fryslan/uploads/list_plaknammen_yn_fryslan.pdf?cb=RAqKiBSg
+/// The Dutch aliases of officially Frisian place names are based on https://cuatro.sim-cdn.nl/fryslan/uploads/list_plaknammen_yn_fryslan.pdf?cb=RAqKiBSg
 const LOCALITY_ALIASES: &[(&str, &str)] = &[
     ("Den Haag", "'s-Gravenhage"),
     ("Den Bosch", "'s-Hertogenbosch"),

--- a/src/utils/locality_aliases.rs
+++ b/src/utils/locality_aliases.rs
@@ -1,0 +1,167 @@
+//! Known non-official locality names and their official counterparts.
+
+/// This list is based on https://cuatro.sim-cdn.nl/fryslan/uploads/list_plaknammen_yn_fryslan.pdf?cb=RAqKiBSg
+const LOCALITY_ALIASES: &[(&str, &str)] = &[
+    ("Den Haag", "'s-Gravenhage"),
+    ("Den Bosch", "'s-Hertogenbosch"),
+    ("Gorkum", "Gorinchem"),
+    ("Gorcum", "Gorinchem"),
+    ("Gravendeel", "'s-Gravendeel"),
+    ("Graveland", "'s-Graveland"),
+    ("Gravenzande", "'s-Gravenzande"),
+    ("Heer Abtskerke", "'s-Heer Abtskerke"),
+    ("Heer Arendskerke", "'s-Heer Arendskerke"),
+    ("Heer Hendrikskinderen", "'s-Heer Hendrikskinderen"),
+    ("Heerenberg", "'s-Heerenberg"),
+    ("Heerenbroek", "'s-Heerenbroek"),
+    ("Heerenhoek", "'s-Heerenhoek"),
+    ("St. Agatha", "Sint Agatha"),
+    ("St. Annaland", "Sint-Annaland"),
+    ("St. Anthonis", "Sint Anthonis"),
+    ("St. Geertruid", "Sint Geertruid"),
+    ("St. Hubert", "Sint Hubert"),
+    ("St. Jansklooster", "Sint Jansklooster"),
+    ("St. Joost", "Sint Joost"),
+    ("St. Kruis", "Sint Kruis"),
+    ("St. Maarten", "Sint Maarten"),
+    ("St. Maartensdijk", "Sint-Maartensdijk"),
+    ("St. Michielsgestel", "Sint-Michielsgestel"),
+    ("St. Nicolaasga", "Sint Nicolaasga"),
+    ("St. Odiliënberg", "Sint Odiliënberg"),
+    ("St. Oedenrode", "Sint-Oedenrode"),
+    ("St. Pancras", "Sint Pancras"),
+    ("St. Philipsland", "Sint Philipsland"),
+    ("Sint Willebrord", "St. Willebrord"),
+    ("Cuyk", "Cuijk"),
+    ("Oude Leije", "Alde Leie"),
+    ("Oldeboorn", "Aldeboarn"),
+    ("Oudkerk", "Aldtsjerk"),
+    ("Oudwoude", "Aldwâld"),
+    ("Augsbuurt", "Augsbuert-Lytsewâld"),
+    ("Baijum", "Baaium"),
+    ("Beers", "Bears"),
+    ("Berlikum", "Berltsum"),
+    ("Beetgum", "Bitgum"),
+    ("Beetgumermolen", "Bitgummole"),
+    ("Blija", "Blije"),
+    ("Bornwird", "Boarnwert"),
+    ("Bozum", "Boazum"),
+    ("Britswerd", "Britswert"),
+    ("Broeksterwoude", "Broeksterwâld"),
+    ("Birdaard", "Burdaard"),
+    ("Bergum", "Burgum"),
+    ("Damwoude", "Damwâld"),
+    ("De Valom", "De Falom"),
+    ("Triemen", "De Trieme"),
+    ("Zwaagwesteinde", "De Westereen"),
+    ("Deersum", "Dearsum"),
+    ("Driesum", "Driezum"),
+    ("Dronrijp", "Dronryp"),
+    ("Aegum", "Eagum"),
+    ("Anjum", "Eanjum"),
+    ("Eernewoude", "Earnewâld"),
+    ("Oosterend", "Easterein"),
+    ("Oosterlittens", "Easterlittens"),
+    ("Oostermeer", "Eastermar"),
+    ("Oosternijkerk", "Easternijtsjerk"),
+    ("Oosterwierum", "Easterwierrum"),
+    ("Oostrum", "Eastrum"),
+    ("Veenklooster", "Feankleaster"),
+    ("Veenwouden", "Feanwâlden"),
+    ("Veenwoudsterwal", "Feanwâldsterwâl"),
+    ("Finkum", "Feinsum"),
+    ("Ferwerd", "Ferwert"),
+    ("Garijp", "Garyp"),
+    ("Genum", "Ginnum"),
+    ("Grouw", "Grou"),
+    ("Giekerk", "Gytsjerk"),
+    ("Hantumeruitburen", "Hantumerútbuorren"),
+    ("Hantumhuizen", "Hantumhuzen"),
+    ("Hogebeintum", "Hegebeintum"),
+    ("Hijlaard", "Hilaard"),
+    ("Hennaard", "Hinnaard"),
+    ("Holwerd", "Holwert"),
+    ("Huins", "Húns"),
+    ("Hardegarijp", "Hurdegaryp"),
+    ("Idaard", "Idaerd"),
+    ("Ee", "Ie"),
+    ("Edens", "Iens"),
+    ("Engelum", "Ingelum"),
+    ("Engwierum", "Ingwierrum"),
+    ("Het Heidenschap", "It Heidenskip"),
+    ("Janum", "Jannum"),
+    ("Irnsum", "Jirnsum"),
+    ("Eestrum", "Jistrum"),
+    ("Jonkersland", "Jonkerslân"),
+    ("Jorwerd", "Jorwert"),
+    ("Cornjum", "Koarnjum"),
+    ("Kollumerzwaag", "Kollumersweach"),
+    ("Kubaard", "Kûbaard"),
+    ("Lions", "Leons"),
+    ("Lioessens", "Ljussens"),
+    ("Lutkewierum", "Lytsewierrum"),
+    ("Marssum", "Marsum"),
+    ("Menaldum", "Menaam"),
+    ("Metslawier", "Mitselwier"),
+    ("Morra", "Moarre"),
+    ("Molenend", "Mûnein"),
+    ("Niawier", "Nijewier"),
+    ("Noordbergum", "Noardburgum"),
+    ("Oenkerk", "Oentsjerk"),
+    ("Paesens", "Peazens"),
+    ("Poppingawier", "Poppenwier"),
+    ("Rauwerd", "Raerd"),
+    ("Roodkerk", "Readtsjerk"),
+    ("Roodhuis", "Reahûs"),
+    ("Roordahuizum", "Reduzum"),
+    ("Rinsumageest", "Rinsumageast"),
+    ("Rijperkerk", "Ryptsjerk"),
+    ("Sijbrandaburen", "Sibrandabuorren"),
+    ("Sijbrandahuis", "Sibrandahûs"),
+    ("Schingen", "Skingen"),
+    ("Suameer", "Sumar"),
+    ("Suawoude", "Suwâld"),
+    ("Zwagerbosch", "Sweagerbosk"),
+    ("Terhorne", "Terherne"),
+    ("Terzool", "Tersoal"),
+    ("Tietjerk", "Tytsjerk"),
+    ("Waaxens", "Waaksens"),
+    ("Wouterswoude", "Wâlterswâld"),
+    ("Wanswerd", "Wânswert"),
+    ("Wartena", "Warten"),
+    ("Warga", "Wergea"),
+    ("Westergeest", "Westergeast"),
+    ("Wieuwerd", "Wiuwert"),
+    ("Welsrijp", "Wjelsryp"),
+    ("Wijns", "Wyns"),
+    ("Wijtgaard", "Wytgaard"),
+    ("IJsbrechtum", "Ysbrechtum"),
+];
+
+/// Returns the official locality name when `input` is a known alias, or `None`
+/// when `input` is not a known alias.
+pub fn replace_locality_alias(input: &str) -> Option<String> {
+    LOCALITY_ALIASES
+        .iter()
+        .find(|(alias, _)| *alias == input)
+        .map(|(_, official)| (*official).to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_official_name_for_known_alias() {
+        assert_eq!(
+            replace_locality_alias("Den Haag").as_deref(),
+            Some("'s-Gravenhage")
+        );
+    }
+
+    #[test]
+    fn returns_none_for_unknown_name() {
+        assert_eq!(replace_locality_alias("'s-Gravenhage"), None);
+        assert_eq!(replace_locality_alias("Amsterdam"), None);
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,6 +2,7 @@
 mod bsn;
 pub mod eks_key;
 pub mod health;
+pub mod locality_aliases;
 pub mod no_cache_headers;
 mod option_string_ext;
 mod query_param_state;


### PR DESCRIPTION
Closes #668

# [DOD](/docs/definition-of-done.md) checklist

## For PR maintainer

Perform these checks before marking the PR as ready:

- [x] I have linked the PR to at least one issue.
- [x] I assigned the PR to myself.
- [x] I have added a description how to test this PR (see "Review Instructions").
- [x] I have added documentation where necessary.

## For reviewer

- I have read all code changes.
- I have audited the code quality.
- I have tested the changes either or both:
  - locally
  - on the test environment (preferred)
- I have validated that the PR is functionally correct (use-cases, figma designs, etc.)

### Review instructions

- Address fields turn green when een postal code - house number lookup was successful
- A single suggestion is shown under localities / place of recidence inputs
- Common aliases (like Den Haag = 's-Gravenhage) are automatically replaced for the official name on submit
- Frisian locality names are not automatically replaced, even when they are not the official locality name
- Municipality names are not suggested for addresses, but are for a place of residence
- When a form with a unknown locality name name is loaded a warning is shown