### PR TITLE
[#838] Improve warnings for name authorisation

### DIFF
--- a/locales/en/political_group.yml
+++ b/locales/en/political_group.yml
@@ -25,8 +25,8 @@ list_submitter_data: List submitter data
 list_submitter_info: The list submitter is the only person authorised to submit the candidate list and to remedy omissions.
 list_type: List designation type
 names_size_hint_add_name: Add the statutory name of the party.
-names_size_hint_combination: Combinations must consist of at least 2 statutory names.
-names_size_hint_standalone: "Remove the unwanted names, or choose a combination of multiple registered names as the list designation type."
+names_size_hint_combination: Combinations must consist of at least two statutory names.
+names_size_hint_standalone: A standalone registered name must consist of a single name.
 no_legal_names: No statutory name
 no_list_submitter: No list submitter
 no_substitute_submitters: No substitute submitters

--- a/locales/en/political_group.yml
+++ b/locales/en/political_group.yml
@@ -24,6 +24,9 @@ list_submitter_address_info: This address will be used to send the notice of omi
 list_submitter_data: List submitter data
 list_submitter_info: The list submitter is the only person authorised to submit the candidate list and to remedy omissions.
 list_type: List designation type
+names_size_hint_add_name: Add the statutory name of the party.
+names_size_hint_combination: Combinations must consist of at least 2 statutory names.
+names_size_hint_standalone: "Remove the unwanted names, or choose a combination of multiple registered names as the list designation type."
 no_legal_names: No statutory name
 no_list_submitter: No list submitter
 no_substitute_submitters: No substitute submitters

--- a/locales/nl/political_group.yml
+++ b/locales/nl/political_group.yml
@@ -24,6 +24,9 @@ list_submitter_address_info: Naar dit adres wordt de verzuimbrief verstuurd
 list_submitter_data: Gegevens lijstinleveraar
 list_submitter_info: De lijstinleveraar is de enige persoon die bevoegd is om de kandidatenlijst in te leveren en om verzuimen te herstellen.
 list_type: Type lijstaanduiding
+names_size_hint_add_name: Voeg de statutaire naam van de partij toe.
+names_size_hint_combination: Combinaties van meerdere geregistreerde namen moeten uit minstens 2 statutaire namen bestaan.
+names_size_hint_standalone: "Verwijder de ongewenste namen, of kies bij type lijstaanduiding voor een combinatie van meerdere geregistreerde namen."
 no_legal_names: Geen statutaire naam
 no_list_submitter: Geen lijstinleveraar
 no_substitute_submitters: Geen vervangers voor het herstel van verzuimen

--- a/locales/nl/political_group.yml
+++ b/locales/nl/political_group.yml
@@ -25,8 +25,8 @@ list_submitter_data: Gegevens lijstinleveraar
 list_submitter_info: De lijstinleveraar is de enige persoon die bevoegd is om de kandidatenlijst in te leveren en om verzuimen te herstellen.
 list_type: Type lijstaanduiding
 names_size_hint_add_name: Voeg de statutaire naam van de partij toe.
-names_size_hint_combination: Combinaties van meerdere geregistreerde namen moeten uit minstens 2 statutaire namen bestaan.
-names_size_hint_standalone: "Verwijder de ongewenste namen, of kies bij type lijstaanduiding voor een combinatie van meerdere geregistreerde namen."
+names_size_hint_combination: Combinaties van meerdere geregistreerde namen moeten uit minstens twee statutaire namen bestaan.
+names_size_hint_standalone: Een op zichzelf staande geregistreerde naam moet uit één naam bestaan.
 no_legal_names: Geen statutaire naam
 no_list_submitter: Geen lijstinleveraar
 no_substitute_submitters: Geen vervangers voor het herstel van verzuimen

--- a/src/app/finalise/structs/problems.rs
+++ b/src/app/finalise/structs/problems.rs
@@ -119,7 +119,7 @@ impl AllProblems {
         let name_authorisations = match political_group.list_designation {
             Some(ListDesignation::Blank) => Vec::new(),
             list_designation => {
-                general.extend(Self::find_name_authorisation_size_problems(
+                general.extend(NameAuthorisation::get_size_problems(
                     list_designation,
                     name_authorisations.len(),
                 ));
@@ -213,28 +213,6 @@ impl AllProblems {
             );
         }
         (problems, info_problems)
-    }
-
-    pub fn find_name_authorisation_size_problems(
-        list_designation: Option<ListDesignation>,
-        authorised_names_count: usize,
-    ) -> Vec<PotentialProblems> {
-        match list_designation.unwrap_or(ListDesignation::Standalone) {
-            ListDesignation::Standalone if authorised_names_count > 1 => {
-                vec![PotentialProblems::TooManyAuthorizedNames {
-                    count: authorised_names_count - 1,
-                }]
-            }
-            ListDesignation::Standalone if authorised_names_count < 1 => {
-                vec![PotentialProblems::TooFewAuthorizedNames { count: 1 }]
-            }
-            ListDesignation::Combined if authorised_names_count < 2 => {
-                vec![PotentialProblems::TooFewAuthorizedNames {
-                    count: 2 - authorised_names_count,
-                }]
-            }
-            _ => Vec::new(),
-        }
     }
 
     pub fn find_candidate_problems(

--- a/src/app/finalise/structs/problems.rs
+++ b/src/app/finalise/structs/problems.rs
@@ -120,7 +120,7 @@ impl AllProblems {
             Some(ListDesignation::Blank) => Vec::new(),
             list_designation => {
                 general.extend(Self::find_name_authorisation_size_problems(
-                    list_designation.unwrap_or(ListDesignation::Standalone),
+                    list_designation,
                     name_authorisations.len(),
                 ));
                 let (problems, infos) = Self::find_name_authorisation_problems(name_authorisations);
@@ -215,11 +215,11 @@ impl AllProblems {
         (problems, info_problems)
     }
 
-    fn find_name_authorisation_size_problems(
-        list_designation: ListDesignation,
+    pub fn find_name_authorisation_size_problems(
+        list_designation: Option<ListDesignation>,
         authorised_names_count: usize,
     ) -> Vec<PotentialProblems> {
-        match list_designation {
+        match list_designation.unwrap_or(ListDesignation::Standalone) {
             ListDesignation::Standalone if authorised_names_count > 1 => {
                 vec![PotentialProblems::TooManyAuthorizedNames {
                     count: authorised_names_count - 1,

--- a/src/app/name_authorisations/pages/view.html
+++ b/src/app/name_authorisations/pages/view.html
@@ -16,9 +16,17 @@
         {% endif %}
       </h3>
       <p class="mb-6">{{ "political_group.authorised_agent_info"|trans }}</p>
-      {% for size_problem in size_problems %}
-        <p class="alert alert-{{ size_problem.severity().class() }}">{{ size_problem.translate(locale) }}</p>
-      {% endfor %}
+      {% if !(steps.initial && name_authorisations.is_empty()) && let Some(size_problem) = size_problem %}
+        <p class="alert alert-{{ size_problem.severity().class() }}">
+          {% if steps.is_combined() %}
+            {{ "political_group.names_size_hint_combination"|trans }}
+          {% else if name_authorisations.is_empty() %}
+            {{ "political_group.names_size_hint_add_name"|trans }}
+          {% else %}
+            {{ size_problem.translate(locale) }}. {{ "political_group.names_size_hint_standalone"|trans }}
+          {% endif %}
+        </p>
+      {% endif %}
       {% if name_authorisations.is_empty() %}
         <p class="mt-md font-italic">{{ "political_group.no_legal_names"|trans }}</p>
       {% else %}

--- a/src/app/name_authorisations/pages/view.html
+++ b/src/app/name_authorisations/pages/view.html
@@ -5,17 +5,20 @@
   <div class="steps">
     {% include "political_groups/components/steps.html" %}
     <div>
-      {% if steps.is_blank %}
+      {% if steps.is_blank() %}
         <div class="alert alert-warning">{{ "political_group.blank_list_warning"|trans }}</div>
       {% endif %}
       <h3 class="mb-6">
-        {% if steps.is_combined %}
+        {% if steps.is_combined() %}
           {{ "political_group.legal_name_data_combined"|trans }}
         {% else %}
           {{ "political_group.legal_name_data"|trans }}
         {% endif %}
       </h3>
       <p class="mb-6">{{ "political_group.authorised_agent_info"|trans }}</p>
+      {% for size_problem in size_problems %}
+        <p class="alert alert-{{ size_problem.severity().class() }}">{{ size_problem.translate(locale) }}</p>
+      {% endfor %}
       {% if name_authorisations.is_empty() %}
         <p class="mt-md font-italic">{{ "political_group.no_legal_names"|trans }}</p>
       {% else %}
@@ -26,7 +29,7 @@
           </a>
         {% endfor %}
       {% endif %}
-      {% if name_authorisations.is_empty() || steps.is_combined %}
+      {% if name_authorisations.is_empty() || steps.is_combined() %}
         <p class="mt-lg">
           <a href="{{ steps.step_url(NameAuthorisation::create_path() ) }}"
              class="button secondary icon-plus"

--- a/src/app/name_authorisations/pages/view.rs
+++ b/src/app/name_authorisations/pages/view.rs
@@ -15,7 +15,7 @@ use axum::{extract::Query, response::IntoResponse};
 #[template(path = "name_authorisations/pages/view.html")]
 struct NameAuthorisationTemplate {
     name_authorisations: Vec<NameAuthorisation>,
-    size_problems: Vec<PotentialProblems>,
+    size_problem: Option<PotentialProblems>,
     steps: PoliticalGroupSteps,
 }
 
@@ -29,7 +29,7 @@ pub async fn list_name_authorisations(
     Ok(HtmlTemplate(
         NameAuthorisationTemplate {
             name_authorisations: steps.name_authorisations.clone(),
-            size_problems: NameAuthorisation::get_size_problems(
+            size_problem: NameAuthorisation::get_size_problems(
                 steps.list_designation,
                 steps.name_authorisations.len(),
             ),

--- a/src/app/name_authorisations/pages/view.rs
+++ b/src/app/name_authorisations/pages/view.rs
@@ -4,7 +4,6 @@ use crate::{
     app::list_designation::ListDesignation,
     common::{HasSeverity, PotentialProblems, Problematic},
     filters,
-    finalise::AllProblems,
     list_submitters::ListSubmitter,
     name_authorisations::NameAuthorisation,
     political_groups::{PoliticalGroup, PoliticalGroupSteps},
@@ -30,7 +29,7 @@ pub async fn list_name_authorisations(
     Ok(HtmlTemplate(
         NameAuthorisationTemplate {
             name_authorisations: steps.name_authorisations.clone(),
-            size_problems: AllProblems::find_name_authorisation_size_problems(
+            size_problems: NameAuthorisation::get_size_problems(
                 steps.list_designation,
                 steps.name_authorisations.len(),
             ),

--- a/src/app/name_authorisations/pages/view.rs
+++ b/src/app/name_authorisations/pages/view.rs
@@ -2,8 +2,9 @@ use super::NameAuthorisationsPath;
 use crate::{
     AppError, AppStore, Context, HtmlTemplate, QueryParamState,
     app::list_designation::ListDesignation,
-    common::{HasSeverity, Problematic},
+    common::{HasSeverity, PotentialProblems, Problematic},
     filters,
+    finalise::AllProblems,
     list_submitters::ListSubmitter,
     name_authorisations::NameAuthorisation,
     political_groups::{PoliticalGroup, PoliticalGroupSteps},
@@ -15,6 +16,7 @@ use axum::{extract::Query, response::IntoResponse};
 #[template(path = "name_authorisations/pages/view.html")]
 struct NameAuthorisationTemplate {
     name_authorisations: Vec<NameAuthorisation>,
+    size_problems: Vec<PotentialProblems>,
     steps: PoliticalGroupSteps,
 }
 
@@ -28,6 +30,10 @@ pub async fn list_name_authorisations(
     Ok(HtmlTemplate(
         NameAuthorisationTemplate {
             name_authorisations: steps.name_authorisations.clone(),
+            size_problems: AllProblems::find_name_authorisation_size_problems(
+                steps.list_designation,
+                steps.name_authorisations.len(),
+            ),
             steps,
         },
         context,

--- a/src/app/name_authorisations/structs/name_authorisation.rs
+++ b/src/app/name_authorisations/structs/name_authorisation.rs
@@ -1,7 +1,8 @@
 use crate::{
     AppError, AppEvent, AppStore,
-    common::{FullName, LegalName, Problematic, Problems, Severity},
+    common::{FullName, LegalName, PotentialProblems, Problematic, Problems, Severity},
     id_newtype,
+    list_designation::ListDesignation,
 };
 use serde::{Deserialize, Serialize};
 
@@ -25,6 +26,28 @@ impl Problematic<()> for NameAuthorisation {
 }
 
 impl NameAuthorisation {
+    pub fn get_size_problems(
+        list_designation: Option<ListDesignation>,
+        name_authorisation_count: usize,
+    ) -> Vec<PotentialProblems> {
+        match list_designation.unwrap_or(ListDesignation::Standalone) {
+            ListDesignation::Standalone if name_authorisation_count > 1 => {
+                vec![PotentialProblems::TooManyAuthorizedNames {
+                    count: name_authorisation_count - 1,
+                }]
+            }
+            ListDesignation::Standalone if name_authorisation_count < 1 => {
+                vec![PotentialProblems::TooFewAuthorizedNames { count: 1 }]
+            }
+            ListDesignation::Combined if name_authorisation_count < 2 => {
+                vec![PotentialProblems::TooFewAuthorizedNames {
+                    count: 2 - name_authorisation_count,
+                }]
+            }
+            _ => Vec::new(),
+        }
+    }
+
     pub async fn create(&self, store: &AppStore) -> Result<(), AppError> {
         store
             .update(AppEvent::CreateNameAuthorisation(self.clone()))

--- a/src/app/name_authorisations/structs/name_authorisation.rs
+++ b/src/app/name_authorisations/structs/name_authorisation.rs
@@ -29,22 +29,22 @@ impl NameAuthorisation {
     pub fn get_size_problems(
         list_designation: Option<ListDesignation>,
         name_authorisation_count: usize,
-    ) -> Vec<PotentialProblems> {
+    ) -> Option<PotentialProblems> {
         match list_designation.unwrap_or(ListDesignation::Standalone) {
             ListDesignation::Standalone if name_authorisation_count > 1 => {
-                vec![PotentialProblems::TooManyAuthorizedNames {
+                Some(PotentialProblems::TooManyAuthorizedNames {
                     count: name_authorisation_count - 1,
-                }]
+                })
             }
             ListDesignation::Standalone if name_authorisation_count < 1 => {
-                vec![PotentialProblems::TooFewAuthorizedNames { count: 1 }]
+                Some(PotentialProblems::TooFewAuthorizedNames { count: 1 })
             }
             ListDesignation::Combined if name_authorisation_count < 2 => {
-                vec![PotentialProblems::TooFewAuthorizedNames {
+                Some(PotentialProblems::TooFewAuthorizedNames {
                     count: 2 - name_authorisation_count,
-                }]
+                })
             }
-            _ => Vec::new(),
+            _ => None,
         }
     }
 

--- a/src/app/political_groups/components/form.html
+++ b/src/app/political_groups/components/form.html
@@ -1,6 +1,6 @@
 <div>
   <input type="hidden" name="csrf_token" value="{{ form.data.csrf_token }}">
-  {% if steps.is_blank %}
+  {% if steps.is_blank() %}
     <div class="alert alert-warning">{{ "political_group.blank_list_warning"|trans }}</div>
   {% endif %}
   <h3 class="mb-6">{{ "common.political_group"|trans }}</h3>
@@ -9,7 +9,7 @@
       <fieldset class="checklist">
         {% let election = "election"|election_value %}
         <legend class="legend-md">
-          {% if steps.is_combined %}
+          {% if steps.is_combined() %}
             {{ "political_group.type.previous_election_results_combined"|trans(&election|election_type_title) }}
           {% else %}
             {{ "political_group.previous_election_results"|trans(&election|election_type_title) }}
@@ -46,14 +46,14 @@
         </div>
         <span class="alert alert-info hide-on-input">
           {{ "political_group.type.previous_election_results_hint"|trans }}
-          {% if steps.is_combined %}{{ "political_group.type.previous_election_results_combined_hint"|trans }}{% endif %}
+          {% if steps.is_combined() %}{{ "political_group.type.previous_election_results_combined_hint"|trans }}{% endif %}
         </span>
       </fieldset>
     </div>
     <div class="form-row">
       <div class="form-field {% if form.data.display_name.is_empty() && steps.basic_state != "empty" %}error{% endif %}">
         <label for="display_name">
-          {% if steps.is_combined %}
+          {% if steps.is_combined() %}
             {{ "political_group.display_name_combined"|trans }}
           {% else %}
             {{ "political_group.display_name"|trans }}
@@ -64,11 +64,11 @@
                value="{{ form.data.display_name }}"
                id="display_name" />
         {% for error in form|error("display_name") %}<span class="error">{{ error }}</span>{% endfor %}
-        {% if !steps.is_combined %}<span class="hint">{{ "political_group.type.display_name_hint"|trans }}</span>{% endif %}
+        {% if !steps.is_combined() %}<span class="hint">{{ "political_group.type.display_name_hint"|trans }}</span>{% endif %}
       </div>
     </div>
     <div class="form-row">
-      {% if steps.is_combined %}
+      {% if steps.is_combined() %}
         <span class="alert alert-info">{{ "political_group.type.display_name_combined_hint"|trans }}</span>
       {% endif %}
     </div>

--- a/src/app/political_groups/components/steps.html
+++ b/src/app/political_groups/components/steps.html
@@ -5,21 +5,21 @@
          class="{{ steps.list_designation_state }}">{{ "political_group.list_type"|trans }}</a>
     </li>
     <li>
-      <a {% if !steps.is_blank %}href="{{ steps.step_url(PoliticalGroup::update_path() ) }}"{% endif %}
-         class="{% if steps.is_blank %}disabled {% endif %}{{ steps.basic_state }}"
+      <a {% if !steps.is_blank() %}href="{{ steps.step_url(PoliticalGroup::update_path() ) }}"{% endif %}
+         class="{% if steps.is_blank() %}disabled {% endif %}{{ steps.basic_state }}"
          data-href="{{ PoliticalGroup::update_path() }}"
          data-state-class="{{ steps.basic_state }}"
          data-skip-if-blank>{{ "political_group.basic_information_political_group"|trans }}</a>
     </li>
     <li>
-      <a {% if !steps.is_blank %}href="{{ steps.step_url(NameAuthorisation::list_path() ) }}"{% endif %}
-         class="{% if steps.is_blank %}disabled {% endif %}{{ steps.name_authorisations_state }}"
+      <a {% if !steps.is_blank() %}href="{{ steps.step_url(NameAuthorisation::list_path() ) }}"{% endif %}
+         class="{% if steps.is_blank() %}disabled {% endif %}{{ steps.name_authorisations_state }}"
          data-href="{{ NameAuthorisation::list_path() }}"
          data-state-class="{{ steps.name_authorisations_state }}"
          data-label="{{ "political_group.legal_name_data"|trans }}"
          data-label-combined="{{ "political_group.legal_name_data_combined"|trans }}"
          data-skip-if-blank>
-        {% if steps.is_combined %}
+        {% if steps.is_combined() %}
           {{ "political_group.legal_name_data_combined"|trans }}
         {% else %}
           {{ "political_group.legal_name_data"|trans }}

--- a/src/app/political_groups/steps.rs
+++ b/src/app/political_groups/steps.rs
@@ -144,6 +144,22 @@ mod tests {
     };
 
     #[tokio::test]
+    async fn name_authorisations_state_error_when_too_many() -> Result<(), AppError> {
+        let store = AppStore::new_for_test();
+        sample_name_authorisation(NameAuthorisationId::new())
+            .create(&store)
+            .await?;
+        sample_name_authorisation(NameAuthorisationId::new())
+            .create(&store)
+            .await?;
+
+        let steps = PoliticalGroupSteps::new(&store, false)?;
+        assert_eq!(steps.name_authorisations_state, "error");
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn submitter_state_empty_with_initial() -> Result<(), AppError> {
         let store = AppStore::new_for_test();
         sample_name_authorisation(NameAuthorisationId::new())

--- a/src/app/political_groups/steps.rs
+++ b/src/app/political_groups/steps.rs
@@ -2,7 +2,7 @@ use axum_extra::routing::TypedPath;
 
 use crate::{
     AppError, AppStore, QueryParamState,
-    app::list_designation::ListDesignation,
+    app::{finalise::AllProblems, list_designation::ListDesignation},
     common::{HasSeverity, Problematic, Severity},
     list_submitters::ListSubmitter,
     name_authorisations::NameAuthorisation,
@@ -14,8 +14,7 @@ pub struct PoliticalGroupSteps {
     pub name_authorisations: Vec<NameAuthorisation>,
     pub list_submitter: ListSubmitter,
     pub substitute_submitters: Vec<ListSubmitter>,
-    pub is_blank: bool,
-    pub is_combined: bool,
+    pub list_designation: Option<ListDesignation>,
     pub initial: bool,
 
     pub list_designation_state: &'static str,
@@ -31,17 +30,13 @@ impl PoliticalGroupSteps {
         let list_submitter = store.get_list_submitter();
         let substitute_submitters = store.get_substitute_submitters();
 
-        let is_blank = political_group.list_designation == Some(ListDesignation::Blank);
-        let is_combined = political_group.list_designation == Some(ListDesignation::Combined);
-
         Ok(Self {
             initial,
-            is_blank,
-            is_combined,
             list_designation_state: Self::list_designation_state(&political_group),
             basic_state: Self::basic_state(initial, &political_group),
             name_authorisations_state: Self::name_authorisations_state(
                 initial,
+                political_group.list_designation,
                 &name_authorisations,
             ),
             submitters_state: Self::submitters_state(
@@ -52,6 +47,7 @@ impl PoliticalGroupSteps {
             name_authorisations,
             list_submitter,
             substitute_submitters,
+            list_designation: political_group.list_designation,
         })
     }
 
@@ -73,15 +69,25 @@ impl PoliticalGroupSteps {
 
     fn name_authorisations_state(
         fine_if_empty: bool,
+        list_designation: Option<ListDesignation>,
         name_authorisations: &[NameAuthorisation],
     ) -> &'static str {
         if name_authorisations.is_empty() {
             return if fine_if_empty { "empty" } else { "warning" };
         }
 
+        let size_severity = AllProblems::find_name_authorisation_size_problems(
+            list_designation,
+            name_authorisations.len(),
+        )
+        .iter()
+        .map(|p| p.severity())
+        .max();
+
         match name_authorisations
             .iter()
             .filter_map(|na| na.get_problems(()).highest_severity())
+            .chain(size_severity)
             .max()
         {
             None => "ok",
@@ -108,6 +114,14 @@ impl PoliticalGroupSteps {
             None => "ok",
             Some(severity) => severity.class(),
         }
+    }
+
+    pub fn is_blank(&self) -> bool {
+        self.list_designation == Some(ListDesignation::Blank)
+    }
+
+    pub fn is_combined(&self) -> bool {
+        self.list_designation == Some(ListDesignation::Combined)
     }
 
     /// Returns the URL for a step link, preserving `?initial=true`

--- a/src/app/political_groups/steps.rs
+++ b/src/app/political_groups/steps.rs
@@ -2,7 +2,7 @@ use axum_extra::routing::TypedPath;
 
 use crate::{
     AppError, AppStore, QueryParamState,
-    app::{finalise::AllProblems, list_designation::ListDesignation},
+    app::list_designation::ListDesignation,
     common::{HasSeverity, Problematic, Severity},
     list_submitters::ListSubmitter,
     name_authorisations::NameAuthorisation,
@@ -76,13 +76,11 @@ impl PoliticalGroupSteps {
             return if fine_if_empty { "empty" } else { "warning" };
         }
 
-        let size_severity = AllProblems::find_name_authorisation_size_problems(
-            list_designation,
-            name_authorisations.len(),
-        )
-        .iter()
-        .map(|p| p.severity())
-        .max();
+        let size_severity =
+            NameAuthorisation::get_size_problems(list_designation, name_authorisations.len())
+                .iter()
+                .map(|p| p.severity())
+                .max();
 
         match name_authorisations
             .iter()


### PR DESCRIPTION
Closes #838

# [DOD](/docs/definition-of-done.md) checklist

## For PR maintainer

Perform these checks before marking the PR as ready:

- [x] I have linked the PR to at least one issue.
- [x] I assigned the PR to myself.
- [x] I have added a description how to test this PR (see "Review Instructions").
- [x] [For bug fixes only] I have added a regression test for the fixed bug.
- [x] I have added documentation where necessary.

## For reviewer

- I have read all code changes.
- I have audited the code quality.
- I have tested the changes either or both:
  - locally
  - on the test environment (preferred)
- I have validated that the PR is functionally correct (use-cases, figma designs, etc.)

### Review instructions

Problems with the number of name authorisations now show warning/errors in the sidebar and on the name authorisation page:
<img width="1092" height="662" alt="image" src="https://github.com/user-attachments/assets/fe09d227-3753-4b63-9776-b5746f7acc0e" />

