### PR TITLE
[#854] dont show no candidate list warning on homepage

### DIFF
--- a/src/app/common/pages/index.rs
+++ b/src/app/common/pages/index.rs
@@ -49,11 +49,9 @@ pub async fn index(
         AllProblems::find_list_problems(&CandidateListSummary::list(&store), &store)?;
 
     // Don't show NoCandidateList problem on the home page, only on the finalise page
-    list_problems.general = list_problems
+    list_problems
         .general
-        .into_iter()
-        .filter(|problem| *problem != PotentialProblems::NoCandidateList)
-        .collect();
+        .retain(|problem| *problem != PotentialProblems::NoCandidateList);
 
     let (problematic_lists, general_list_problems, problematic_lists_severity) =
         if list_problems.is_empty() {

--- a/src/app/common/pages/index.rs
+++ b/src/app/common/pages/index.rs
@@ -4,8 +4,11 @@ use axum::response::IntoResponse;
 use super::IndexPath;
 
 use crate::{
-    AppResponse, AppStore, Context, HtmlTemplate, candidate_lists::CandidateListSummary,
-    common::Severity, filters, finalise::AllProblems,
+    AppResponse, AppStore, Context, HtmlTemplate,
+    candidate_lists::CandidateListSummary,
+    common::{PotentialProblems, Severity},
+    filters,
+    finalise::AllProblems,
 };
 
 #[derive(Template)]
@@ -50,12 +53,15 @@ pub async fn index(
             (0, 0, "")
         } else {
             let list_count = list_problems.per_list.len();
-            let general_count = list_problems.general.len();
+            let general_count = list_problems
+                .general
+                .iter()
+                .filter(|&problem| problem != &PotentialProblems::NoCandidateList)
+                .count();
             let severity_class = list_problems
                 .highest_severity()
                 .map(|s| s.class())
                 .unwrap_or_default();
-
             (list_count, general_count, severity_class)
         };
 

--- a/src/app/common/pages/index.rs
+++ b/src/app/common/pages/index.rs
@@ -45,19 +45,22 @@ pub async fn index(
         (problems.len() + general_infos.len(), severity_class)
     };
     // no infos, these are also not shown on the candidate list overview page
-    let (list_problems, _) =
+    let (mut list_problems, _) =
         AllProblems::find_list_problems(&CandidateListSummary::list(&store), &store)?;
+
+    // Don't show NoCandidateList problem on the home page, only on the finalise page
+    list_problems.general = list_problems
+        .general
+        .into_iter()
+        .filter(|problem| *problem != PotentialProblems::NoCandidateList)
+        .collect();
 
     let (problematic_lists, general_list_problems, problematic_lists_severity) =
         if list_problems.is_empty() {
             (0, 0, "")
         } else {
             let list_count = list_problems.per_list.len();
-            let general_count = list_problems
-                .general
-                .iter()
-                .filter(|&problem| problem != &PotentialProblems::NoCandidateList)
-                .count();
+            let general_count = list_problems.general.len();
             let severity_class = list_problems
                 .highest_severity()
                 .map(|s| s.class())


### PR DESCRIPTION
Closes #854

# [DOD](/docs/definition-of-done.md) checklist

closes #854

## For PR maintainer

Perform these checks before marking the PR as ready:

- [x] I have linked the PR to at least one issue.
- [x] I assigned the PR to myself.
- [x] I have added a description how to test this PR (see "Review Instructions").

## For reviewer

- I have read all code changes.
- I have audited the code quality.
- I have tested the changes either or both:
  - locally
  - on the test environment (preferred)
- I have validated that the PR is functionally correct (use-cases, figma designs, etc.)

### Review instructions

Don't load fixtures and go to the home page. See no list candidate error. The error is still present on the finalize page.

Other errors (such as empty candidate list) still show up on.
