### PR TITLE
[#719, #720, #722, #724] Combinations/blank general data

### DIFF
--- a/frontend/index.ts
+++ b/frontend/index.ts
@@ -2,6 +2,7 @@ import bsnInput from "./scripts/form-inputs/bsn-input";
 import countryCodeInput from "./scripts/form-inputs/country-input";
 import dateInput from "./scripts/form-inputs/date-input";
 import electionRegion from "./scripts/form-inputs/election-region";
+import listDesignation from "./scripts/form-inputs/list-designation";
 import setupFileImport from "./scripts/form-inputs/file-import";
 import initialsInput from "./scripts/form-inputs/initials-input";
 import localitySuggestions from "./scripts/form-inputs/locality-suggestions";
@@ -41,6 +42,7 @@ localitySuggestions();
 setupPositionPreview();
 setupSelectAllCheckbox();
 electionRegion();
+listDesignation();
 
 // generic UI
 setupStickyNav();

--- a/frontend/scripts/form-inputs/list-designation.ts
+++ b/frontend/scripts/form-inputs/list-designation.ts
@@ -1,0 +1,25 @@
+function updateSkippedSteps(isBlank: boolean) {
+  document
+    .querySelectorAll<HTMLAnchorElement>("[data-skip-if-blank]")
+    .forEach((link) => {
+      if (isBlank) {
+        link.removeAttribute("href");
+        link.className = "disabled";
+      } else {
+        if (link.dataset.href) link.href = link.dataset.href;
+        link.className = link.dataset.stateClass ?? "";
+      }
+    });
+}
+
+export default function listDesignation() {
+  const inputs = document.querySelectorAll<HTMLInputElement>(
+    'input[name="list_designation_type"]',
+  );
+
+  inputs.forEach((input) => {
+    input.addEventListener("change", () => {
+      updateSkippedSteps(input.value === "blank" && input.checked);
+    });
+  });
+}

--- a/frontend/scripts/form-inputs/list-designation.ts
+++ b/frontend/scripts/form-inputs/list-designation.ts
@@ -12,6 +12,16 @@ function updateSkippedSteps(isBlank: boolean) {
     });
 }
 
+function updateStepLabels(isCombined: boolean) {
+  document
+    .querySelectorAll<HTMLAnchorElement>("[data-label-combined]")
+    .forEach((link) => {
+      link.textContent = isCombined
+        ? (link.dataset.labelCombined ?? "")
+        : (link.dataset.label ?? "");
+    });
+}
+
 export default function listDesignation() {
   const inputs = document.querySelectorAll<HTMLInputElement>(
     'input[name="list_designation_type"]',
@@ -20,6 +30,7 @@ export default function listDesignation() {
   inputs.forEach((input) => {
     input.addEventListener("change", () => {
       updateSkippedSteps(input.value === "blank" && input.checked);
+      updateStepLabels(input.value === "combined" && input.checked);
     });
   });
 }

--- a/locales/en/political_group.yml
+++ b/locales/en/political_group.yml
@@ -8,6 +8,7 @@ authorised_agent: Authorised agent
 authorised_agent_data: (Deputy) authorised agent data
 authorised_agent_info: An authorised representative or deputy representative for the party designation is registered with the central electoral committee. This person grants the person submitting the list permission to place the party name above the candidate list. This is done using form H 3-1 or H 3-2.
 basic_information_political_group: Political group data
+blank_list_warning: You are using a blank list. Any changes made here will have no effect.
 delete_name_authorisation_warning_text: Are you sure you want to delete this Statutory name authorisation? This action cannot be undone.
 delete_substitute_submitter_warning_text: Are you sure you want to delete this substitute submitter? This action cannot be undone.
 display_name: Registered designation

--- a/locales/en/political_group.yml
+++ b/locales/en/political_group.yml
@@ -12,12 +12,13 @@ blank_list_warning: You are using a blank list. Any changes made here will have 
 delete_name_authorisation_warning_text: Are you sure you want to delete this Statutory name authorisation? This action cannot be undone.
 delete_substitute_submitter_warning_text: Are you sure you want to delete this substitute submitter? This action cannot be undone.
 display_name: Registered designation
+display_name_combined: Combined designation
 edit_legal_name: Edit statutory name authorisation
 edit_list_submitter: Edit list submitter
 edit_substitute_submitter: Edit substitute submitter
-general_information: General
 legal_name: Full statutory name
 legal_name_data: Statutory name authorisation
+legal_name_data_combined: Statutory name authorisations
 list_submitter: List submitter
 list_submitter_address_info: This address will be used to send the notice of omissions
 list_submitter_data: List submitter data
@@ -35,11 +36,14 @@ title: Political group
 type:
   blank_name: Blank list
   blank_name_hint: There is no registered designation.
+  display_name_combined_hint: The name formed by combining the designations of political groups or abbreviations thereof. This name will be displayed on the ballot paper.
   display_name_hint: The name that is registered with the central electoral committee. This name will be displayed on the ballot paper.
   legal_name_hint: The name registered in the notarial deed and with the Chamber of Commerce.
   name_combination: Combination of multiple registered names
   name_combination_hint: "The party has formed an alliance with one or more other registered parties. Together, they nominate all candidates for the candidate list."
   one_to_fifteen_seats: 1 to 15 seats
+  previous_election_results_combined: "In the previous {}, one of the parties in the combination, or the combination as a whole, obtained:"
+  previous_election_results_combined_hint: "If the combination participated separately in the previous election, choose the highest individual obtained result."
   previous_election_results_hint: "This determines whether a deposit needs to be paid, and whether you may include 50 or 80 candidates on each list."
   registered_name: Standalone registered name
   registered_name_hint: "The party participates in the election as a single, unified party."

--- a/locales/en/political_group.yml
+++ b/locales/en/political_group.yml
@@ -7,7 +7,7 @@ add_substitute_submitter: Add substitute submitter
 authorised_agent: Authorised agent
 authorised_agent_data: (Deputy) authorised agent data
 authorised_agent_info: An authorised representative or deputy representative for the party designation is registered with the central electoral committee. This person grants the person submitting the list permission to place the party name above the candidate list. This is done using form H 3-1 or H 3-2.
-basic_information_political_group: Information political group
+basic_information_political_group: Political group data
 delete_name_authorisation_warning_text: Are you sure you want to delete this Statutory name authorisation? This action cannot be undone.
 delete_substitute_submitter_warning_text: Are you sure you want to delete this substitute submitter? This action cannot be undone.
 display_name: Registered designation

--- a/locales/nl/political_group.yml
+++ b/locales/nl/political_group.yml
@@ -12,12 +12,13 @@ blank_list_warning: U gebruikt een blanco lijst. Wijzigingen die u hier maakt he
 delete_name_authorisation_warning_text: Weet u zeker dat u de machtiging voor deze statutaire naam wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.
 delete_substitute_submitter_warning_text: Weet u zeker dat u deze vervanger voor het herstel van verzuimen wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.
 display_name: Geregistreerde aanduiding
+display_name_combined: Samengevoegde aanduiding
 edit_legal_name: Machtiging statutaire naam aanpassen
 edit_list_submitter: Gegevens lijstinleveraar aanpassen
 edit_substitute_submitter: Gegevens vervangers voor het herstel van verzuimen aanpassen
-general_information: Algemeen
 legal_name: Volledige statutaire naam
 legal_name_data: Machtiging statutaire naam
+legal_name_data_combined: Machtigingen statutaire namen
 list_submitter: Lijstinleveraar
 list_submitter_address_info: Naar dit adres wordt de verzuimbrief verstuurd
 list_submitter_data: Gegevens lijstinleveraar
@@ -35,11 +36,14 @@ title: Politieke groepering
 type:
   blank_name: Blanco lijst
   blank_name_hint: Er is geen geregistreerde aanduiding.
+  display_name_combined_hint: De naam die is gevormd door samenvoeging van de aanduidingen van politieke groeperingen of afkortingen daarvan. Deze komt op het stembiljet te staan.
   display_name_hint: De naam die is geregistreerd bij het centraal stembureau. Deze komt op het stembiljet te staan.
   legal_name_hint: De naam die is vastgelegd in de notariële akte en bij de Kamer van Koophandel.
   name_combination: Combinatie van meerdere geregistreerde namen
   name_combination_hint: De partij heeft een samenwerkingsverband met één of meer andere geregistreerde partijen. Samen leveren zij alle kandidaten voor de kandidatenlijst.
   one_to_fifteen_seats: 1 tot 15 zetels
+  previous_election_results_combined: "Bij de vorige {} had één van de partijen in de combinatie, of de combinatie als geheel:"
+  previous_election_results_combined_hint: "Indien de combinatie bij de vorige verkiezing los heeft meegedaan, kies het maximaal behaalde individuele resultaat."
   previous_election_results_hint: "Dit bepaalt of uw partij een waarborgsom moet betalen, en of u 50 of 80 kandidaten per lijst op mag voeren."
   registered_name: Op zichzelf staande geregistreerde naam
   registered_name_hint: De partij neemt als één eenduidige partij deel aan de verkiezing.

--- a/locales/nl/political_group.yml
+++ b/locales/nl/political_group.yml
@@ -8,6 +8,7 @@ authorised_agent: Gemachtigde
 authorised_agent_data: Gegevens (plv.) gemachtigde
 authorised_agent_info: Bij het centraal stembureau is een gemachtigde of plaatsvervangend gemachtigde voor de aanduiding geregistreerd. Deze persoon geeft de lijstinleveraar toestemming om de naam van de partij boven de kandidatenlijst te plaatsen. Dit gebeurt met formulier H 3-1 of H 3-2.
 basic_information_political_group: Gegevens politieke groepering
+blank_list_warning: U gebruikt een blanco lijst. Wijzigingen die u hier maakt hebben geen effect.
 delete_name_authorisation_warning_text: Weet u zeker dat u de machtiging voor deze statutaire naam wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.
 delete_substitute_submitter_warning_text: Weet u zeker dat u deze vervanger voor het herstel van verzuimen wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.
 display_name: Geregistreerde aanduiding

--- a/src/app/list_designation/components/form.html
+++ b/src/app/list_designation/components/form.html
@@ -1,9 +1,8 @@
 <div>
   <input type="hidden" name="csrf_token" value="{{ form.data.csrf_token }}">
-  <h3>{{ "political_group.general_information"|trans }}</h3>
+  <h2>{{ "political_group.list_type"|trans }}</h2>
   <div class="form-row">
     <fieldset class="checklist">
-      <legend>{{ "political_group.list_type"|trans }}</legend>
       <div class="checkbox">
         <input type="radio"
                required

--- a/src/app/list_designation/pages/update.rs
+++ b/src/app/list_designation/pages/update.rs
@@ -77,3 +77,126 @@ pub async fn update_list_designation_submit(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        AppError, AppStore, Context, Form, QueryParamState, test_utils::response_body_string,
+    };
+    use axum::{
+        http::{StatusCode, header},
+        response::IntoResponse,
+    };
+    use axum_extra::routing::TypedPath;
+
+    #[tokio::test]
+    async fn update_list_designation_renders_existing_data() -> Result<(), AppError> {
+        let store = AppStore::new_for_test();
+        let political_group = store.get_political_group();
+
+        let response = update_list_designation(
+            ListDesignationUpdatePath {},
+            Context::new_test_without_db(),
+            store,
+            political_group,
+        )
+        .await
+        .unwrap()
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_body_string(response).await;
+        assert!(body.contains("name=\"csrf_token\""));
+        assert!(body.contains("id=\"standalone\""));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn update_list_designation_persists_and_redirects_to_basic_info() -> Result<(), AppError>
+    {
+        let store = AppStore::new_for_test();
+        let political_group = store.get_political_group();
+
+        let context = Context::new_test_without_db();
+        let form = ListDesignationForm {
+            list_designation_type: "standalone".to_string(),
+            csrf_token: context.session.csrf_token.clone(),
+        };
+
+        let response = update_list_designation_submit(
+            ListDesignationUpdatePath {},
+            context,
+            store.clone(),
+            political_group,
+            Query(QueryParamState::default()),
+            Form(form),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response.status(), StatusCode::SEE_OTHER);
+        let location = response
+            .headers()
+            .get(header::LOCATION)
+            .expect("location header")
+            .to_str()
+            .expect("location header value");
+        assert_eq!(
+            location,
+            PoliticalGroup::update_path()
+                .with_query_params(QueryParamState::success())
+                .to_string()
+        );
+        assert_eq!(
+            store.get_political_group().list_designation,
+            Some(ListDesignation::Standalone)
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn update_list_designation_blank_redirects_to_list_submitter() -> Result<(), AppError> {
+        let store = AppStore::new_for_test();
+        let political_group = store.get_political_group();
+
+        let context = Context::new_test_without_db();
+        let form = ListDesignationForm {
+            list_designation_type: "blank".to_string(),
+            csrf_token: context.session.csrf_token.clone(),
+        };
+
+        let response = update_list_designation_submit(
+            ListDesignationUpdatePath {},
+            context,
+            store.clone(),
+            political_group,
+            Query(QueryParamState::default()),
+            Form(form),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response.status(), StatusCode::SEE_OTHER);
+        let location = response
+            .headers()
+            .get(header::LOCATION)
+            .expect("location header")
+            .to_str()
+            .expect("location header value");
+        assert_eq!(
+            location,
+            ListSubmitter::view_path()
+                .with_query_params(QueryParamState::success())
+                .to_string()
+        );
+        assert_eq!(
+            store.get_political_group().list_designation,
+            Some(ListDesignation::Blank)
+        );
+
+        Ok(())
+    }
+}

--- a/src/app/list_designation/pages/update.rs
+++ b/src/app/list_designation/pages/update.rs
@@ -69,7 +69,11 @@ pub async fn update_list_designation_submit(
             political_group.list_designation = Some(list_designation.list_designation_type);
             political_group.update(&store).await?;
 
-            Ok(query.redirect_or(PoliticalGroup::update_path()))
+            if political_group.list_designation == Some(ListDesignation::Blank) {
+                Ok(query.redirect_or(ListSubmitter::view_path()))
+            } else {
+                Ok(query.redirect_or(PoliticalGroup::update_path()))
+            }
         }
     }
 }

--- a/src/app/name_authorisations/pages/view.html
+++ b/src/app/name_authorisations/pages/view.html
@@ -8,7 +8,13 @@
       {% if steps.is_blank %}
         <div class="alert alert-warning">{{ "political_group.blank_list_warning"|trans }}</div>
       {% endif %}
-      <h2>{{ "political_group.legal_name_data"|trans }}</h2>
+      <h2>
+        {% if steps.is_combined %}
+          {{ "political_group.legal_name_data_combined"|trans }}
+        {% else %}
+          {{ "political_group.legal_name_data"|trans }}
+        {% endif %}
+      </h2>
       <p class="info">{{ "political_group.authorised_agent_info"|trans }}</p>
       {% if name_authorisations.is_empty() %}
         <p class="mt-md font-italic">{{ "political_group.no_legal_names"|trans }}</p>
@@ -20,7 +26,7 @@
           </a>
         {% endfor %}
       {% endif %}
-      {% if name_authorisations.is_empty() || is_combined %}
+      {% if name_authorisations.is_empty() || steps.is_combined %}
         <p class="mt-lg">
           <a href="{{ NameAuthorisation::create_path() }}"
              class="button secondary icon-plus"

--- a/src/app/name_authorisations/pages/view.html
+++ b/src/app/name_authorisations/pages/view.html
@@ -5,6 +5,9 @@
   <div class="steps">
     {% include "political_groups/components/steps.html" %}
     <div>
+      {% if steps.is_blank %}
+        <div class="alert alert-warning">{{ "political_group.blank_list_warning"|trans }}</div>
+      {% endif %}
       <h2>{{ "political_group.legal_name_data"|trans }}</h2>
       <p class="info">{{ "political_group.authorised_agent_info"|trans }}</p>
       {% if name_authorisations.is_empty() %}

--- a/src/app/name_authorisations/pages/view.html
+++ b/src/app/name_authorisations/pages/view.html
@@ -17,7 +17,7 @@
           </a>
         {% endfor %}
       {% endif %}
-      {% if name_authorisations.len() == 0 %}
+      {% if name_authorisations.is_empty() || is_combined %}
         <p class="mt-lg">
           <a href="{{ NameAuthorisation::create_path() }}"
              class="button secondary icon-plus"

--- a/src/app/name_authorisations/pages/view.rs
+++ b/src/app/name_authorisations/pages/view.rs
@@ -25,8 +25,8 @@ pub async fn list_name_authorisations(
     store: AppStore,
 ) -> Result<impl IntoResponse, AppError> {
     let steps = PoliticalGroupSteps::new(&store)?;
-    let is_combined = store.get_political_group().list_designation
-        == Some(ListDesignation::Combined);
+    let is_combined =
+        store.get_political_group().list_designation == Some(ListDesignation::Combined);
     Ok(HtmlTemplate(
         NameAuthorisationTemplate {
             name_authorisations: steps.name_authorisations.clone(),

--- a/src/app/name_authorisations/pages/view.rs
+++ b/src/app/name_authorisations/pages/view.rs
@@ -15,7 +15,6 @@ use axum::response::IntoResponse;
 #[template(path = "name_authorisations/pages/view.html")]
 struct NameAuthorisationTemplate {
     name_authorisations: Vec<NameAuthorisation>,
-    is_combined: bool,
     steps: PoliticalGroupSteps,
 }
 
@@ -25,12 +24,9 @@ pub async fn list_name_authorisations(
     store: AppStore,
 ) -> Result<impl IntoResponse, AppError> {
     let steps = PoliticalGroupSteps::new(&store)?;
-    let is_combined =
-        store.get_political_group().list_designation == Some(ListDesignation::Combined);
     Ok(HtmlTemplate(
         NameAuthorisationTemplate {
             name_authorisations: steps.name_authorisations.clone(),
-            is_combined,
             steps,
         },
         context,

--- a/src/app/name_authorisations/pages/view.rs
+++ b/src/app/name_authorisations/pages/view.rs
@@ -15,6 +15,7 @@ use axum::response::IntoResponse;
 #[template(path = "name_authorisations/pages/view.html")]
 struct NameAuthorisationTemplate {
     name_authorisations: Vec<NameAuthorisation>,
+    is_combined: bool,
     steps: PoliticalGroupSteps,
 }
 
@@ -24,9 +25,12 @@ pub async fn list_name_authorisations(
     store: AppStore,
 ) -> Result<impl IntoResponse, AppError> {
     let steps = PoliticalGroupSteps::new(&store)?;
+    let is_combined = store.get_political_group().list_designation
+        == Some(ListDesignation::Combined);
     Ok(HtmlTemplate(
         NameAuthorisationTemplate {
             name_authorisations: steps.name_authorisations.clone(),
+            is_combined,
             steps,
         },
         context,

--- a/src/app/political_groups/components/form.html
+++ b/src/app/political_groups/components/form.html
@@ -3,13 +3,17 @@
   {% if steps.is_blank %}
     <div class="alert alert-warning">{{ "political_group.blank_list_warning"|trans }}</div>
   {% endif %}
-  <h3>{{ "political_group.title"|trans }}</h3>
+  <h2>{{ "political_group.title"|trans }}</h2>
   <fieldset>
     <div class="form-row">
       <fieldset class="checklist">
         {% let election = "election"|election_value %}
         <legend class="legend-md">
-          {{ "political_group.previous_election_results"|trans(&election|election_type_title) }}
+          {% if steps.is_combined %}
+            {{ "political_group.type.previous_election_results_combined"|trans(&election|election_type_title) }}
+          {% else %}
+            {{ "political_group.previous_election_results"|trans(&election|election_type_title) }}
+          {% endif %}
         </legend>
         <div class="checklist">
           <div class="checkbox">
@@ -37,28 +41,35 @@
             <label for="previous_election_results_16">{{ "political_group.type.sixteen_or_more_seats"|trans }}</label>
           </div>
         </div>
-        <span class="alert alert-info">{{ "political_group.type.previous_election_results_hint"|trans }}</span>
+        <span class="alert alert-info">
+          {{ "political_group.type.previous_election_results_hint"|trans }}
+          {% if steps.is_combined %}{{ "political_group.type.previous_election_results_combined_hint"|trans }}{% endif %}
+        </span>
       </fieldset>
     </div>
     <div class="form-row">
       <div class="form-field {% if form.data.display_name.is_empty() && steps.basic_state != "empty" %}error{% endif %}">
-        <label for="display_name">{{ "political_group.display_name"|trans }}</label>
+        <label for="display_name">
+          {% if steps.is_combined %}
+            {{ "political_group.display_name_combined"|trans }}
+          {% else %}
+            {{ "political_group.display_name"|trans }}
+          {% endif %}
+        </label>
         <input type="text"
                name="display_name"
                value="{{ form.data.display_name }}"
                id="display_name" />
         {% for error in form|error("display_name") %}<span class="error">{{ error }}</span>{% endfor %}
-        <span class="hint">{{ "political_group.type.display_name_hint"|trans }}</span>
+        <span class="hint">
+          {% if steps.is_combined %}
+            {{ "political_group.type.display_name_combined_hint"|trans }}
+          {% else %}
+            {{ "political_group.type.display_name_hint"|trans }}
+          {% endif %}
+        </span>
       </div>
     </div>
-    {# <div class="form-row mt-md">
-    <div class="form-field {% if form.data.legal_name.is_empty() && steps.basic_state != "empty" %}warning{% endif %}">
-      <label for="legal_name">{{ "political_group.legal_name"|trans }}</label>
-      <input type="text" name="legal_name" value="{{ form.data.legal_name }}" id="legal_name" />
-      {% for error in form|error("legal_name") %}<span class="error">{{ error }}</span>{% endfor %}
-      <span class="hint">{{ "political_group.type.legal_name_hint"|trans }}</span>
-    </div>
-  </div> #}
   </fieldset>
   {% set submit_label = "action.save_and_continue"|trans %}
   {% include "common/components/submit.html" %}

--- a/src/app/political_groups/components/form.html
+++ b/src/app/political_groups/components/form.html
@@ -1,5 +1,8 @@
 <div>
   <input type="hidden" name="csrf_token" value="{{ form.data.csrf_token }}">
+  {% if steps.is_blank %}
+    <div class="alert alert-warning">{{ "political_group.blank_list_warning"|trans }}</div>
+  {% endif %}
   <h3>{{ "political_group.title"|trans }}</h3>
   <fieldset>
     <div class="form-row">

--- a/src/app/political_groups/components/steps.html
+++ b/src/app/political_groups/components/steps.html
@@ -5,12 +5,18 @@
          class="{{ steps.list_designation_state }}">{{ "political_group.list_type"|trans }}</a>
     </li>
     <li>
-      <a href="{{ PoliticalGroup::update_path() }}"
-         class="{{ steps.basic_state }}">{{ "political_group.basic_information_political_group"|trans }}</a>
+      <a {% if !steps.is_blank %}href="{{ PoliticalGroup::update_path() }}"{% endif %}
+         class="{% if steps.is_blank %}disabled {% endif %}{{ steps.basic_state }}"
+         data-href="{{ PoliticalGroup::update_path() }}"
+         data-state-class="{{ steps.basic_state }}"
+         data-skip-if-blank>{{ "political_group.basic_information_political_group"|trans }}</a>
     </li>
     <li>
-      <a href="{{ NameAuthorisation::list_path() }}"
-         class="{{ steps.name_authorisations_state }}">{{ "political_group.legal_name_data"|trans }}</a>
+      <a {% if !steps.is_blank %}href="{{ NameAuthorisation::list_path() }}"{% endif %}
+         class="{% if steps.is_blank %}disabled {% endif %}{{ steps.name_authorisations_state }}"
+         data-href="{{ NameAuthorisation::list_path() }}"
+         data-state-class="{{ steps.name_authorisations_state }}"
+         data-skip-if-blank>{{ "political_group.legal_name_data"|trans }}</a>
     </li>
     <li>
       <a href="{{ ListSubmitter::view_path() }}"

--- a/src/app/political_groups/components/steps.html
+++ b/src/app/political_groups/components/steps.html
@@ -16,7 +16,15 @@
          class="{% if steps.is_blank %}disabled {% endif %}{{ steps.name_authorisations_state }}"
          data-href="{{ NameAuthorisation::list_path() }}"
          data-state-class="{{ steps.name_authorisations_state }}"
-         data-skip-if-blank>{{ "political_group.legal_name_data"|trans }}</a>
+         data-label="{{ "political_group.legal_name_data"|trans }}"
+         data-label-combined="{{ "political_group.legal_name_data_combined"|trans }}"
+         data-skip-if-blank>
+        {% if steps.is_combined %}
+          {{ "political_group.legal_name_data_combined"|trans }}
+        {% else %}
+          {{ "political_group.legal_name_data"|trans }}
+        {% endif %}
+      </a>
     </li>
     <li>
       <a href="{{ ListSubmitter::view_path() }}"

--- a/src/app/political_groups/steps.rs
+++ b/src/app/political_groups/steps.rs
@@ -13,6 +13,7 @@ pub struct PoliticalGroupSteps {
     pub list_submitter: ListSubmitter,
     pub substitute_submitters: Vec<ListSubmitter>,
     pub is_blank: bool,
+    pub is_combined: bool,
 
     pub list_designation_state: &'static str,
     pub basic_state: &'static str,
@@ -29,9 +30,11 @@ impl PoliticalGroupSteps {
 
         let basic_info_empty = political_group.is_basic_info_empty();
         let is_blank = political_group.list_designation == Some(ListDesignation::Blank);
+        let is_combined = political_group.list_designation == Some(ListDesignation::Combined);
 
         Ok(Self {
             is_blank,
+            is_combined,
             list_designation_state: Self::list_designation_state(&political_group),
             basic_state: Self::basic_state(basic_info_empty, &political_group),
             name_authorisations_state: Self::name_authorisations_state(

--- a/src/app/political_groups/steps.rs
+++ b/src/app/political_groups/steps.rs
@@ -1,5 +1,6 @@
 use crate::{
     AppError, AppStore,
+    app::list_designation::ListDesignation,
     common::{Problematic, Severity},
     list_submitters::ListSubmitter,
     name_authorisations::NameAuthorisation,
@@ -11,6 +12,7 @@ pub struct PoliticalGroupSteps {
     pub name_authorisations: Vec<NameAuthorisation>,
     pub list_submitter: ListSubmitter,
     pub substitute_submitters: Vec<ListSubmitter>,
+    pub is_blank: bool,
 
     pub list_designation_state: &'static str,
     pub basic_state: &'static str,
@@ -26,8 +28,10 @@ impl PoliticalGroupSteps {
         let substitute_submitters = store.get_substitute_submitters();
 
         let basic_info_empty = political_group.is_basic_info_empty();
+        let is_blank = political_group.list_designation == Some(ListDesignation::Blank);
 
         Ok(Self {
+            is_blank,
             list_designation_state: Self::list_designation_state(&political_group),
             basic_state: Self::basic_state(basic_info_empty, &political_group),
             name_authorisations_state: Self::name_authorisations_state(

--- a/src/app/political_groups/structs/political_group.rs
+++ b/src/app/political_groups/structs/political_group.rs
@@ -14,6 +14,10 @@ pub struct PoliticalGroup {
 
 impl Problematic for PoliticalGroup {
     fn get_problems(&self) -> Vec<PotentialProblems> {
+        if self.list_designation == Some(ListDesignation::Blank) {
+            return Vec::new();
+        }
+
         [
             self.display_name.get_problems(),
             self.previous_election_results
@@ -28,7 +32,22 @@ impl Problematic for PoliticalGroup {
 }
 
 impl PoliticalGroup {
+    pub fn effective_display_name(&self) -> Result<String, AppError> {
+        if self.list_designation == Some(ListDesignation::Blank) {
+            return Ok(String::new());
+        }
+        self.display_name
+            .as_ref()
+            .map(|d| Ok(d.to_string()))
+            .unwrap_or(Err(AppError::IncompleteData(
+                "Missing registered designation",
+            )))
+    }
+
     pub fn get_max_candidates(&self) -> usize {
+        if self.list_designation == Some(ListDesignation::Blank) {
+            return 50;
+        }
         match self.previous_election_results {
             Some(PreviousElectionResults::SixteenOrMoreSeats) => 80,
             _ => 50,
@@ -36,6 +55,9 @@ impl PoliticalGroup {
     }
 
     pub fn was_previously_seated(&self) -> bool {
+        if self.list_designation == Some(ListDesignation::Blank) {
+            return false;
+        }
         self.previous_election_results
             .is_some_and(|r| r != PreviousElectionResults::ZeroSeats)
     }
@@ -87,5 +109,23 @@ mod tests {
         .get_problems();
 
         assert!(complete_items.is_empty());
+    }
+
+    #[test]
+    fn blank_lists_force_defaults_even_if_set_differently() {
+        let mut group = PoliticalGroup {
+            previous_election_results: Some(PreviousElectionResults::SixteenOrMoreSeats),
+            list_designation: Some(ListDesignation::Standalone),
+            display_name: DisplayName::from_str("test").ok(),
+        };
+        assert_eq!(group.effective_display_name().unwrap(), "test");
+        assert_eq!(group.get_max_candidates(), 80);
+        assert_eq!(group.was_previously_seated(), true);
+
+        // the set values should be ignored when switching to a blank list
+        group.list_designation = Some(ListDesignation::Blank);
+        assert_eq!(group.effective_display_name().unwrap(), "");
+        assert_eq!(group.get_max_candidates(), 50);
+        assert_eq!(group.was_previously_seated(), false);
     }
 }

--- a/src/app/political_groups/structs/political_group.rs
+++ b/src/app/political_groups/structs/political_group.rs
@@ -112,6 +112,18 @@ mod tests {
     }
 
     #[test]
+    fn incomplete_items_blank_list() {
+        let empty_items = PoliticalGroup {
+            previous_election_results: None,
+            list_designation: Some(ListDesignation::Blank),
+            display_name: None,
+        }
+        .get_problems();
+
+        assert!(empty_items.is_empty());
+    }
+
+    #[test]
     fn blank_lists_force_defaults_even_if_set_differently() {
         let mut group = PoliticalGroup {
             previous_election_results: Some(PreviousElectionResults::SixteenOrMoreSeats),

--- a/src/app/political_groups/structs/political_group.rs
+++ b/src/app/political_groups/structs/political_group.rs
@@ -120,12 +120,12 @@ mod tests {
         };
         assert_eq!(group.effective_display_name().unwrap(), "test");
         assert_eq!(group.get_max_candidates(), 80);
-        assert_eq!(group.was_previously_seated(), true);
+        assert!(group.was_previously_seated());
 
         // the set values should be ignored when switching to a blank list
         group.list_designation = Some(ListDesignation::Blank);
         assert_eq!(group.effective_display_name().unwrap(), "");
         assert_eq!(group.get_max_candidates(), 50);
-        assert_eq!(group.was_previously_seated(), false);
+        assert!(!group.was_previously_seated());
     }
 }

--- a/src/app/submit/structs/documents.rs
+++ b/src/app/submit/structs/documents.rs
@@ -141,14 +141,7 @@ impl DocumentData {
         let electoral_districts = TypstElectoralDistricts::from(&list, &context.election, locale);
 
         let group = store.get_political_group();
-        // Missing designation prevents export
-        let designation = group
-            .display_name
-            .as_ref()
-            .ok_or(AppError::IncompleteData(
-                "Missing registered designation from political group",
-            ))?
-            .to_string();
+        let designation = group.effective_display_name()?;
 
         let list_submitter = store.get_list_submitter();
         if list_submitter.is_empty() || !list_submitter.is_all_good() {

--- a/src/app/submit/structs/eml210.rs
+++ b/src/app/submit/structs/eml210.rs
@@ -320,11 +320,7 @@ impl Eml210 {
                 )
             })
             .affiliation(NominationAffiliation {
-                registered_name: political_group
-                    .display_name
-                    .as_ref()
-                    .ok_or(AppError::IncompleteData("Missing registered display name"))?
-                    .to_string(),
+                registered_name: political_group.effective_display_name()?,
                 affiliation_type: StringValue::from_value(AffiliationType::StandAloneList),
                 list_data,
                 candidates: candidates


### PR DESCRIPTION
Closes #719
Closes #720
Closes #722
Closes #724

# [DOD](/docs/definition-of-done.md) checklist

TODO:
- [x] Add warning about blank list on disabled pages
- [x] Update texts for combined lists regarding display name, etc.
- [x] Make headers more consistent? h3/h2, "General"

## For PR maintainer

Perform these checks before marking the PR as ready:

- [x] I have linked the PR to at least one issue.
- [x] I assigned the PR to myself.
- [x] I have added a description how to test this PR (see "Review Instructions").
- [x] I have added documentation where necessary.

## For reviewer

- I have read all code changes.
- I have audited the code quality.
- I have tested the changes either or both:
  - locally
  - on the test environment (preferred)
- I have validated that the PR is functionally correct (use-cases, figma designs, etc.)

### Review instructions
- For list combinations: you can add as many name authorisations as you would like!
- For blank list: the two irrelevant steps become disabled and get skipped

Note that it is possible to have multiple name authorisations on a standalone list if you switch from list combination to standalone. @Drevanoorschot will add a validation error for this as part of #683.