### PR TITLE
[#780] Download warning

### DIFF
--- a/frontend/styles/alert.css
+++ b/frontend/styles/alert.css
@@ -65,7 +65,7 @@
     border: 1px solid var(--alert-border-color);
     border-radius: var(--rounded-sm);
     z-index: 1000;
-    margin: 0;
+    margin: 0 auto;
     box-shadow: 0 0.2rem 0.5rem rgba(0, 0, 0, 0.15);
     animation: alert-float 4.5s ease-in-out forwards;
   }
@@ -96,6 +96,7 @@
 .download-warning-banner {
   position: fixed;
   bottom: 0;
+  z-index: 10000;
 
   .alert-floating {
     background-size: 1.5rem;

--- a/frontend/styles/alert.css
+++ b/frontend/styles/alert.css
@@ -59,7 +59,8 @@
     background-size: 1rem;
     position: fixed;
     left: 4rem;
-    padding: var(--space-sm) var(--space-md) var(--space-sm) var(--space-xl);
+    right: 4rem;
+    padding: var(--space-sm) var(--space-md) var(--space-sm) var(--space-12);
     bottom: var(--space-lg);
     border: 1px solid var(--alert-border-color);
     border-radius: var(--rounded-sm);
@@ -67,7 +68,6 @@
     margin: 0;
     box-shadow: 0 0.2rem 0.5rem rgba(0, 0, 0, 0.15);
     animation: alert-float 4.5s ease-in-out forwards;
-    text-transform: capitalize;
   }
 }
 
@@ -90,5 +90,39 @@
   100% {
     transform: translateX(-120%);
     opacity: 0;
+  }
+}
+
+.download-warning-banner {
+  position: fixed;
+  bottom: 0;
+
+  .alert-floating {
+    background-size: 1.5rem;
+    padding-left: var(--space-14);
+    max-width: 46rem;
+    animation: none;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .close-overlay {
+    display: block;
+    flex-shrink: 0;
+    background-color: transparent;
+    background-image: url("../icons/cross.svg");
+    background-repeat: no-repeat;
+    background-size: 1.5rem;
+    background-position: right center;
+    width: 2rem;
+    height: 2rem;
+    border: none;
+    cursor: pointer;
+    outline: none;
+
+    span {
+      display: none;
+    }
   }
 }

--- a/frontend/styles/alert.css
+++ b/frontend/styles/alert.css
@@ -65,7 +65,7 @@
     border: 1px solid var(--alert-border-color);
     border-radius: var(--rounded-sm);
     z-index: 1000;
-    margin: 0 auto;
+    margin: 0;
     box-shadow: 0 0.2rem 0.5rem rgba(0, 0, 0, 0.15);
     animation: alert-float 4.5s ease-in-out forwards;
   }
@@ -101,6 +101,7 @@
   .alert-floating {
     background-size: 1.5rem;
     padding-left: var(--space-14);
+    margin: 0 auto;
     max-width: 46rem;
     animation: none;
     display: flex;

--- a/locales/en/audit_log.yml
+++ b/locales/en/audit_log.yml
@@ -50,6 +50,7 @@ event:
   delete_substitute_submitter: Deleted substitute submitter of the list
   developer_login: Developer login
   download_file: Downloaded file
+  hide_download_warning: Dismissed download warning
   export_csv: Exported CSV
   import_csv: Imported CSV
   remove_candidate_from_list: Removed candidate from list

--- a/locales/en/common.yml
+++ b/locales/en/common.yml
@@ -26,7 +26,8 @@ lists_have_problems: "{} lists have problems"
 lists_have_problems_one: 1 list has problems
 possible_problems: "{} possible problems"
 possible_problems_one: 1 possible problem
-save_success: saved
+download_warning: "Warning: the documents have already been downloaded. The data on paper is leading. If any changes are still needed, make sure to reprint the documents and submit the correct version."
+save_success: Saved
 select_election:
   description: Select the election you want to work on to continue.
   label: Select election

--- a/locales/nl/audit_log.yml
+++ b/locales/nl/audit_log.yml
@@ -50,6 +50,7 @@ event:
   delete_substitute_submitter: Vervanger herstel verzuim verwijderd
   developer_login: Ontwikkelaar ingelogd
   download_file: Bestand gedownload
+  hide_download_warning: Downloadwaarschuwing gesloten
   export_csv: CSV geëxporteerd
   import_csv: CSV geïmporteerd
   remove_candidate_from_list: Kandidaat van lijst verwijderd

--- a/locales/nl/common.yml
+++ b/locales/nl/common.yml
@@ -26,7 +26,8 @@ lists_have_problems: "{} lijsten hebben problemen"
 lists_have_problems_one: 1 lijst heeft problemen
 possible_problems: "{} mogelijke problemen"
 possible_problems_one: 1 mogelijk probleem
-save_success: opgeslagen
+download_warning: "Let op: de documenten zijn al gedownload. De gegevens op papier zijn leidend. Zorg ervoor dat u de documenten opnieuw print en de juiste versie inlevert als er nog wijzigingen nodig zijn."
+save_success: Opgeslagen
 select_election:
   description: Kies de verkiezing waar je mee wilt werken om verder te gaan.
   label: Kies een verkiezing

--- a/src/app/audit_log/pages/detail.html
+++ b/src/app/audit_log/pages/detail.html
@@ -32,7 +32,7 @@
       {% endif %}
     </dl>
     {% if detail.changes.is_empty() %}
-      <p>{{ "audit_log.detail.no_changes"|trans }}</p>
+      <p class="mb-md">{{ "audit_log.detail.no_changes"|trans }}</p>
     {% else %}
       <table class="diff-table mb-md">
         <thead>

--- a/src/app/audit_log/pages/list.rs
+++ b/src/app/audit_log/pages/list.rs
@@ -77,6 +77,7 @@ pub const EVENT_TYPES_BY_CATEGORY: &[EventTypeCategory] = &[
         event_types: &[
             "developer_login",
             "download_file",
+            "hide_download_warning",
             "export_csv",
             "import_csv",
         ],

--- a/src/app/audit_log/structs/event_info.rs
+++ b/src/app/audit_log/structs/event_info.rs
@@ -74,6 +74,7 @@ pub(super) fn event_description(event: &AppEvent, locale: Locale) -> String {
         }
         AppEvent::DeveloperLogin { .. } => trans!("audit_log.event.developer_login", locale),
         AppEvent::DownloadFile { .. } => trans!("audit_log.event.download_file", locale),
+        AppEvent::HideDownloadWarning => trans!("audit_log.event.hide_download_warning", locale),
         AppEvent::ExportCsv { .. } => trans!("audit_log.event.export_csv", locale),
         AppEvent::ImportCandidates { .. } => {
             trans!("audit_log.event.import_csv", locale)
@@ -124,7 +125,8 @@ pub(super) fn event_details(event: &AppEvent) -> String {
         | AppEvent::DeleteCandidateList(..)
         | AppEvent::DeleteNameAuthorisation(..)
         | AppEvent::DeleteSubstituteSubmitter { .. }
-        | AppEvent::DeveloperLogin { .. } => DEFAULT_DETAILS.to_string(),
+        | AppEvent::DeveloperLogin { .. }
+        | AppEvent::HideDownloadWarning => DEFAULT_DETAILS.to_string(),
     }
 }
 
@@ -198,7 +200,7 @@ pub(super) fn subject_id_full(event: &AppEvent) -> String {
         AppEvent::ExportCsv { list_id, .. } | AppEvent::ImportCandidates { list_id, .. } => {
             list_id.to_string()
         }
-        AppEvent::DownloadFile { .. } => String::new(),
+        AppEvent::DownloadFile { .. } | AppEvent::HideDownloadWarning => String::new(),
     }
 }
 

--- a/src/app/audit_log/structs/event_payload.rs
+++ b/src/app/audit_log/structs/event_payload.rs
@@ -96,6 +96,7 @@ pub(super) fn extract_old_new(
         } => update!(Vec, substitute_submitters, *ss_id),
 
         AppEvent::DeveloperLogin { stream_id } => event!({ stream_id: stream_id.to_string() }),
+        AppEvent::HideDownloadWarning => event!({}),
         AppEvent::DownloadFile {
             file_name,
             download_path,

--- a/src/app/candidate_lists/mod.rs
+++ b/src/app/candidate_lists/mod.rs
@@ -9,5 +9,5 @@ mod pages;
 mod structs;
 
 pub use forms::{CandidateListCreateForm, CandidateListForm};
-pub use pages::{ViewCandidateListPath, router};
+pub use pages::{CandidateListsPath, ViewCandidateListPath, router};
 pub use structs::{CandidateList, CandidateListId, CandidateListSummary, FullCandidateList};

--- a/src/app/common/components/layout.html
+++ b/src/app/common/components/layout.html
@@ -75,9 +75,14 @@
     <div class="download-warning-banner">
       <div class="alert alert-warning alert-floating">
         <div>{{ "common.download_warning"|trans }}</div>
-        <a href="/" class="close-overlay active" aria-label="Close">
-          <span>Close</span>
-        </a>
+        <form method="post"
+              action="{{ crate::common::HideDownloadWarningPath{}.to_string() }}">
+          <button type="submit"
+                  class="close-overlay"
+                  aria-label="{{ "action.close"|trans }}">
+            <span>{{ "action.close"|trans }}</span>
+          </button>
+        </form>
       </div>
     </div>
   {% endif %}

--- a/src/app/common/components/layout.html
+++ b/src/app/common/components/layout.html
@@ -71,6 +71,16 @@
       {% if let Some(server) = "server_name"|optional_str_value %}· <strong>{{ server }}</strong>{% endif %}
     </span>
   </footer>
+  {% if "show_download_warning"|value_true %}
+    <div class="download-warning-banner">
+      <div class="alert alert-warning alert-floating">
+        <div>{{ "common.download_warning"|trans }}</div>
+        <a href="/" class="close-overlay active" aria-label="Close">
+          <span>Close</span>
+        </a>
+      </div>
+    </div>
+  {% endif %}
   {% block overlay %}{% endblock %}
   {% if "show_success_alert"|value_true %}
     <div class="alert alert-success alert-floating">{{ "common.save_success"|trans }}</div>

--- a/src/app/common/mod.rs
+++ b/src/app/common/mod.rs
@@ -21,6 +21,6 @@ pub use structs::{
 };
 
 pub use pages::{
-    IndexPath, SelectElectionPath, SwitchElectionPath, SwitchLanguagePath, not_found, router,
-    select_election_router, wellknown_router,
+    HideDownloadWarningPath, IndexPath, SelectElectionPath, SwitchElectionPath, SwitchLanguagePath,
+    not_found, router, select_election_router, wellknown_router,
 };

--- a/src/app/common/pages/hide_download_warning.rs
+++ b/src/app/common/pages/hide_download_warning.rs
@@ -1,0 +1,89 @@
+use axum::response::Redirect;
+use axum_extra::{TypedHeader, headers};
+
+use crate::{AppEvent, AppStore, common::HideDownloadWarningPath};
+
+pub async fn hide_download_warning(
+    _: HideDownloadWarningPath,
+    TypedHeader(referer): TypedHeader<headers::Referer>,
+    store: AppStore,
+) -> Result<Redirect, crate::AppError> {
+    store.update(AppEvent::HideDownloadWarning).await?;
+    Ok(Redirect::to(&referer.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        Router,
+        body::Body,
+        http::{Request, StatusCode, header},
+        middleware,
+    };
+    use axum_extra::routing::RouterExt;
+    use tower::ServiceExt;
+
+    use crate::{AppEvent, AppState, ElectionConfig, session_middleware, store_middleware};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn hide_download_warning_records_event_and_redirects() {
+        let state = AppState::new_for_tests().await;
+        let app = Router::new()
+            .typed_post(hide_download_warning)
+            .layer(middleware::from_fn_with_state(
+                state.clone(),
+                store_middleware,
+            ))
+            .layer(middleware::from_fn_with_state(
+                state.clone(),
+                session_middleware,
+            ))
+            .with_state(state.clone());
+
+        let stream_id = crate::StreamId::new();
+        let store = state
+            .store_for_stream(stream_id, ElectionConfig::EK27, false)
+            .await
+            .expect("store");
+
+        let mut session = crate::Session::new();
+        session.set_stream_id(stream_id);
+        session.set_current_election(ElectionConfig::EK27);
+        let token = session.token().to_exposed_string();
+        state.sessions.insert(session).await;
+
+        // after download, the warning should show
+        store
+            .update(AppEvent::DownloadFile {
+                file_name: "documents.zip".to_string(),
+                download_path: "/download".to_string(),
+            })
+            .await
+            .unwrap();
+        assert!(store.should_show_download_warning());
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/hide-download-warning")
+            .header(header::REFERER, "https://example.com/candidate-lists")
+            .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+            .header(
+                header::COOKIE,
+                format!("{}={}", crate::SESSION_COOKIE_NAME, token),
+            )
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.expect("response");
+
+        // we should be redirected and the warning should no longer show
+        assert_eq!(response.status(), StatusCode::SEE_OTHER);
+        assert_eq!(
+            response.headers().get(header::LOCATION).unwrap(),
+            "https://example.com/candidate-lists",
+        );
+        assert!(!store.should_show_download_warning());
+    }
+}

--- a/src/app/common/pages/mod.rs
+++ b/src/app/common/pages/mod.rs
@@ -1,6 +1,7 @@
 use axum::Router;
 use axum_extra::routing::{RouterExt, TypedPath};
 
+mod hide_download_warning;
 mod index;
 mod not_found;
 mod select_election;
@@ -28,12 +29,17 @@ pub struct SwitchElectionPath;
 #[typed_path("/select-election", rejection(AppError))]
 pub struct SelectElectionPath;
 
+#[derive(TypedPath)]
+#[typed_path("/hide-download-warning", rejection(AppError))]
+pub struct HideDownloadWarningPath;
+
 pub fn router() -> Router<AppState> {
     Router::new()
         .typed_get(index::index)
         .typed_post(switch_locale::switch_language)
         .typed_get(switch_election::switch_election)
         .typed_post(switch_election::switch_election_submit)
+        .typed_post(hide_download_warning::hide_download_warning)
 }
 
 /// Routes that need a session but NOT the store middleware.

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -113,7 +113,8 @@ impl<S: AppRequestState> FromRequestParts<S> for Context {
         let path = parts.uri.path();
         context.show_download_warning = context.show_download_warning
             && (path.starts_with(crate::list_designation::ListDesignationUpdatePath::PATH)
-                || path.starts_with(crate::candidate_lists::CandidateListsPath::PATH));
+                || path.starts_with(crate::candidate_lists::CandidateListsPath::PATH)
+                || path.starts_with(crate::persons::PersonsPath::PATH));
 
         context.show_success_alert = parts
             .uri

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -2,6 +2,7 @@
 //! Extracted from requests and passed into Askama templates.
 
 use axum::{extract::FromRequestParts, http::request::Parts};
+use axum_extra::routing::TypedPath;
 
 use crate::{
     AppError, AppRequestState, AppStore, ElectionConfig, Session, political_groups::PoliticalGroup,
@@ -23,6 +24,8 @@ pub struct Context {
     pub multiple_candidate_lists: bool,
     /// Whether to show the success alert based on the request query.
     pub show_success_alert: bool,
+    /// Whether to show a warning that documents were downloaded and changes won't be reflected.
+    pub show_download_warning: bool,
     /// Whether the request came from an overlay page (via referrer query).
     pub overlay_referrer: bool,
     /// Session data for locale and CSRF.
@@ -44,12 +47,15 @@ impl Context {
 
         let general_information_path = political_group.general_information_path(store);
 
+        let show_download_warning = store.has_download_events();
+
         Self {
             election,
             political_group,
             max_candidates,
             multiple_candidate_lists,
             show_success_alert: false,
+            show_download_warning,
             overlay_referrer: false,
             session,
             server_name: None,
@@ -80,6 +86,7 @@ impl askama::Values for Context {
             "election" => Some(&self.election as &dyn std::any::Any),
             "max_candidates" => Some(&self.max_candidates as &dyn std::any::Any),
             "show_success_alert" => Some(&self.show_success_alert as &dyn std::any::Any),
+            "show_download_warning" => Some(&self.show_download_warning as &dyn std::any::Any),
             "multiple_candidate_lists" => {
                 Some(&self.multiple_candidate_lists as &dyn std::any::Any)
             }
@@ -102,6 +109,11 @@ impl<S: AppRequestState> FromRequestParts<S> for Context {
         let mut context = Context::new(&store, session);
 
         context.server_name = state.config().server_name.as_deref();
+
+        let path = parts.uri.path();
+        context.show_download_warning = context.show_download_warning
+            && (path.starts_with(crate::list_designation::ListDesignationUpdatePath::PATH)
+                || path.starts_with(crate::candidate_lists::CandidateListsPath::PATH));
 
         context.show_success_alert = parts
             .uri

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -47,7 +47,7 @@ impl Context {
 
         let general_information_path = political_group.general_information_path(store);
 
-        let show_download_warning = store.has_download_events();
+        let show_download_warning = store.should_show_download_warning();
 
         Self {
             election,

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -47,15 +47,13 @@ impl Context {
 
         let general_information_path = political_group.general_information_path(store);
 
-        let show_download_warning = store.should_show_download_warning();
-
         Self {
             election,
             political_group,
             max_candidates,
             multiple_candidate_lists,
             show_success_alert: false,
-            show_download_warning,
+            show_download_warning: false,
             overlay_referrer: false,
             session,
             server_name: None,
@@ -111,7 +109,7 @@ impl<S: AppRequestState> FromRequestParts<S> for Context {
         context.server_name = state.config().server_name.as_deref();
 
         let path = parts.uri.path();
-        context.show_download_warning = context.show_download_warning
+        context.show_download_warning = store.should_show_download_warning()
             && (path.starts_with(crate::list_designation::ListDesignationUpdatePath::PATH)
                 || path.starts_with(crate::candidate_lists::CandidateListsPath::PATH)
                 || path.starts_with(crate::persons::PersonsPath::PATH));

--- a/src/app/event.rs
+++ b/src/app/event.rs
@@ -76,6 +76,7 @@ pub enum AppEvent {
         file_name: String,
         download_path: String,
     },
+    HideDownloadWarning,
 
     ExportCsv {
         file_name: String,
@@ -120,6 +121,7 @@ impl AppEvent {
             | AppEvent::DeleteSubstituteSubmitter { .. } => "substitute_submitter",
             AppEvent::DeveloperLogin { .. }
             | AppEvent::DownloadFile { .. }
+            | AppEvent::HideDownloadWarning
             | AppEvent::ExportCsv { .. }
             | AppEvent::ImportCandidates { .. } => "system",
         }
@@ -155,6 +157,7 @@ impl AppEvent {
             AppEvent::DeleteSubstituteSubmitter { .. } => "delete_substitute_submitter",
             AppEvent::DeveloperLogin { .. } => "developer_login",
             AppEvent::DownloadFile { .. } => "download_file",
+            AppEvent::HideDownloadWarning => "hide_download_warning",
             AppEvent::ExportCsv { .. } => "export_csv",
             AppEvent::ImportCandidates { .. } => "import_csv",
         }

--- a/src/app/list_designation/mod.rs
+++ b/src/app/list_designation/mod.rs
@@ -3,5 +3,5 @@ pub mod forms;
 pub mod pages;
 pub mod structs;
 
-pub use pages::router;
+pub use pages::{ListDesignationUpdatePath, router};
 pub use structs::ListDesignation;

--- a/src/app/persons/mod.rs
+++ b/src/app/persons/mod.rs
@@ -9,5 +9,5 @@ pub use forms::{
     AddressForm, PersonalDataFieldsForm, PersonalDataForm, RepresentativeFieldsForm,
     RepresentativeForm,
 };
-pub use pages::{UpdatePersonPath, router};
+pub use pages::{PersonsPath, UpdatePersonPath, router};
 pub use structs::{Person, PersonId, PersonPagination, PersonSort, PersonalData, Representative};

--- a/src/app/store/getters.rs
+++ b/src/app/store/getters.rs
@@ -148,6 +148,13 @@ impl AppStore {
         let data = self.data.read();
         data.events.clone()
     }
+
+    pub fn has_download_events(&self) -> bool {
+        let data = self.data.read();
+        data.events
+            .iter()
+            .any(|e| matches!(e.payload, crate::AppEvent::DownloadFile { .. }))
+    }
 }
 
 #[cfg(test)]

--- a/src/app/store/getters.rs
+++ b/src/app/store/getters.rs
@@ -149,17 +149,29 @@ impl AppStore {
         data.events.clone()
     }
 
-    pub fn has_download_events(&self) -> bool {
+    /// We show a warning after the user has downloaded the documents.
+    ///
+    /// If the user closes this warning, an `HideDownloadWarning` event is stored and we should no longer show the warning.
+    pub fn should_show_download_warning(&self) -> bool {
         let data = self.data.read();
         data.events
             .iter()
-            .any(|e| matches!(e.payload, crate::AppEvent::DownloadFile { .. }))
+            .rev()
+            .find(|e| {
+                matches!(
+                    e.payload,
+                    crate::AppEvent::DownloadFile { .. } | crate::AppEvent::HideDownloadWarning
+                )
+            })
+            .is_some_and(|e| matches!(e.payload, crate::AppEvent::DownloadFile { .. }))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{AppStore, list_submitters::ListSubmitterId, test_utils::sample_list_submitter};
+    use crate::{
+        AppEvent, AppStore, list_submitters::ListSubmitterId, test_utils::sample_list_submitter,
+    };
 
     #[tokio::test]
     async fn substitute_submitters_remain_in_order() {
@@ -197,5 +209,37 @@ mod tests {
                 .unwrap()
                 .is_substitute
         );
+    }
+
+    #[tokio::test]
+    async fn should_show_download_warning_tracks_download_and_hide_events() {
+        let store = AppStore::new_for_test();
+
+        // start without warning
+        assert!(!store.should_show_download_warning());
+
+        // after download, the warning should show
+        store
+            .update(AppEvent::DownloadFile {
+                file_name: "documents.zip".to_string(),
+                download_path: "/download".to_string(),
+            })
+            .await
+            .unwrap();
+        assert!(store.should_show_download_warning());
+
+        // after hiding, the warning should no longer show
+        store.update(AppEvent::HideDownloadWarning).await.unwrap();
+        assert!(!store.should_show_download_warning());
+
+        // after downloading again, the warning should show again
+        store
+            .update(AppEvent::DownloadFile {
+                file_name: "documents.zip".to_string(),
+                download_path: "/download".to_string(),
+            })
+            .await
+            .unwrap();
+        assert!(store.should_show_download_warning());
     }
 }

--- a/src/app/store/mod.rs
+++ b/src/app/store/mod.rs
@@ -94,6 +94,7 @@ impl StoreData for AppStoreData {
             // Only the serialized event is relevant for logging.
             AppEvent::DeveloperLogin { .. }
             | AppEvent::DownloadFile { .. }
+            | AppEvent::HideDownloadWarning
             | AppEvent::ExportCsv { .. } => {}
         }
     }


### PR DESCRIPTION
Closes #780

# [DOD](/docs/definition-of-done.md) checklist

## For PR maintainer

Perform these checks before marking the PR as ready:

- [x] I have linked the PR to at least one issue.
- [x] I assigned the PR to myself.
- [x] I have added a description how to test this PR (see "Review Instructions").
- [x] I have added documentation where necessary.

## For reviewer

Note: merge #829 first

- I have read all code changes.
- I have audited the code quality.
- I have tested the changes either or both:
  - locally
  - on the test environment (preferred)
- I have validated that the PR is functionally correct (use-cases, figma designs, etc.)

### Review instructions

<img width="1548" height="194" alt="image" src="https://github.com/user-attachments/assets/d714ef1a-3b08-47a8-bc05-73613ad543bc" />

After downloading the documents, a warning should appear on the `/political-group/*`, `/persons/*` and `/candidate-lists/*` pages. You can click this warning away by clicking the cross, which will remove the warning until you download again.