### PR TITLE
[#522] Show what warnings/errors in candidate lists are for

### DIFF
--- a/locales/en/person.yml
+++ b/locales/en/person.yml
@@ -36,7 +36,6 @@ hints:
   optional: optional
 list:
   empty: No persons found.
-missing_information: Not all required information has been provided for this person.
 no_bsn_confirm: I confirm this person does not have a BSN.
 not_found: "Person {} not found."
 not_found_in_candidate_list: Person not found in candidate list.

--- a/locales/nl/person.yml
+++ b/locales/nl/person.yml
@@ -36,7 +36,6 @@ hints:
   optional: optioneel
 list:
   empty: Geen kandidaten gevonden.
-missing_information: Niet alle vereiste informatie is ingevuld voor deze kandidaat.
 no_bsn_confirm: Ik bevestig dat deze persoon geen BSN heeft.
 not_found: "Persoon {} niet gevonden."
 not_found_in_candidate_list: Kandidaat niet gevonden in kandidatenlijst.

--- a/src/app/candidate_lists/components/candidates_table.html
+++ b/src/app/candidate_lists/components/candidates_table.html
@@ -35,7 +35,7 @@
         <td>
           <a href="{{ candidate.update_position_path() }}"
              aria-label="{{ "action.edit"|trans }}"
-             title="{% if !candidate.person.is_all_good() %}{{ "person.missing_information"|trans }}{% endif %}">
+             {% if let Some(summary) = candidate.person.problem_summary(locale) %}title="{{ summary }}"{% endif %}>
             <span>{{ "action.edit"|trans }}</span>
           </a>
         </td>

--- a/src/app/common/structs/mod.rs
+++ b/src/app/common/structs/mod.rs
@@ -16,7 +16,7 @@ mod locality;
 mod name;
 mod postal_code;
 mod previous_election_results;
-mod problems;
+mod problematic;
 mod utc_date_time;
 
 pub use address::{Address, DutchAddress, InternationalAddress};
@@ -37,5 +37,5 @@ pub use locality::{Locality, PlaceOfResidence};
 pub use name::FullName;
 pub use postal_code::{InternationalPostalCode, PostalCode};
 pub use previous_election_results::PreviousElectionResults;
-pub use problems::{PotentialProblems, Problematic, Severity};
+pub use problematic::{PotentialProblems, Problematic, Severity};
 pub use utc_date_time::UtcDateTime;

--- a/src/app/common/structs/problematic.rs
+++ b/src/app/common/structs/problematic.rs
@@ -270,3 +270,65 @@ impl PotentialProblems {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct WithProblems(Vec<PotentialProblems>);
+
+    impl Problematic for WithProblems {
+        fn get_problems(&self) -> Vec<PotentialProblems> {
+            self.0.clone()
+        }
+    }
+
+    #[test]
+    fn severity_order() {
+        assert!(Severity::Info < Severity::Warn);
+        assert!(Severity::Warn < Severity::Error);
+    }
+
+    #[test]
+    fn highest_severity_none_when_no_problems() {
+        let no_problems = WithProblems(vec![]);
+        assert_eq!(no_problems.highest_severity(), None);
+        assert!(!no_problems.has_severity_or_higher(Severity::Info));
+        assert!(!no_problems.has_severity_or_higher(Severity::Warn));
+        assert!(!no_problems.has_severity_or_higher(Severity::Error));
+    }
+
+    #[test]
+    fn highest_severity_info_when_only_info() {
+        let only_info = WithProblems(vec![PotentialProblems::NoLastName(Severity::Info)]);
+        assert_eq!(only_info.highest_severity(), Some(Severity::Info));
+        assert!(only_info.has_severity_or_higher(Severity::Info));
+        assert!(!only_info.has_severity_or_higher(Severity::Warn));
+        assert!(!only_info.has_severity_or_higher(Severity::Error));
+    }
+
+    #[test]
+    fn highest_severity_warn_when_only_warnings() {
+        let info_warn = WithProblems(vec![
+            PotentialProblems::NoLastName(Severity::Info),
+            PotentialProblems::NoLastName(Severity::Warn),
+        ]);
+        assert_eq!(info_warn.highest_severity(), Some(Severity::Warn));
+        assert!(info_warn.has_severity_or_higher(Severity::Info));
+        assert!(info_warn.has_severity_or_higher(Severity::Warn));
+        assert!(!info_warn.has_severity_or_higher(Severity::Error));
+    }
+
+    #[test]
+    fn highest_severity_error_when_mix_of_severities() {
+        let with_error = WithProblems(vec![
+            PotentialProblems::NoLastName(Severity::Info),
+            PotentialProblems::NoLastName(Severity::Warn),
+            PotentialProblems::NoLastName(Severity::Error),
+        ]);
+        assert_eq!(with_error.highest_severity(), Some(Severity::Error));
+        assert!(with_error.has_severity_or_higher(Severity::Info));
+        assert!(with_error.has_severity_or_higher(Severity::Warn));
+        assert!(with_error.has_severity_or_higher(Severity::Error));
+    }
+}

--- a/src/app/common/structs/problematic.rs
+++ b/src/app/common/structs/problematic.rs
@@ -293,18 +293,22 @@ mod tests {
     fn highest_severity_none_when_no_problems() {
         let no_problems = WithProblems(vec![]);
         assert_eq!(no_problems.highest_severity(), None);
+        assert_eq!(no_problems.highest_severity_class(), "ok");
         assert!(!no_problems.has_severity_or_higher(Severity::Info));
         assert!(!no_problems.has_severity_or_higher(Severity::Warn));
         assert!(!no_problems.has_severity_or_higher(Severity::Error));
+        assert!(no_problems.is_all_good());
     }
 
     #[test]
     fn highest_severity_info_when_only_info() {
         let only_info = WithProblems(vec![PotentialProblems::NoLastName(Severity::Info)]);
         assert_eq!(only_info.highest_severity(), Some(Severity::Info));
+        assert_eq!(only_info.highest_severity_class(), "info");
         assert!(only_info.has_severity_or_higher(Severity::Info));
         assert!(!only_info.has_severity_or_higher(Severity::Warn));
         assert!(!only_info.has_severity_or_higher(Severity::Error));
+        assert!(!only_info.is_all_good());
     }
 
     #[test]
@@ -314,9 +318,11 @@ mod tests {
             PotentialProblems::NoLastName(Severity::Warn),
         ]);
         assert_eq!(info_warn.highest_severity(), Some(Severity::Warn));
+        assert_eq!(info_warn.highest_severity_class(), "warning");
         assert!(info_warn.has_severity_or_higher(Severity::Info));
         assert!(info_warn.has_severity_or_higher(Severity::Warn));
         assert!(!info_warn.has_severity_or_higher(Severity::Error));
+        assert!(!info_warn.is_all_good());
     }
 
     #[test]
@@ -327,8 +333,84 @@ mod tests {
             PotentialProblems::NoLastName(Severity::Error),
         ]);
         assert_eq!(with_error.highest_severity(), Some(Severity::Error));
+        assert_eq!(with_error.highest_severity_class(), "error");
         assert!(with_error.has_severity_or_higher(Severity::Info));
         assert!(with_error.has_severity_or_higher(Severity::Warn));
         assert!(with_error.has_severity_or_higher(Severity::Error));
+        assert!(!with_error.is_all_good());
+    }
+
+    #[test]
+    fn no_problem_summary() {
+        let no_problems = WithProblems(vec![]);
+        assert_eq!(no_problems.problem_summary(&Locale::Nl), None);
+    }
+
+    #[test]
+    fn single_problem_summary() {
+        let problem = PotentialProblems::VeryOldDateOfBirth;
+        let single_problems = WithProblems(vec![problem.clone()]);
+        assert_eq!(
+            single_problems.problem_summary(&Locale::Nl).unwrap(),
+            problem.translate(&Locale::Nl)
+        );
+    }
+
+    #[test]
+    fn multiple_problem_summary() {
+        let problems = [
+            PotentialProblems::NoBsn,
+            PotentialProblems::NoPlaceOfResidence,
+            PotentialProblems::NoDateOfBirth,
+            PotentialProblems::RepresentativeProblem(Box::new(PotentialProblems::NoPostalCode(
+                Severity::Warn,
+            ))),
+            PotentialProblems::RepresentativeProblem(Box::new(PotentialProblems::NoLocality(
+                Severity::Warn,
+            ))),
+            PotentialProblems::RepresentativeProblem(Box::new(PotentialProblems::NoCountry(
+                Severity::Warn,
+            ))),
+            PotentialProblems::RepresentativeProblem(Box::new(PotentialProblems::NoHouseNumber(
+                Severity::Warn,
+            ))),
+            PotentialProblems::RepresentativeProblem(Box::new(PotentialProblems::NoStreetName(
+                Severity::Warn,
+            ))),
+        ];
+        let multiple_problems = WithProblems(problems.to_vec());
+        let summary = multiple_problems.problem_summary(&Locale::Nl).unwrap();
+        for problem in problems {
+            assert!(summary.contains(&problem.translate(&Locale::Nl)));
+        }
+    }
+
+    #[test]
+    fn deviation_shows_numbers() {
+        let problems = vec![
+            PotentialProblems::FewCandidatesWithFirstName {
+                count: 2,
+                total: 37,
+            },
+            PotentialProblems::FewCandidatesWithGender {
+                count: 2,
+                total: 37,
+            },
+            PotentialProblems::FewCandidatesWithoutFirstName {
+                count: 2,
+                total: 37,
+            },
+            PotentialProblems::FewCandidatesWithoutGender {
+                count: 2,
+                total: 37,
+            },
+        ];
+        for problem in problems {
+            let summary = WithProblems(vec![problem])
+                .problem_summary(&Locale::Nl)
+                .unwrap();
+            assert!(summary.contains("2"));
+            assert!(summary.contains("37"));
+        }
     }
 }

--- a/src/app/common/structs/problems.rs
+++ b/src/app/common/structs/problems.rs
@@ -45,6 +45,23 @@ pub trait Problematic {
     fn has_severity_or_higher(&self, severity: Severity) -> bool {
         self.get_problems().iter().any(|p| p.severity() >= severity)
     }
+
+    /// Get a summary of the potential problems, if any
+    fn problem_summary(&self, locale: &Locale) -> Option<String> {
+        let problems = self.get_problems();
+
+        if problems.is_empty() {
+            return None;
+        }
+
+        Some(
+            problems
+                .iter()
+                .map(|p| p.translate(locale))
+                .collect::<Vec<_>>()
+                .join(", "),
+        )
+    }
 }
 
 #[derive(Clone, PartialEq, Debug)]

--- a/src/app/persons/components/person_table.html
+++ b/src/app/persons/components/person_table.html
@@ -54,7 +54,7 @@
         <td>
           <a href="{{ person.update_path() }}"
              aria-label="{{ "action.edit"|trans }}"
-             title="{% if !person.is_all_good() %}{{ "person.missing_information"|trans }}{% endif %}">
+             {% if let Some(summary) = person.problem_summary(locale) %}title="{{ summary }}"{% endif %}>
             <span>{{ "action.edit"|trans }}</span>
           </a>
         </td>

--- a/src/app/submit/mod.rs
+++ b/src/app/submit/mod.rs
@@ -7,5 +7,5 @@ mod structs;
 pub use pages::{SubmitPath, router};
 pub use structs::{
     documents::DocumentData,
-    potential_problems::{GeneralProblems, ListProblems, PersonProblems, Problems},
+    problems::{GeneralProblems, ListProblems, PersonProblems, Problems},
 };

--- a/src/app/submit/structs/mod.rs
+++ b/src/app/submit/structs/mod.rs
@@ -4,7 +4,7 @@ pub mod h1;
 pub mod h3_1;
 pub mod h4;
 pub mod h9;
-pub mod potential_problems;
+pub mod problems;
 mod typst_authorised_agent;
 pub mod typst_candidate;
 mod typst_datetime;

--- a/src/app/submit/structs/problems.rs
+++ b/src/app/submit/structs/problems.rs
@@ -193,7 +193,6 @@ pub struct ListProblems {
 mod tests {
     use crate::{
         candidate_lists::CandidateListId,
-        common::Severity,
         persons::PersonId,
         test_utils::{sample_candidate_list, sample_person},
     };
@@ -207,63 +206,6 @@ mod tests {
             list_submitter: Vec::new(),
             substitute_submitters: Vec::new(),
         }
-    }
-
-    struct WithProblems(Vec<PotentialProblems>);
-
-    impl Problematic for WithProblems {
-        fn get_problems(&self) -> Vec<PotentialProblems> {
-            self.0.clone()
-        }
-    }
-
-    #[test]
-    fn severity_order() {
-        assert!(Severity::Info < Severity::Warn);
-        assert!(Severity::Warn < Severity::Error);
-    }
-
-    #[test]
-    fn highest_severity_none_when_no_problems() {
-        let no_problems = WithProblems(vec![]);
-        assert_eq!(no_problems.highest_severity(), None);
-        assert!(!no_problems.has_severity_or_higher(Severity::Info));
-        assert!(!no_problems.has_severity_or_higher(Severity::Warn));
-        assert!(!no_problems.has_severity_or_higher(Severity::Error));
-    }
-
-    #[test]
-    fn highest_severity_info_when_only_info() {
-        let only_info = WithProblems(vec![PotentialProblems::NoLastName(Severity::Info)]);
-        assert_eq!(only_info.highest_severity(), Some(Severity::Info));
-        assert!(only_info.has_severity_or_higher(Severity::Info));
-        assert!(!only_info.has_severity_or_higher(Severity::Warn));
-        assert!(!only_info.has_severity_or_higher(Severity::Error));
-    }
-
-    #[test]
-    fn highest_severity_warn_when_only_warnings() {
-        let info_warn = WithProblems(vec![
-            PotentialProblems::NoLastName(Severity::Info),
-            PotentialProblems::NoLastName(Severity::Warn),
-        ]);
-        assert_eq!(info_warn.highest_severity(), Some(Severity::Warn));
-        assert!(info_warn.has_severity_or_higher(Severity::Info));
-        assert!(info_warn.has_severity_or_higher(Severity::Warn));
-        assert!(!info_warn.has_severity_or_higher(Severity::Error));
-    }
-
-    #[test]
-    fn highest_severity_error_when_mix_of_severities() {
-        let with_error = WithProblems(vec![
-            PotentialProblems::NoLastName(Severity::Info),
-            PotentialProblems::NoLastName(Severity::Warn),
-            PotentialProblems::NoLastName(Severity::Error),
-        ]);
-        assert_eq!(with_error.highest_severity(), Some(Severity::Error));
-        assert!(with_error.has_severity_or_higher(Severity::Info));
-        assert!(with_error.has_severity_or_higher(Severity::Warn));
-        assert!(with_error.has_severity_or_higher(Severity::Error));
     }
 
     #[test]


### PR DESCRIPTION
Closes #522

# [DOD](/docs/definition-of-done.md) checklist

## For PR maintainer

Perform these checks before marking the PR as ready:

- [x] I have linked the PR to at least one issue.
- [x] I assigned the PR to myself.
- [x] I have added a description how to test this PR (see "Review Instructions").
- [x] I have added documentation where necessary.

## For reviewer

- I have read all code changes.
- I have audited the code quality.
- I have tested the changes either or both:
  - locally
  - on the test environment (preferred)
- I have validated that the PR is functionally correct (use-cases, figma designs, etc.)

### Review instructions

Hover over the error/warning icons in the candidate/person table, it should display what the problem is, e.g.:

<img width="186" height="108" alt="image" src="https://github.com/user-attachments/assets/a680a28e-83a6-4eec-84bb-1cd3f11b9fca" />