### PR TITLE
[#767] Add `/.well-known/security txt`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,8 @@ phf_codegen = "0.13.1"
 http-body-util = "0.1"
 tower = "0.5"
 tracing-test = "0.2.6"
+# Adds 'now' to chrono for testing against the current block
+chrono = { version = "0.4.44", features = ["now"] }
 # Adds rustls to reqwest for TLS server tests. Dev-only: the production
 # binary still builds reqwest without any TLS backend.
 reqwest = { version = "0.13.4", default-features = false, features = ["rustls"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ phf_codegen = "0.13.1"
 http-body-util = "0.1"
 tower = "0.5"
 tracing-test = "0.2.6"
-# Adds 'now' to chrono for testing against the current block
+# Adds 'now' to chrono for testing against the current clock
 chrono = { version = "0.4.44", features = ["now"] }
 # Adds rustls to reqwest for TLS server tests. Dev-only: the production
 # binary still builds reqwest without any TLS backend.

--- a/development/src/bin/setup.rs
+++ b/development/src/bin/setup.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<()> {
         .await
         .context("create tools directory")?;
 
-    // if an srgument is passed, only install that tool
+    // if an argument is passed, only install that tool
     let args: Vec<String> = std::env::args().collect();
     if args.len() == 2 {
         let tool_name = &args[1];

--- a/src/app/common/mod.rs
+++ b/src/app/common/mod.rs
@@ -22,5 +22,5 @@ pub use structs::{
 
 pub use pages::{
     IndexPath, SelectElectionPath, SwitchElectionPath, SwitchLanguagePath, not_found, router,
-    select_election_router,
+    select_election_router, wellknown_router,
 };

--- a/src/app/common/pages/mod.rs
+++ b/src/app/common/pages/mod.rs
@@ -6,6 +6,7 @@ mod not_found;
 mod select_election;
 mod switch_election;
 mod switch_locale;
+mod well_known;
 
 use crate::{AppError, AppState};
 
@@ -33,6 +34,7 @@ pub fn router() -> Router<AppState> {
         .typed_post(switch_locale::switch_language)
         .typed_get(switch_election::switch_election)
         .typed_post(switch_election::switch_election_submit)
+        .typed_get(well_known::index)
 }
 
 /// Routes that need a session but NOT the store middleware.

--- a/src/app/common/pages/mod.rs
+++ b/src/app/common/pages/mod.rs
@@ -34,7 +34,6 @@ pub fn router() -> Router<AppState> {
         .typed_post(switch_locale::switch_language)
         .typed_get(switch_election::switch_election)
         .typed_post(switch_election::switch_election_submit)
-        .typed_get(well_known::index)
 }
 
 /// Routes that need a session but NOT the store middleware.
@@ -43,4 +42,9 @@ pub fn select_election_router() -> Router<AppState> {
     Router::new()
         .typed_get(select_election::select_election)
         .typed_post(select_election::select_election_submit)
+}
+
+/// Routes for paths under .well-known
+pub fn wellknown_router() -> Router<AppState> {
+    Router::new().typed_get(well_known::security_txt)
 }

--- a/src/app/common/pages/well_known.rs
+++ b/src/app/common/pages/well_known.rs
@@ -16,11 +16,14 @@ pub(super) async fn security_txt(_: SecurityTxt) -> String {
     let date_str = SECURITY_EXPIRATION.to_rfc3339_opts(SecondsFormat::Secs, true);
 
     format!(
-        "Contact: mailto:security@kiesraad.nl
-Expires: {date_str}
-Preferred-Languages: en, nl
+        "Expires: {date_str}
 Canonical: https://kandidaatstellen.kiesraad.nl/.well-known/security.txt
+
 Policy: https://code.overheid.nl/Kiesraad/e-KS/src/branch/main/SECURITY.md
+
+Contact: mailto:security@kiesraad.nl
+Preferred-Languages: en, nl
+
 Hiring: https://www.werkenvoornederland.nl
 CSAF: https://advisories.ncsc.nl/.well-known/csaf/provider-metadata.json
 "

--- a/src/app/common/pages/well_known.rs
+++ b/src/app/common/pages/well_known.rs
@@ -12,6 +12,7 @@ const SECURITY_EXPIRATION: DateTime<Utc> = DateTime::from_naive_utc_and_offset(
     Utc,
 );
 
+/// Emit a security.txt file, for background information see <https://github.com/securitytxt/security-txt>
 pub(super) async fn security_txt(_: SecurityTxt) -> impl IntoResponse {
     let date_str = SECURITY_EXPIRATION.to_rfc3339_opts(SecondsFormat::Secs, true);
 

--- a/src/app/common/pages/well_known.rs
+++ b/src/app/common/pages/well_known.rs
@@ -35,7 +35,7 @@ mod tests {
 
     use crate::test_utils::response_body_string;
     use axum::response::IntoResponse;
-    use chrono::{Months, Utc};
+    use chrono::{Days, Months, Utc};
 
     #[tokio::test]
     async fn security_renders_text() {
@@ -48,20 +48,17 @@ mod tests {
 
     #[test]
     fn security_is_not_stale() {
-        // This tests that EXPIRATION is in the future, and,
+        // This tests that EXPIRATION is in the near future, and,
         // per RFC9116, is not more than one year in the future
-        assert!(SECURITY_EXPIRATION > Utc::now());
+        assert!(SECURITY_EXPIRATION > Utc::now() + Days::new(7));
         assert!(SECURITY_EXPIRATION < Utc::now() + Months::new(12));
 
         // Nice idea from Michiel: make the unit test deliberately flaky
-        // if the expiration date is soon to expire. This will definitely
-        // show up in CI, but can easily be squelched by re-trying so it won't
-        // block whatever else needs attention.
-        if SECURITY_EXPIRATION < Utc::now() + Months::new(3) {
-            use rand::RngExt;
-            if rand::rng().random_bool(1.0 / 3.0) {
-                panic!("SECURITY_EXPIRATION will expire within three months, please update it");
-            }
+        // if the expiration date is soon to expire.
+        if option_env!("EKS_CHECK_EXPIRATION") == Some("1")
+            && SECURITY_EXPIRATION < Utc::now() + Months::new(3)
+        {
+            panic!("SECURITY_EXPIRATION will expire within three months, please update it");
         }
     }
 }

--- a/src/app/common/pages/well_known.rs
+++ b/src/app/common/pages/well_known.rs
@@ -1,4 +1,3 @@
-use axum::response::IntoResponse;
 use axum_extra::routing::TypedPath;
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, SecondsFormat, Utc};
 use serde::Deserialize;
@@ -13,7 +12,7 @@ const SECURITY_EXPIRATION: DateTime<Utc> = DateTime::from_naive_utc_and_offset(
 );
 
 /// Emit a security.txt file, for background information see <https://github.com/securitytxt/security-txt>
-pub(super) async fn security_txt(_: SecurityTxt) -> impl IntoResponse {
+pub(super) async fn security_txt(_: SecurityTxt) -> String {
     let date_str = SECURITY_EXPIRATION.to_rfc3339_opts(SecondsFormat::Secs, true);
 
     format!(
@@ -32,7 +31,18 @@ CSAF: https://advisories.ncsc.nl/.well-known/csaf/provider-metadata.json
 mod tests {
     use super::*;
 
+    use crate::test_utils::response_body_string;
+    use axum::response::IntoResponse;
     use chrono::{Months, Utc};
+
+    #[tokio::test]
+    async fn security_renders_text() {
+        // This text is almost useless, except that it forces (at compile time, most likely)
+        // that security.txt is a text/plain.
+        let text = security_txt(SecurityTxt {}).await;
+        let body = response_body_string(text.clone().into_response()).await;
+        assert_eq!(body, text);
+    }
 
     #[test]
     fn security_is_not_stale() {

--- a/src/app/common/pages/well_known.rs
+++ b/src/app/common/pages/well_known.rs
@@ -1,0 +1,81 @@
+use axum::response::IntoResponse;
+use axum_extra::routing::TypedPath;
+use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, SecondsFormat, Utc};
+use serde::Deserialize;
+
+use crate::AppError;
+
+#[derive(TypedPath, Deserialize)]
+#[typed_path("/.well-known/{file_name}")]
+pub(super) struct WellKnownEntry {
+    file_name: String,
+}
+
+pub(super) async fn index(WellKnownEntry { file_name }: WellKnownEntry) -> impl IntoResponse {
+    match file_name.as_str() {
+        "security.txt" => Ok(security_text()),
+        _ => Err(AppError::GenericNotFound),
+    }
+}
+
+const SECURITY_EXPIRATION: DateTime<Utc> = DateTime::from_naive_utc_and_offset(
+    NaiveDateTime::new(
+        NaiveDate::from_ymd_opt(2026, 7, 25).unwrap(),
+        NaiveTime::MIN,
+    ),
+    Utc,
+);
+
+fn security_text() -> String {
+    let date_str = SECURITY_EXPIRATION.to_rfc3339_opts(SecondsFormat::Secs, true);
+
+    format!(
+        "Contact: mailto:security@kiesraad.nl
+Expires: {date_str}
+Preferred-Languages: en, nl
+Canonical: https://kandidaatstellen.kiesraad.nl/.well-known/security.txt
+Policy: https://code.overheid.nl/Kiesraad/e-KS/src/branch/main/SECURITY.md
+Hiring: https://www.werkenvoornederland.nl
+CSAF: https://advisories.ncsc.nl/.well-known/csaf/provider-metadata.json
+"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::test_utils::response_body_string;
+    use chrono::{Months, Utc};
+
+    #[tokio::test]
+    async fn security_renders_text() {
+        let body = index(WellKnownEntry {
+            file_name: "security.txt".to_string(),
+        })
+        .await
+        .into_response();
+
+        let body = response_body_string(body).await;
+        assert_eq!(body, security_text());
+    }
+
+    #[test]
+    fn security_is_not_stale() {
+        // This tests that EXPIRATION is in the future, and,
+        // per RFC9116, is not more than one year in the future
+        assert!(SECURITY_EXPIRATION > Utc::now());
+        assert!(SECURITY_EXPIRATION < Utc::now() + Months::new(12));
+
+        // Nice idea from Michiel: make the unit test deliberately flaky
+        // if the expiration date is soon to expire. This will definitely
+        // show up in CI, but can easily be squelched by re-trying so it won't
+        // block whatever else needs attention.
+        if SECURITY_EXPIRATION < Utc::now() + Months::new(3) {
+            use rand::RngExt;
+            if rand::rng().random_bool(1.0 / 3.0) {
+                panic!("SECURITY_EXPIRATION will expire within three months, please update it");
+            }
+        }
+    }
+}

--- a/src/app/common/pages/well_known.rs
+++ b/src/app/common/pages/well_known.rs
@@ -25,7 +25,6 @@ Contact: mailto:security@kiesraad.nl
 Preferred-Languages: en, nl
 
 Hiring: https://www.werkenvoornederland.nl
-CSAF: https://advisories.ncsc.nl/.well-known/csaf/provider-metadata.json
 "
     )
 }

--- a/src/app/common/pages/well_known.rs
+++ b/src/app/common/pages/well_known.rs
@@ -3,30 +3,16 @@ use axum_extra::routing::TypedPath;
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, SecondsFormat, Utc};
 use serde::Deserialize;
 
-use crate::AppError;
-
 #[derive(TypedPath, Deserialize)]
-#[typed_path("/.well-known/{file_name}")]
-pub(super) struct WellKnownEntry {
-    file_name: String,
-}
-
-pub(super) async fn index(WellKnownEntry { file_name }: WellKnownEntry) -> impl IntoResponse {
-    match file_name.as_str() {
-        "security.txt" => Ok(security_text()),
-        _ => Err(AppError::GenericNotFound),
-    }
-}
+#[typed_path("/security.txt")]
+pub struct SecurityTxt {}
 
 const SECURITY_EXPIRATION: DateTime<Utc> = DateTime::from_naive_utc_and_offset(
-    NaiveDateTime::new(
-        NaiveDate::from_ymd_opt(2026, 7, 25).unwrap(),
-        NaiveTime::MIN,
-    ),
+    NaiveDateTime::new(NaiveDate::from_ymd_opt(2027, 2, 1).unwrap(), NaiveTime::MIN),
     Utc,
 );
 
-fn security_text() -> String {
+pub(super) async fn security_txt(_: SecurityTxt) -> impl IntoResponse {
     let date_str = SECURITY_EXPIRATION.to_rfc3339_opts(SecondsFormat::Secs, true);
 
     format!(
@@ -45,20 +31,7 @@ CSAF: https://advisories.ncsc.nl/.well-known/csaf/provider-metadata.json
 mod tests {
     use super::*;
 
-    use crate::test_utils::response_body_string;
     use chrono::{Months, Utc};
-
-    #[tokio::test]
-    async fn security_renders_text() {
-        let body = index(WellKnownEntry {
-            file_name: "security.txt".to_string(),
-        })
-        .await
-        .into_response();
-
-        let body = response_body_string(body).await;
-        assert_eq!(body, security_text());
-    }
 
     #[test]
     fn security_is_not_stale() {

--- a/src/app/common/pages/well_known.rs
+++ b/src/app/common/pages/well_known.rs
@@ -39,7 +39,7 @@ mod tests {
 
     #[tokio::test]
     async fn security_renders_text() {
-        // This text is almost useless, except that it forces (at compile time, most likely)
+        // This test is almost useless, except that it forces (at compile time, most likely)
         // that security.txt is a text/plain.
         let text = security_txt(SecurityTxt {}).await;
         let body = response_body_string(text.clone().into_response()).await;

--- a/src/router.rs
+++ b/src/router.rs
@@ -114,6 +114,8 @@ pub fn create(state: AppState) -> Router<AppState> {
         )),
     );
 
+    let router = router.nest("/.well-known", common::wellknown_router());
+
     router.layer(middleware::from_fn_with_state(
         state.clone(),
         eks_key_middleware,

--- a/src/router.rs
+++ b/src/router.rs
@@ -19,16 +19,16 @@ use crate::{
 pub fn create(state: AppState) -> Router<AppState> {
     let app_router = Router::new()
         .merge(audit_log::router())
-        .merge(common::router())
-        .merge(persons::router())
-        .merge(list_designation::router())
-        .merge(political_groups::router())
-        .merge(name_authorisations::router())
-        .merge(list_submitters::router())
-        .merge(substitute_list_submitters::router())
-        .merge(submit::router())
+        .merge(candidates::router())
         .merge(candidate_lists::router())
-        .merge(candidates::router());
+        .merge(common::router())
+        .merge(list_designation::router())
+        .merge(list_submitters::router())
+        .merge(name_authorisations::router())
+        .merge(persons::router())
+        .merge(political_groups::router())
+        .merge(submit::router())
+        .merge(substitute_list_submitters::router());
 
     #[cfg(feature = "dev-features")]
     let dev_router = Router::new().route(


### PR DESCRIPTION
Closes #767

# [DOD](/docs/definition-of-done.md) checklist

## For PR maintainer

Perform these checks before marking the PR as ready:

- [x] I have linked the PR to at least one issue.
- [x] I assigned the PR to myself.
- [x] I have added a description how to test this PR (see "Review Instructions").
- [x] [For bug fixes only] I have added a regression test for the fixed bug.
- [x] I have added documentation where necessary.

## For reviewer

- I have read all code changes.
- I have audited the code quality.
- I have tested the changes either or both:
  - locally
  - on the test environment (preferred)
- I have validated that the PR is functionally correct (use-cases, figma designs, etc.)

### Review instructions
For background info:

* https://securitytxt.org/
* https://github.com/securitytxt/security-txt/blob/master/rfc9116.txt

Testing: launch e-KS and `curl -v https://localhost:3000/.well_known/security.txt`. Note that this should give a `text/plain` response.