### PR TITLE
[#871] Add fixtures for CSB module

### DIFF
--- a/src/app/common/pages/select_election.html
+++ b/src/app/common/pages/select_election.html
@@ -41,15 +41,17 @@
               {% for wc in water_councils %}<option value="{{ wc.code() }}">{{ wc.title(*title_locale) }}</option>{% endfor %}
             </select>
           </p>
-          {% if fixtures %}
+          {% if cfg!(feature = "fixtures") %}
             <p class="mt-md checkbox">
               <input type="checkbox" name="load_fixtures" id="load_fixtures" value="true">
               <label for="load_fixtures">{{ "common.select_election.load_fixtures"|trans }}</label>
             </p>
-            <p class="mt-md checkbox">
-              <input type="checkbox" name="login_as_csb" id="login_as_csb" value="true">
-              <label for="login_as_csb">{{ "common.development.login_as_csb"|trans }}</label>
-            </p>
+            {% if cfg!(feature = "dev-features") %}
+              <p class="mt-md checkbox">
+                <input type="checkbox" name="login_as_csb" id="login_as_csb" value="true">
+                <label for="login_as_csb">{{ "common.development.login_as_csb"|trans }}</label>
+              </p>
+            {% endif %}
           {% endif %}
         </fieldset>
         <div class="form-actions">

--- a/src/app/common/pages/select_election.html
+++ b/src/app/common/pages/select_election.html
@@ -46,12 +46,10 @@
               <input type="checkbox" name="load_fixtures" id="load_fixtures" value="true">
               <label for="load_fixtures">{{ "common.select_election.load_fixtures"|trans }}</label>
             </p>
-            {% if cfg!(feature = "dev-features") %}
-              <p class="mt-md checkbox">
-                <input type="checkbox" name="login_as_csb" id="login_as_csb" value="true">
-                <label for="login_as_csb">{{ "common.development.login_as_csb"|trans }}</label>
-              </p>
-            {% endif %}
+            <p class="mt-md checkbox">
+              <input type="checkbox" name="login_as_csb" id="login_as_csb" value="true">
+              <label for="login_as_csb">{{ "common.development.login_as_csb"|trans }}</label>
+            </p>
           {% endif %}
         </fieldset>
         <div class="form-actions">

--- a/src/app/common/pages/select_election.rs
+++ b/src/app/common/pages/select_election.rs
@@ -94,11 +94,30 @@ pub async fn select_election_submit(
         session.stream_id = Some(StreamId::new());
         session.scope = Scope::CentralElectoralCommittee;
         session.set_current_election(election);
+
+        #[cfg(feature = "fixtures")]
+        if form.load_fixtures() {
+            let pg_stream_id = StreamId::new();
+            let app_store = state.store_for_stream(pg_stream_id, election, true).await?;
+            let snapshot = crate::AppStoreData::snapshot_until(&app_store.get_events(), usize::MAX);
+
+            state
+                .csb_store_for_stream(StreamId::new(), election)
+                .await?
+                .update(crate::CsbEvent::Import {
+                    hash: "fixtures".to_string(),
+                    source_stream_id: pg_stream_id,
+                    snapshot: Box::new(snapshot),
+                })
+                .await?;
+        }
+
         state.sessions.insert(session).await;
 
         return Ok(Redirect::to(&CsbExaminationOverviewPath {}.to_string()).into_response());
     }
 
+    // use the stream ID derived from the authenticated login
     let Some(stream_id) = session.stream_id else {
         return Ok(Redirect::to(&SelectElectionPath.to_string()).into_response());
     };

--- a/src/app/common/pages/select_election.rs
+++ b/src/app/common/pages/select_election.rs
@@ -6,9 +6,8 @@ use axum::{
 };
 
 use crate::{
-    AnyLocale, AppError, AppState, Context, Locale, Province, Scope, Session, StreamId,
-    WaterCouncil, common::SelectElectionForm, csb::examination::CsbExaminationOverviewPath,
-    filters,
+    AnyLocale, AppError, AppState, Context, Locale, Province, Scope, Session, WaterCouncil,
+    common::SelectElectionForm, csb::examination::CsbExaminationOverviewPath, filters,
 };
 
 use super::{IndexPath, SelectElectionPath};
@@ -21,7 +20,6 @@ struct SelectElectionTemplate {
     provinces: &'static [Province],
     water_councils: &'static [WaterCouncil],
     csrf_token: crate::TokenValue,
-    fixtures: bool,
 }
 
 struct LocaleValues {
@@ -55,7 +53,6 @@ pub async fn select_election(
         provinces: Province::ALL,
         water_councils: WaterCouncil::ALL,
         csrf_token,
-        fixtures: cfg!(feature = "fixtures"),
     };
 
     let values = LocaleValues {
@@ -90,26 +87,15 @@ pub async fn select_election_submit(
         return Ok(Redirect::to(&SelectElectionPath.to_string()).into_response());
     };
 
+    #[cfg(feature = "dev-features")]
     if form.login_as_csb() {
-        session.stream_id = Some(StreamId::new());
+        session.stream_id = Some(crate::StreamId::new());
         session.scope = Scope::CentralElectoralCommittee;
         session.set_current_election(election);
 
         #[cfg(feature = "fixtures")]
         if form.load_fixtures() {
-            let pg_stream_id = StreamId::new();
-            let app_store = state.store_for_stream(pg_stream_id, election, true).await?;
-            let snapshot = crate::AppStoreData::snapshot_until(&app_store.get_events(), usize::MAX);
-
-            state
-                .csb_store_for_stream(StreamId::new(), election)
-                .await?
-                .update(crate::CsbEvent::Import {
-                    hash: "fixtures".to_string(),
-                    source_stream_id: pg_stream_id,
-                    snapshot: Box::new(snapshot),
-                })
-                .await?;
+            crate::auth::dev_login::import_csb_fixture(&state, election).await?;
         }
 
         state.sessions.insert(session).await;

--- a/src/app/common/pages/select_election.rs
+++ b/src/app/common/pages/select_election.rs
@@ -87,7 +87,6 @@ pub async fn select_election_submit(
         return Ok(Redirect::to(&SelectElectionPath.to_string()).into_response());
     };
 
-    #[cfg(feature = "dev-features")]
     if form.login_as_csb() {
         session.stream_id = Some(crate::StreamId::new());
         session.scope = Scope::CentralElectoralCommittee;
@@ -95,7 +94,7 @@ pub async fn select_election_submit(
 
         #[cfg(feature = "fixtures")]
         if form.load_fixtures() {
-            crate::auth::dev_login::import_csb_fixture(&state, election).await?;
+            crate::csb::import::import_csb_fixture(&state, election).await?;
         }
 
         state.sessions.insert(session).await;

--- a/src/app/common/pages/select_election.rs
+++ b/src/app/common/pages/select_election.rs
@@ -87,14 +87,16 @@ pub async fn select_election_submit(
         return Ok(Redirect::to(&SelectElectionPath.to_string()).into_response());
     };
 
+    // Only available with the `fixtures` feature: this is a test/dev shortcut
+    // into the committee (CSB) scope
+    #[cfg(feature = "fixtures")]
     if form.login_as_csb() {
         session.stream_id = Some(crate::StreamId::new());
         session.scope = Scope::CentralElectoralCommittee;
         session.set_current_election(election);
 
-        #[cfg(feature = "fixtures")]
         if form.load_fixtures() {
-            crate::csb::import::import_csb_fixture(&state, election).await?;
+            crate::csb::import::fixture::import_csb_fixture(&state, election).await?;
         }
 
         state.sessions.insert(session).await;

--- a/src/auth/dev_login.rs
+++ b/src/auth/dev_login.rs
@@ -90,7 +90,7 @@ async fn perform_dev_login(
 
             #[cfg(feature = "fixtures")]
             if load_fixtures {
-                crate::csb::import::import_csb_fixture(&state, election).await?;
+                crate::csb::import::fixture::import_csb_fixture(&state, election).await?;
             }
 
             CsbExaminationOverviewPath {}.to_string()

--- a/src/auth/dev_login.rs
+++ b/src/auth/dev_login.rs
@@ -90,7 +90,7 @@ async fn perform_dev_login(
 
             #[cfg(feature = "fixtures")]
             if load_fixtures {
-                import_csb_fixture(&state, election).await?;
+                crate::csb::import::import_csb_fixture(&state, election).await?;
             }
 
             CsbExaminationOverviewPath {}.to_string()
@@ -128,28 +128,6 @@ pub(crate) fn request_locale(headers: &axum::http::HeaderMap) -> Locale {
         .and_then(|value| value.to_str().ok())
         .and_then(Locale::from_accept_language)
         .unwrap_or_default()
-}
-
-/// Create a political group stream with fixtures and import it as a CSB stream
-#[cfg(feature = "fixtures")]
-pub(crate) async fn import_csb_fixture(
-    state: &AppState,
-    election: ElectionConfig,
-) -> Result<(), AppError> {
-    let pg_stream_id = StreamId::new();
-    let app_store = state.store_for_stream(pg_stream_id, election, true).await?;
-    let events = app_store.get_events();
-    let snapshot = AppStoreData::snapshot_until(&events, usize::MAX);
-
-    state
-        .csb_store_for_stream(StreamId::new(), election)
-        .await?
-        .update(crate::CsbEvent::Import {
-            hash: "fixtures".to_string(),
-            source_stream_id: pg_stream_id,
-            snapshot: Box::new(snapshot),
-        })
-        .await
 }
 
 async fn ensure_dev_store(

--- a/src/auth/dev_login.rs
+++ b/src/auth/dev_login.rs
@@ -76,6 +76,8 @@ async fn perform_dev_login(
     session.set_stream_id(stream_id);
     session.set_scope(scope);
 
+    let load_fixtures = query.fixtures.unwrap_or(false);
+
     let redirect_to = match scope {
         Scope::CentralElectoralCommittee => {
             // Prime the CSB store. Creating it records the committee scope on the
@@ -85,6 +87,12 @@ async fn perform_dev_login(
             let election = ElectionConfig::EK27;
             state.csb_store_for_stream(stream_id, election).await?;
             session.set_current_election(election);
+
+            #[cfg(feature = "fixtures")]
+            if load_fixtures {
+                import_csb_fixture(&state, election).await?;
+            }
+
             CsbExaminationOverviewPath {}.to_string()
         }
         Scope::PoliticalGroup => {
@@ -92,7 +100,6 @@ async fn perform_dev_login(
                 SelectElectionPath.to_string()
             } else {
                 let election = ElectionConfig::EK27;
-                let load_fixtures = query.fixtures.unwrap_or(false);
                 let (store, was_new) =
                     ensure_dev_store(&state, stream_id, load_fixtures, election).await?;
 
@@ -121,6 +128,28 @@ pub(crate) fn request_locale(headers: &axum::http::HeaderMap) -> Locale {
         .and_then(|value| value.to_str().ok())
         .and_then(Locale::from_accept_language)
         .unwrap_or_default()
+}
+
+/// Create a political group stream with fixtures and import it as a CSB stream
+#[cfg(feature = "fixtures")]
+pub(crate) async fn import_csb_fixture(
+    state: &AppState,
+    election: ElectionConfig,
+) -> Result<(), AppError> {
+    let pg_stream_id = StreamId::new();
+    let app_store = state.store_for_stream(pg_stream_id, election, true).await?;
+    let events = app_store.get_events();
+    let snapshot = AppStoreData::snapshot_until(&events, usize::MAX);
+
+    state
+        .csb_store_for_stream(StreamId::new(), election)
+        .await?
+        .update(crate::CsbEvent::Import {
+            hash: "fixtures".to_string(),
+            source_stream_id: pg_stream_id,
+            snapshot: Box::new(snapshot),
+        })
+        .await
 }
 
 async fn ensure_dev_store(

--- a/src/auth/dev_login_tests.rs
+++ b/src/auth/dev_login_tests.rs
@@ -243,7 +243,7 @@ async fn dev_login_csb_with_fixtures_creates_imported_stream() {
         panic!("unexpected event: {event:?}");
     };
 
-    assert_eq!(hash, "fixtures");
+    assert_eq!(hash, crate::csb::import::fixture::FIXTURE_IMPORT_HASH);
     assert!(!snapshot.persons.is_empty());
     assert!(!snapshot.candidate_lists.is_empty());
 }

--- a/src/auth/dev_login_tests.rs
+++ b/src/auth/dev_login_tests.rs
@@ -8,8 +8,8 @@ use tower::ServiceExt;
 use secrecy::SecretString;
 
 use crate::{
-    AppEvent, AppState, AppStore, ElectionConfig, Locale, Scope, Session, StreamId, router,
-    store::StoreEvent, test_utils::response_body_string,
+    AppEvent, AppState, AppStore, CsbEvent, ElectionConfig, Locale, Scope, Session, StreamId,
+    router, store::StoreEvent, test_utils::response_body_string,
 };
 
 const TEST_ID_CODE: &str = "999999990";
@@ -208,6 +208,44 @@ fn dev_login_csb_request(query: &str) -> Request<Body> {
         .uri(format!("/dev/login?csb=true&bsn={TEST_ID_CODE}&{query}"))
         .body(Body::empty())
         .unwrap()
+}
+
+#[cfg(feature = "fixtures")]
+#[tokio::test]
+async fn dev_login_csb_with_fixtures_creates_imported_stream() {
+    let (state, app) = test_app().await;
+
+    let response = app
+        .oneshot(dev_login_csb_request("fixtures=true"))
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::SEE_OTHER);
+
+    let csb_stores = state
+        .csb_store_registry
+        .stores_by_scope()
+        .await
+        .expect("csb stores");
+
+    assert_eq!(csb_stores.len(), 1);
+    let csb_store = &csb_stores[0];
+
+    let events = csb_store.data.read().events.clone();
+    assert_eq!(events.len(), 1);
+
+    let event = events[0].clone();
+    let StoreEvent {
+        payload: CsbEvent::Import { hash, snapshot, .. },
+        ..
+    } = event
+    else {
+        panic!("unexpected event: {event:?}");
+    };
+
+    assert_eq!(hash, "fixtures");
+    assert!(!snapshot.persons.is_empty());
+    assert!(!snapshot.candidate_lists.is_empty());
 }
 
 #[tokio::test]

--- a/src/csb/examination/pages/overview.html
+++ b/src/csb/examination/pages/overview.html
@@ -15,7 +15,7 @@
             <li>{{ "csb.finish_instruction.create_model_i1"|trans }}</li>
             <li>{{ "csb.finish_instruction.create_defects"|trans }}</li>
           </ul>
-          <button class="button md">{{ "csb.action.finish"|trans }}</button>
+          <button class="button mt-md">{{ "csb.action.finish"|trans }}</button>
         </div>
       </div>
       <h4>{{ "csb.progress"|trans }}</h4>

--- a/src/csb/import/fixture.rs
+++ b/src/csb/import/fixture.rs
@@ -1,0 +1,24 @@
+use crate::{AppError, AppState, AppStoreData, CsbEvent, ElectionConfig, StreamId};
+
+/// Create a political group stream with fixtures and import it as a CSB stream.
+pub async fn import_csb_fixture(
+    state: &AppState,
+    election: ElectionConfig,
+) -> Result<(), AppError> {
+    let pg_stream_id = StreamId::new();
+    let app_store = state.store_for_stream(pg_stream_id, election, true).await?;
+    let events = app_store.get_events();
+    let snapshot = AppStoreData::snapshot_until(&events, usize::MAX);
+
+    state
+        .csb_store_for_stream(StreamId::new(), election)
+        .await?
+        .update(CsbEvent::Import {
+            hash: "fixtures".to_string(),
+            source_stream_id: pg_stream_id,
+            snapshot: Box::new(snapshot),
+        })
+        .await?;
+
+    Ok(())
+}

--- a/src/csb/import/fixture.rs
+++ b/src/csb/import/fixture.rs
@@ -1,10 +1,24 @@
 use crate::{AppError, AppState, AppStoreData, CsbEvent, ElectionConfig, StreamId};
 
-/// Create a political group stream with fixtures and import it as a CSB stream.
+/// Marks CSB imports that were created from fixtures
+pub const FIXTURE_IMPORT_HASH: &str = "fixtures";
+
+/// Create a political group stream with fixtures and import it as a CSB stream
+/// if it doesn't exist already
 pub async fn import_csb_fixture(
     state: &AppState,
     election: ElectionConfig,
 ) -> Result<(), AppError> {
+    // Skip if a fixture import already exists in any committee-scoped stream.
+    for store in state.csb_store_registry.stores_by_scope().await? {
+        let comes_from_fixtures = store.data.read().events.first().is_some_and(
+            |e| matches!(&e.payload, CsbEvent::Import { hash, .. } if hash == FIXTURE_IMPORT_HASH),
+        );
+        if comes_from_fixtures {
+            return Ok(());
+        }
+    }
+
     let pg_stream_id = StreamId::new();
     let app_store = state.store_for_stream(pg_stream_id, election, true).await?;
     let events = app_store.get_events();
@@ -14,11 +28,37 @@ pub async fn import_csb_fixture(
         .csb_store_for_stream(StreamId::new(), election)
         .await?
         .update(CsbEvent::Import {
-            hash: "fixtures".to_string(),
+            hash: FIXTURE_IMPORT_HASH.to_string(),
             source_stream_id: pg_stream_id,
             snapshot: Box::new(snapshot),
         })
         .await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::AppState;
+
+    #[tokio::test]
+    async fn repeated_import_is_a_no_op() {
+        let state = AppState::new_for_tests().await;
+        let election = ElectionConfig::EK27;
+
+        import_csb_fixture(&state, election).await.unwrap();
+        import_csb_fixture(&state, election).await.unwrap();
+
+        let csb_stores = state
+            .csb_store_registry
+            .stores_by_scope()
+            .await
+            .expect("csb stores");
+        assert_eq!(
+            csb_stores.len(),
+            1,
+            "a second fixture import should be skipped"
+        );
+    }
 }

--- a/src/csb/import/mod.rs
+++ b/src/csb/import/mod.rs
@@ -2,9 +2,6 @@
 mod pages;
 
 #[cfg(feature = "fixtures")]
-mod fixture;
-
-#[cfg(feature = "fixtures")]
-pub use fixture::import_csb_fixture;
+pub mod fixture;
 
 pub use pages::{CsbImportPath, router};

--- a/src/csb/import/mod.rs
+++ b/src/csb/import/mod.rs
@@ -1,4 +1,10 @@
 //! CSB import flow and related routes.
 mod pages;
 
+#[cfg(feature = "fixtures")]
+mod fixture;
+
+#[cfg(feature = "fixtures")]
+pub use fixture::import_csb_fixture;
+
 pub use pages::{CsbImportPath, router};


### PR DESCRIPTION
Closes #871

# [DOD](/docs/definition-of-done.md) checklist

## For PR maintainer

Perform these checks before marking the PR as ready:

- [x] I have linked the PR to at least one issue.
- [x] I assigned the PR to myself.
- [x] I have added a description how to test this PR (see "Review Instructions").
- [x] I have added documentation where necessary.

## For reviewer

- I have read all code changes.
- I have audited the code quality.
- I have tested the changes either or both:
  - locally
  - on the test environment (preferred)
- I have validated that the PR is functionally correct (use-cases, figma designs, etc.)

### Review instructions

Select "Load fixtures" when logging in as CSB: it should now create and import a political group stream for the CSB. This works both for the select election screen and the dev login.

Because all CSB logins have access to all imported political group streams, every time you log in with fixtures enabled, another political group stream will be added.