### PR TITLE
[#841] Fix double initial=true

### DIFF
--- a/src/utils/query_param_state.rs
+++ b/src/utils/query_param_state.rs
@@ -156,10 +156,48 @@ impl QueryParamState {
     pub fn redirect_or_preserving_initial(&self, default: impl std::fmt::Display) -> Response {
         let mut url = self.redirect_url_or(default);
 
-        if self.initial {
-            url.push_str("&initial=true");
+        if self.initial && !url.contains("initial=") {
+            if url.contains('?') {
+                url.push_str("&initial=true");
+            } else {
+                url.push_str("?initial=true");
+            }
         }
 
         Redirect::to(&url).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::header::LOCATION;
+
+    use super::*;
+
+    fn location(response: axum::response::Response) -> String {
+        response
+            .headers()
+            .get(LOCATION)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string()
+    }
+
+    #[test]
+    fn redirect_or_preserving_initial_does_not_duplicate_initial_param() {
+        // redirect_to already carries initial=true
+        let state = QueryParamState {
+            initial: true,
+            redirect_to: Some("/foo?initial=true".to_string()),
+            ..Default::default()
+        };
+        let loc = location(state.redirect_or_preserving_initial("/fallback"));
+        assert_eq!(loc, "/foo?initial=true");
+
+        // default path already carries initial=true
+        let state = QueryParamState::initial();
+        let loc = location(state.redirect_or_preserving_initial("/bar?initial=true"));
+        assert_eq!(loc, "/bar?initial=true");
     }
 }


### PR DESCRIPTION
Closes #841

# [DOD](/docs/definition-of-done.md) checklist

## For PR maintainer

Perform these checks before marking the PR as ready:

- [x] I have linked the PR to at least one issue.
- [x] I assigned the PR to myself.
- [x] I have added a description how to test this PR (see "Review Instructions").
- [x] [For bug fixes only] I have added a regression test for the fixed bug.
- [x] I have added documentation where necessary.

## For reviewer

- I have read all code changes.
- I have audited the code quality.
- I have tested the changes either or both:
  - locally
  - on the test environment (preferred)
- I have validated that the PR is functionally correct (use-cases, figma designs, etc.)

### Review instructions

Follow the procedure explained in the issue, it should now no longer duplicate the initial query parameter.