### PR TITLE
[#679] Show version number and hash in PDF footer

### DIFF
--- a/models/example-inputs/model-h1-example-1.json
+++ b/models/example-inputs/model-h1-example-1.json
@@ -106,6 +106,6 @@
     "second": 21
   },
   "event_id": 42,
-  "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0 9184 446B 5415 8D5D 674A B7BC E92C E98A",
+  "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0",
   "locale": "nl"
 }

--- a/models/example-inputs/model-h1-example-1.json
+++ b/models/example-inputs/model-h1-example-1.json
@@ -105,5 +105,7 @@
     "minute": 32,
     "second": 21
   },
+  "event_id": 42,
+  "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0 9184 446B 5415 8D5D 674A B7BC E92C E98A",
   "locale": "nl"
 }

--- a/models/example-inputs/model-h1-example-2.json
+++ b/models/example-inputs/model-h1-example-2.json
@@ -70,6 +70,6 @@
     "second": 21
   },
   "event_id": 42,
-  "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0 9184 446B 5415 8D5D 674A B7BC E92C E98A",
+  "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0",
   "locale": "fry"
 }

--- a/models/example-inputs/model-h1-example-2.json
+++ b/models/example-inputs/model-h1-example-2.json
@@ -69,6 +69,7 @@
     "minute": 32,
     "second": 21
   },
+  "event_id": 42,
   "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0 9184 446B 5415 8D5D 674A B7BC E92C E98A",
   "locale": "fry"
 }

--- a/models/example-inputs/model-h1-example-3.json
+++ b/models/example-inputs/model-h1-example-3.json
@@ -70,6 +70,6 @@
     "second": 21
   },
   "event_id": 42,
-  "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0 9184 446B 5415 8D5D 674A B7BC E92C E98A",
+  "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0",
   "locale": "nl"
 }

--- a/models/example-inputs/model-h1-example-3.json
+++ b/models/example-inputs/model-h1-example-3.json
@@ -69,6 +69,7 @@
     "minute": 32,
     "second": 21
   },
+  "event_id": 42,
   "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0 9184 446B 5415 8D5D 674A B7BC E92C E98A",
   "locale": "nl"
 }

--- a/models/example-inputs/model-h3-1-example-1.json
+++ b/models/example-inputs/model-h3-1-example-1.json
@@ -63,6 +63,6 @@
     "second": 21
   },
   "event_id": 42,
-  "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0 9184 446B 5415 8D5D 674A B7BC E92C E98A",
+  "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0",
   "locale": "nl"
 }

--- a/models/example-inputs/model-h3-1-example-1.json
+++ b/models/example-inputs/model-h3-1-example-1.json
@@ -62,6 +62,7 @@
     "minute": 32,
     "second": 21
   },
+  "event_id": 42,
   "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0 9184 446B 5415 8D5D 674A B7BC E92C E98A",
   "locale": "nl"
 }

--- a/models/example-inputs/model-h3-1-example-2.json
+++ b/models/example-inputs/model-h3-1-example-2.json
@@ -57,6 +57,7 @@
     "minute": 32,
     "second": 21
   },
+  "event_id": 42,
   "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0 9184 446B 5415 8D5D 674A B7BC E92C E98A",
   "locale": "fry"
 }

--- a/models/example-inputs/model-h3-1-example-2.json
+++ b/models/example-inputs/model-h3-1-example-2.json
@@ -58,6 +58,6 @@
     "second": 21
   },
   "event_id": 42,
-  "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0 9184 446B 5415 8D5D 674A B7BC E92C E98A",
+  "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0",
   "locale": "fry"
 }

--- a/models/example-inputs/model-h3-1-example-3.json
+++ b/models/example-inputs/model-h3-1-example-3.json
@@ -58,6 +58,6 @@
     "second": 21
   },
   "event_id": 42,
-  "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0 9184 446B 5415 8D5D 674A B7BC E92C E98A",
+  "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0",
   "locale": "nl"
 }

--- a/models/example-inputs/model-h3-1-example-3.json
+++ b/models/example-inputs/model-h3-1-example-3.json
@@ -57,6 +57,7 @@
     "minute": 32,
     "second": 21
   },
+  "event_id": 42,
   "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0 9184 446B 5415 8D5D 674A B7BC E92C E98A",
   "locale": "nl"
 }

--- a/models/example-inputs/model-h4-example-1.json
+++ b/models/example-inputs/model-h4-example-1.json
@@ -67,5 +67,7 @@
     "minute": 32,
     "second": 21
   },
+  "event_id": 42,
+  "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0 9184 446B 5415 8D5D 674A B7BC E92C E98A",
   "locale": "nl"
 }

--- a/models/example-inputs/model-h4-example-1.json
+++ b/models/example-inputs/model-h4-example-1.json
@@ -68,6 +68,6 @@
     "second": 21
   },
   "event_id": 42,
-  "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0 9184 446B 5415 8D5D 674A B7BC E92C E98A",
+  "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0",
   "locale": "nl"
 }

--- a/models/example-inputs/model-h4-example-2.json
+++ b/models/example-inputs/model-h4-example-2.json
@@ -67,5 +67,7 @@
     "minute": 32,
     "second": 21
   },
+  "event_id": 42,
+  "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0 9184 446B 5415 8D5D 674A B7BC E92C E98A",
   "locale": "nl"
 }

--- a/models/example-inputs/model-h4-example-2.json
+++ b/models/example-inputs/model-h4-example-2.json
@@ -68,6 +68,6 @@
     "second": 21
   },
   "event_id": 42,
-  "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0 9184 446B 5415 8D5D 674A B7BC E92C E98A",
+  "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0",
   "locale": "nl"
 }

--- a/models/example-inputs/model-h4-example-3.json
+++ b/models/example-inputs/model-h4-example-3.json
@@ -68,6 +68,6 @@
     "second": 21
   },
   "event_id": 42,
-  "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0 9184 446B 5415 8D5D 674A B7BC E92C E98A",
+  "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0",
   "locale": "fry"
 }

--- a/models/example-inputs/model-h4-example-3.json
+++ b/models/example-inputs/model-h4-example-3.json
@@ -67,5 +67,7 @@
     "minute": 32,
     "second": 21
   },
+  "event_id": 42,
+  "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0 9184 446B 5415 8D5D 674A B7BC E92C E98A",
   "locale": "fry"
 }

--- a/models/example-inputs/model-h9-example-1.json
+++ b/models/example-inputs/model-h9-example-1.json
@@ -70,6 +70,7 @@
     "minute": 32,
     "second": 21
   },
+  "event_id": 42,
   "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0 9184 446B 5415 8D5D 674A B7BC E92C E98A",
   "locale": "nl"
 }

--- a/models/example-inputs/model-h9-example-1.json
+++ b/models/example-inputs/model-h9-example-1.json
@@ -71,6 +71,6 @@
     "second": 21
   },
   "event_id": 42,
-  "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0 9184 446B 5415 8D5D 674A B7BC E92C E98A",
+  "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0",
   "locale": "nl"
 }

--- a/models/example-inputs/model-h9-example-2.json
+++ b/models/example-inputs/model-h9-example-2.json
@@ -73,6 +73,7 @@
     "minute": 32,
     "second": 21
   },
+  "event_id": 42,
   "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0 9184 446B 5415 8D5D 674A B7BC E92C E98A",
   "locale": "fry"
 }

--- a/models/example-inputs/model-h9-example-2.json
+++ b/models/example-inputs/model-h9-example-2.json
@@ -74,6 +74,6 @@
     "second": 21
   },
   "event_id": 42,
-  "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0 9184 446B 5415 8D5D 674A B7BC E92C E98A",
+  "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0",
   "locale": "fry"
 }

--- a/models/example-inputs/model-h9-example-3.json
+++ b/models/example-inputs/model-h9-example-3.json
@@ -66,6 +66,6 @@
     "second": 21
   },
   "event_id": 42,
-  "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0 9184 446B 5415 8D5D 674A B7BC E92C E98A",
+  "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0",
   "locale": "nl"
 }

--- a/models/example-inputs/model-h9-example-3.json
+++ b/models/example-inputs/model-h9-example-3.json
@@ -65,6 +65,7 @@
     "minute": 32,
     "second": 21
   },
+  "event_id": 42,
   "sha_hash": "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0 9184 446B 5415 8D5D 674A B7BC E92C E98A",
   "locale": "nl"
 }

--- a/models/layout.typ
+++ b/models/layout.typ
@@ -21,7 +21,11 @@
     gutter: .75em,
     context grid(
       columns: (1fr, auto),
-      [ #muted[Versie:] #mono[#input.event_id] #h(1em) #muted[Hash:] #mono(input.sha_hash) ],
+      [
+        #muted((translator(input.locale))[Versie:][Ferzje:]) #mono[#input.event_id]
+        #h(1em)
+        #muted[Hash:] #mono(input.sha_hash)
+      ],
       counter(page).display(page-label, both: true),
     ),
   )

--- a/models/layout.typ
+++ b/models/layout.typ
@@ -1,5 +1,7 @@
 #let mono(content) = text(font: "Geist Mono", content)
 
+#let muted(content) = text(fill: rgb("888888"), content)
+
 #let highlight_color = rgb("F6F6F6")
 
 #let translator(locale) = (dutch, frisian) => if locale == "nl" { dutch } else { frisian }
@@ -19,10 +21,9 @@
     gutter: .75em,
     context grid(
       columns: (1fr, auto),
-      [#datetime(..input.timestamp).display("[day]-[month]-[year] [hour repr:24]:[minute]:[second]")],
+      [ #muted[Versie:] #mono[#input.event_id] #h(1em) #muted[Hash:] #mono(input.sha_hash) ],
       counter(page).display(page-label, both: true),
     ),
-    align(left, if "sha_hash" in input [ SHA-256:#h(.5em) #mono(input.sha_hash) ]),
   )
 
   #set page(

--- a/src/app/store.rs
+++ b/src/app/store.rs
@@ -193,6 +193,16 @@ impl StoreData for AppStoreData {
     }
 }
 
+impl crate::store::Store<AppStoreData> {
+    pub fn current_event_id(&self) -> usize {
+        self.data.read().last_event_id()
+    }
+
+    pub fn current_event_hash(&self) -> [u8; 32] {
+        self.data.read().last_event_hash()
+    }
+}
+
 #[cfg(test)]
 impl crate::store::Store<AppStoreData> {
     pub fn new_for_test() -> Self {

--- a/src/app/submit/pages/documents.rs
+++ b/src/app/submit/pages/documents.rs
@@ -28,30 +28,23 @@ pub async fn gen_documents(
         return Err(AppError::IncompleteData("No candidate lists"));
     }
 
-    let event_id = store.current_event_id();
-    let event_hash = store.current_event_hash();
-
     let bundles = if list_ids.len() == 1 {
-        let mut bundle =
-            DocumentData::new(&store, &context, list_ids[0], locale, event_id, event_hash)?;
+        let mut bundle = DocumentData::new(&store, &context, list_ids[0], locale)?;
         bundle.folder_name = None;
+
         vec![bundle]
     } else {
         list_ids
             .iter()
-            .map(|&list_id| {
-                DocumentData::new(&store, &context, list_id, locale, event_id, event_hash)
-            })
+            .map(|&list_id| DocumentData::new(&store, &context, list_id, locale))
             .collect::<Result<Vec<_>, _>>()?
     };
 
-    let political_group = store.get_political_group();
-    let designation = political_group
-        .display_name
-        .ok_or(AppError::IncompleteData("Missing political group name"))?;
+    let Some(document_data) = bundles.first() else {
+        return Err(AppError::IncompleteData("No candidate lists"));
+    };
 
-    let filename =
-        DocumentData::archive_filename(&context.election, locale, &designation, event_id);
+    let filename = document_data.archive_filename();
 
     tracing::info!(
         filename,
@@ -329,15 +322,8 @@ mod tests {
         let expected_folders = list_ids
             .iter()
             .map(|&list_id| {
-                DocumentData::new(
-                    &store,
-                    &context,
-                    list_id,
-                    ModelLocale::Nl,
-                    store.current_event_id(),
-                    store.current_event_hash(),
-                )
-                .map(|bundle| bundle.folder_name.expect("folder name"))
+                DocumentData::new(&store, &context, list_id, ModelLocale::Nl)
+                    .map(|bundle| bundle.folder_name.expect("folder name"))
             })
             .collect::<Result<Vec<_>, _>>()?;
         let response = gen_documents(

--- a/src/app/submit/pages/documents.rs
+++ b/src/app/submit/pages/documents.rs
@@ -28,14 +28,20 @@ pub async fn gen_documents(
         return Err(AppError::IncompleteData("No candidate lists"));
     }
 
+    let event_id = store.current_event_id();
+    let event_hash = store.current_event_hash();
+
     let bundles = if list_ids.len() == 1 {
-        let mut bundle = DocumentData::new(&store, &context, list_ids[0], locale)?;
+        let mut bundle =
+            DocumentData::new(&store, &context, list_ids[0], locale, event_id, event_hash)?;
         bundle.folder_name = None;
         vec![bundle]
     } else {
         list_ids
             .iter()
-            .map(|&list_id| DocumentData::new(&store, &context, list_id, locale))
+            .map(|&list_id| {
+                DocumentData::new(&store, &context, list_id, locale, event_id, event_hash)
+            })
             .collect::<Result<Vec<_>, _>>()?
     };
 
@@ -44,9 +50,8 @@ pub async fn gen_documents(
         .display_name
         .ok_or(AppError::IncompleteData("Missing political group name"))?;
 
-    let version = store.get_events().last().map(|e| e.event_id).unwrap_or(0);
-
-    let filename = DocumentData::archive_filename(&context.election, locale, &designation, version);
+    let filename =
+        DocumentData::archive_filename(&context.election, locale, &designation, event_id);
 
     tracing::info!(
         filename,
@@ -324,8 +329,15 @@ mod tests {
         let expected_folders = list_ids
             .iter()
             .map(|&list_id| {
-                DocumentData::new(&store, &context, list_id, ModelLocale::Nl)
-                    .map(|bundle| bundle.folder_name.expect("folder name"))
+                DocumentData::new(
+                    &store,
+                    &context,
+                    list_id,
+                    ModelLocale::Nl,
+                    store.current_event_id(),
+                    store.current_event_hash(),
+                )
+                .map(|bundle| bundle.folder_name.expect("folder name"))
             })
             .collect::<Result<Vec<_>, _>>()?;
         let response = gen_documents(

--- a/src/app/submit/structs/documents.rs
+++ b/src/app/submit/structs/documents.rs
@@ -19,7 +19,7 @@ use crate::{
             typst_person::TypstPerson,
         },
     },
-    utils::slugify_teletex,
+    utils::{format_hash, slugify_teletex},
 };
 
 pub struct DocumentData {
@@ -37,6 +37,8 @@ pub struct DocumentData {
     pub list_submitter: TypstPerson,
     pub substitute_submitters: Vec<TypstPerson>,
     pub authorised_agent: TypstAuthorisedAgent,
+    pub event_id: usize,
+    pub event_hash: String,
     nomination: Eml210,
 }
 
@@ -69,6 +71,8 @@ impl DocumentData {
         context: &Context,
         list_id: CandidateListId,
         locale: ModelLocale,
+        event_id: usize,
+        event_hash: [u8; 32],
     ) -> Result<Self, AppError> {
         let election = context.election;
         if !election.frisian_export_allowed() && locale == ModelLocale::Fry {
@@ -150,6 +154,8 @@ impl DocumentData {
             list_submitter,
             substitute_submitters,
             authorised_agent,
+            event_id,
+            event_hash: format_hash(&event_hash, true),
             nomination,
         })
     }

--- a/src/app/submit/structs/documents.rs
+++ b/src/app/submit/structs/documents.rs
@@ -43,19 +43,15 @@ pub struct DocumentData {
 }
 
 impl DocumentData {
-    pub fn archive_filename(
-        election: &ElectionConfig,
-        locale: ModelLocale,
-        designation: &str,
-        version: usize,
-    ) -> String {
-        let name_slug = slugify_teletex(designation, true);
-        let mut election_slug = election.code().to_lowercase();
-        if let Some(region) = election.region_code() {
+    pub fn archive_filename(&self) -> String {
+        let name_slug = slugify_teletex(&self.designation, true);
+        let mut election_slug = self.election.code().to_lowercase();
+        if let Some(region) = self.election.region_code() {
             election_slug.push_str(&region.to_lowercase());
         }
+        let version = self.event_id;
 
-        if locale == ModelLocale::Fry {
+        if self.locale == ModelLocale::Fry {
             format!("{name_slug}-{election_slug}-v{version}-fry.zip")
         } else {
             format!("{name_slug}-{election_slug}-v{version}.zip")
@@ -71,8 +67,6 @@ impl DocumentData {
         context: &Context,
         list_id: CandidateListId,
         locale: ModelLocale,
-        event_id: usize,
-        event_hash: [u8; 32],
     ) -> Result<Self, AppError> {
         let election = context.election;
         if !election.frisian_export_allowed() && locale == ModelLocale::Fry {
@@ -80,6 +74,9 @@ impl DocumentData {
                 "Frisian export not allowed for this election".to_string(),
             ));
         }
+
+        let event_id = store.current_event_id();
+        let event_hash = store.current_event_hash();
 
         let FullCandidateList {
             list,

--- a/src/app/submit/structs/eml210.rs
+++ b/src/app/submit/structs/eml210.rs
@@ -26,7 +26,6 @@ use crate::{
     list_submitters::ListSubmitter,
     persons::Representative,
     political_groups::PoliticalGroup,
-    store::StoreData,
     utils::slugify_teletex,
 };
 
@@ -293,7 +292,7 @@ impl Eml210 {
         let now = chrono::Utc::now();
         let nomination = Nomination::builder()
             .transaction_id(
-                u64::try_from(store.data.read().last_event_id())
+                u64::try_from(store.current_event_id())
                     .map_err(|_| AppError::InternalServerError)?,
             )
             .managing_authority(

--- a/src/app/submit/structs/h1.rs
+++ b/src/app/submit/structs/h1.rs
@@ -19,6 +19,8 @@ pub struct H1<'a> {
     substitute_submitters: &'a Vec<TypstPerson>,
     timestamp: &'a TypstDatetime,
     locale: ModelLocale,
+    event_id: usize,
+    sha_hash: &'a str,
     filename: &'static str,
 }
 
@@ -53,6 +55,8 @@ impl<'a> From<&'a DocumentData> for H1<'a> {
             substitute_submitters: &data.substitute_submitters,
             timestamp: &data.timestamp,
             locale,
+            event_id: data.event_id,
+            sha_hash: &data.event_hash,
             filename,
         }
     }

--- a/src/app/submit/structs/h3_1.rs
+++ b/src/app/submit/structs/h3_1.rs
@@ -22,6 +22,8 @@ pub struct H31<'a> {
     authorised_agent: &'a TypstAuthorisedAgent,
     timestamp: &'a TypstDatetime,
     locale: ModelLocale,
+    event_id: usize,
+    sha_hash: &'a str,
     filename: &'static str,
 }
 
@@ -56,6 +58,8 @@ impl<'a> From<&'a DocumentData> for H31<'a> {
             authorised_agent: &data.authorised_agent,
             timestamp: &data.timestamp,
             locale,
+            event_id: data.event_id,
+            sha_hash: &data.event_hash,
             filename,
         }
     }

--- a/src/app/submit/structs/h4.rs
+++ b/src/app/submit/structs/h4.rs
@@ -16,6 +16,8 @@ pub struct H4<'a> {
     candidates: &'a Vec<TypstCandidate>,
     timestamp: &'a TypstDatetime,
     locale: ModelLocale,
+    event_id: usize,
+    sha_hash: &'a str,
     filename: &'static str,
 }
 
@@ -46,6 +48,8 @@ impl<'a> From<&'a DocumentData> for H4<'a> {
             candidates: &data.ordered_candidates,
             timestamp: &data.timestamp,
             locale,
+            event_id: data.event_id,
+            sha_hash: &data.event_hash,
             filename,
         }
     }

--- a/src/app/submit/structs/h9.rs
+++ b/src/app/submit/structs/h9.rs
@@ -22,6 +22,8 @@ pub struct H9<'a> {
     detailed_candidate: &'a TypstDetailedCandidate,
     timestamp: &'a TypstDatetime,
     locale: ModelLocale,
+    event_id: usize,
+    sha_hash: &'a str,
     filename: String,
 }
 
@@ -55,6 +57,8 @@ impl<'a> From<(&'a DocumentData, &'a TypstDetailedCandidate)> for H9<'a> {
             detailed_candidate: candidate,
             timestamp: &data.timestamp,
             locale,
+            event_id: data.event_id,
+            sha_hash: &data.event_hash,
             filename,
         }
     }

--- a/src/utils/format_hash.rs
+++ b/src/utils/format_hash.rs
@@ -1,0 +1,53 @@
+/// Format a hash as uppercase hex with a space after every 4 characters.
+pub fn format_hash(hash: &[u8], half: bool) -> String {
+    let bytes = if half { &hash[..hash.len() / 2] } else { hash };
+    let mut out = String::with_capacity(bytes.len() * 2 + bytes.len() / 2);
+    for (i, byte) in bytes.iter().enumerate() {
+        if i > 0 && i % 2 == 0 {
+            out.push(' ');
+        }
+        out.push_str(&format!("{byte:02X}"));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn formats_32_byte_hash_with_spaces_every_4_chars() {
+        let hash: [u8; 32] = [
+            0xF3, 0x81, 0x3D, 0xE7, 0x96, 0xD3, 0x80, 0x33, 0xFA, 0xF5, 0x8D, 0x2C, 0xE6, 0x94,
+            0x61, 0xF0, 0x91, 0x84, 0x44, 0x6B, 0x54, 0x15, 0x8D, 0x5D, 0x67, 0x4A, 0xB7, 0xBC,
+            0xE9, 0x2C, 0xE9, 0x8A,
+        ];
+        assert_eq!(
+            format_hash(&hash, false),
+            "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0 9184 446B 5415 8D5D 674A B7BC E92C E98A"
+        );
+    }
+
+    #[test]
+    fn formats_half_of_32_byte_hash() {
+        let hash: [u8; 32] = [
+            0xF3, 0x81, 0x3D, 0xE7, 0x96, 0xD3, 0x80, 0x33, 0xFA, 0xF5, 0x8D, 0x2C, 0xE6, 0x94,
+            0x61, 0xF0, 0x91, 0x84, 0x44, 0x6B, 0x54, 0x15, 0x8D, 0x5D, 0x67, 0x4A, 0xB7, 0xBC,
+            0xE9, 0x2C, 0xE9, 0x8A,
+        ];
+        assert_eq!(
+            format_hash(&hash, true),
+            "F381 3DE7 96D3 8033 FAF5 8D2C E694 61F0"
+        );
+    }
+
+    #[test]
+    fn empty_hash_produces_empty_string() {
+        assert_eq!(format_hash(&[], false), "");
+    }
+
+    #[test]
+    fn single_byte_has_no_trailing_space() {
+        assert_eq!(format_hash(&[0xAB], false), "AB");
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,6 +1,7 @@
 //! Utilities and small helpers shared across the application.
 mod bsn;
 pub mod eks_key;
+mod format_hash;
 pub mod health;
 pub mod no_cache_headers;
 mod option_string_ext;
@@ -27,6 +28,7 @@ pub mod embed_bag;
 pub mod test_utils;
 
 pub use bsn::random_bsn;
+pub use format_hash::format_hash;
 pub use no_cache_headers::generate_attachment_headers;
 pub use option_string_ext::{OptionAsStrExt, OptionStringExt};
 pub use query_param_state::QueryParamState;


### PR DESCRIPTION
Closes #679

# [DOD](/docs/definition-of-done.md) checklist

This shows the an identifiable portion of the even hash and the event number in the footer of all documents.

## For PR maintainer

Perform these checks before marking the PR as ready:

- [x] I have linked the PR to at least one issue.
- [x] I assigned the PR to myself.
- [x] I have added a description how to test this PR (see "Review Instructions").
- [x] I have added documentation where necessary.

## For reviewer

- I have read all code changes.
- I have audited the code quality.
- I have tested the changes either or both:
  - locally
  - on the test environment (preferred)
- I have validated that the PR is functionally correct (use-cases, figma designs, etc.)

### Review instructions

See the footer of PDF files:

<img width="1898" height="360" alt="image" src="https://github.com/user-attachments/assets/e11f8a9d-5803-40d8-8483-ceaef152e67b" />
