### PR TITLE
[#942] Link candidate list omissions to electoral districts

### DIFF
--- a/frontend/scripts/form-inputs/omission-preset.ts
+++ b/frontend/scripts/form-inputs/omission-preset.ts
@@ -23,6 +23,15 @@ function selectedDistrictNames(): string[] {
   return names;
 }
 
+const PLACEHOLDER_RE = /\{[^}]+\}/;
+
+function updatePlaceholderWarning(
+  description: HTMLTextAreaElement,
+  warning: HTMLElement,
+) {
+  warning.classList.toggle("hidden", !PLACEHOLDER_RE.test(description.value));
+}
+
 // Fill the omission description and help-text fields when a preset is clicked.
 export default function omissionPreset() {
   const title = document.querySelector<HTMLInputElement>(
@@ -37,10 +46,17 @@ export default function omissionPreset() {
   const recoverable = document.querySelector<HTMLInputElement>(
     "[data-omission-recoverable]",
   );
+  const warning = document.querySelector<HTMLElement>(
+    "[data-omission-placeholder-warning]",
+  );
 
-  if (!description) {
+  if (!description || !warning) {
     return;
   }
+
+  description.addEventListener("input", () =>
+    updatePlaceholderWarning(description, warning),
+  );
 
   document
     .querySelectorAll<HTMLButtonElement>("[data-omission-preset]")
@@ -59,6 +75,7 @@ export default function omissionPreset() {
         }
 
         setValue(description, desc);
+        updatePlaceholderWarning(description, warning);
         setValue(helpText, button.dataset.helpText);
         if (recoverable) {
           recoverable.checked = button.dataset.recoverable !== "false";

--- a/frontend/scripts/form-inputs/omission-preset.ts
+++ b/frontend/scripts/form-inputs/omission-preset.ts
@@ -23,13 +23,11 @@ function selectedDistrictNames(): string[] {
   return names;
 }
 
-const PLACEHOLDER_RE = /\{[^}]+\}/;
-
 function updatePlaceholderWarning(
   description: HTMLTextAreaElement,
   warning: HTMLElement,
 ) {
-  warning.classList.toggle("hidden", !PLACEHOLDER_RE.test(description.value));
+  warning.classList.toggle("hidden", !description.value.includes("{"));
 }
 
 // Fill the omission description and help-text fields when a preset is clicked.
@@ -69,7 +67,7 @@ export default function omissionPreset() {
         if (districts.length === 1) {
           desc = desc.replace("{district}", districts[0]);
         } else if (districts.length > 1) {
-          const last = districts[districts.length - 1];
+          const last = districts.at(-1);
           const rest = districts.slice(0, -1);
           desc = desc.replace("{districts}", `${rest.join(", ")} en ${last}`);
         }

--- a/frontend/scripts/form-inputs/omission-preset.ts
+++ b/frontend/scripts/form-inputs/omission-preset.ts
@@ -8,6 +8,21 @@ function setValue(
   }
 }
 
+// Return Dutch names of the currently checked district checkboxes
+function selectedDistrictNames(): string[] {
+  const names: string[] = [];
+  document
+    .querySelectorAll<HTMLInputElement>(
+      'input[name="electoral_districts"]:checked',
+    )
+    .forEach((input) => {
+      if (input.dataset.districtNl) {
+        names.push(input.dataset.districtNl);
+      }
+    });
+  return names;
+}
+
 // Fill the omission description and help-text fields when a preset is clicked.
 export default function omissionPreset() {
   const title = document.querySelector<HTMLInputElement>(
@@ -32,7 +47,18 @@ export default function omissionPreset() {
     .forEach((button) => {
       button.addEventListener("click", () => {
         setValue(title, button.dataset.title);
-        setValue(description, button.dataset.description);
+
+        const districts = selectedDistrictNames();
+        let desc = button.dataset.description ?? "";
+        if (districts.length === 1) {
+          desc = desc.replace("{district}", districts[0]);
+        } else if (districts.length > 1) {
+          const last = districts[districts.length - 1];
+          const rest = districts.slice(0, -1);
+          desc = desc.replace("{districts}", `${rest.join(", ")} en ${last}`);
+        }
+
+        setValue(description, desc);
         setValue(helpText, button.dataset.helpText);
         if (recoverable) {
           recoverable.checked = button.dataset.recoverable !== "false";

--- a/frontend/scripts/form-inputs/select-all-checkbox.ts
+++ b/frontend/scripts/form-inputs/select-all-checkbox.ts
@@ -4,10 +4,11 @@ export default function setupSelectAllCheckbox() {
     selectAllCheckbox: HTMLInputElement,
     checkList: NodeListOf<HTMLInputElement>,
   ) => {
-    if (Array.from(checkList).every((cb) => cb.checked)) {
+    const enabled = Array.from(checkList).filter((cb) => !cb.disabled);
+    if (enabled.every((cb) => cb.checked)) {
       selectAllCheckbox.checked = true;
       selectAllCheckbox.indeterminate = false;
-    } else if (Array.from(checkList).every((cb) => !cb.checked)) {
+    } else if (enabled.every((cb) => !cb.checked)) {
       selectAllCheckbox.checked = false;
       selectAllCheckbox.indeterminate = false;
     } else {
@@ -36,7 +37,9 @@ export default function setupSelectAllCheckbox() {
       // add event listener for the select all checkbox
       selectAllCheckbox.addEventListener("change", (_) => {
         checkList.forEach((checkbox) => {
-          checkbox.checked = selectAllCheckbox.checked;
+          if (!checkbox.disabled) {
+            checkbox.checked = selectAllCheckbox.checked;
+          }
         });
         determineSelectAllState(selectAllCheckbox, checkList);
       });

--- a/frontend/styles/checkbox.css
+++ b/frontend/styles/checkbox.css
@@ -8,14 +8,16 @@
   gap: var(--space-4);
 
   &.grid {
-    --checklist-column-min-width: 25rem;
-    display: grid;
-    grid-template-columns: repeat(
-        auto-fit,
-        minmax(var(--checklist-column-min-width), 1fr)
-      );
-    align-items: start;
-    gap: var(--space-md) 0;
+    --checklist-column-min-width: 20rem;
+    display: block;
+    columns: var(--checklist-column-min-width);
+    column-gap: 0;
+    width: 100%;
+
+    > .checkbox {
+      break-inside: avoid;
+      margin-bottom: var(--space-md);
+    }
   }
 
   legend {

--- a/frontend/styles/form.css
+++ b/frontend/styles/form.css
@@ -353,7 +353,6 @@
 }
 
 .form input:disabled {
-  background-color: var(--bg-gray-light);
   cursor: not-allowed;
 }
 

--- a/frontend/styles/form.css
+++ b/frontend/styles/form.css
@@ -141,6 +141,11 @@
     .form-field {
       flex: 1;
     }
+
+    &.card {
+      padding: var(--space-8);
+      border: none;
+    }
   }
 
   fieldset {

--- a/frontend/styles/omission.css
+++ b/frontend/styles/omission.css
@@ -1,3 +1,7 @@
+.omission-overlay .checklist.grid {
+  --checklist-column-min-width: 12em;
+}
+
 .omission-presets,
 .omission-badges {
   display: flex;

--- a/locales/en/csb.yml
+++ b/locales/en/csb.yml
@@ -102,6 +102,7 @@ omission:
   form:
     description_label: Add I 1 omission
     districts_intro: "This omission applies to:"
+    placeholder_warning: "The text still contains unfilled placeholders."
     help_text_label: Add omission letter note
     presets_heading: Add one of these omissions
     recoverable_label: Recoverable omission

--- a/locales/en/csb.yml
+++ b/locales/en/csb.yml
@@ -101,6 +101,7 @@ omission:
     singular: 1 omission
   form:
     description_label: Add I 1 omission
+    districts_intro: "This omission applies to:"
     help_text_label: Add omission letter note
     presets_heading: Add one of these omissions
     recoverable_label: Recoverable omission

--- a/locales/nl/csb.yml
+++ b/locales/nl/csb.yml
@@ -101,6 +101,7 @@ omission:
     singular: 1 verzuim
   form:
     description_label: I1 verzuim toevoegen
+    districts_intro: "Dit verzuim geldt voor:"
     help_text_label: Verzuimbriefnotitie toevoegen
     presets_heading: Voeg één van deze verzuimen toe
     recoverable_label: Herstelbaar verzuim

--- a/locales/nl/csb.yml
+++ b/locales/nl/csb.yml
@@ -102,6 +102,7 @@ omission:
   form:
     description_label: I1 verzuim toevoegen
     districts_intro: "Dit verzuim geldt voor:"
+    placeholder_warning: "De tekst bevat nog niet ingevulde placeholders."
     help_text_label: Verzuimbriefnotitie toevoegen
     presets_heading: Voeg één van deze verzuimen toe
     recoverable_label: Herstelbaar verzuim

--- a/src/csb/audit_log/pages/list.rs
+++ b/src/csb/audit_log/pages/list.rs
@@ -300,7 +300,7 @@ mod tests {
         csb_store.update(CsbEvent::SetFinished(true)).await?;
         csb_store
             .update(CsbEvent::CreateOmission(Omission::new(
-                OmissionCategory::General,
+                OmissionCategory::PoliticalGroup,
                 "test".to_string(),
                 "test".to_string(),
                 "test".to_string(),

--- a/src/csb/examination/forms/omission_form.rs
+++ b/src/csb/examination/forms/omission_form.rs
@@ -1,7 +1,7 @@
 use serde::Deserialize;
 use validate::Validate;
 
-use crate::csb::Omission;
+use crate::{ElectoralDistrict, csb::Omission};
 
 /// Form backing the "add omission" dialog. The category is not part of the form:
 /// it is derived from the dialog's path parameters and set on the resulting
@@ -22,6 +22,10 @@ pub struct OmissionForm {
     /// falls back to `false` here, explicitly marking the omission irreparable.
     #[serde(default)]
     pub recoverable: bool,
+    /// The electoral districts selected for a CandidateList omission.
+    /// Ignored for other omission types; validated in the handler.
+    #[validate(ignore)]
+    pub electoral_districts: Vec<ElectoralDistrict>,
 }
 
 impl Default for OmissionForm {
@@ -33,6 +37,7 @@ impl Default for OmissionForm {
             // A fresh omission is recoverable unless the committee marks it
             // otherwise (the common case); presets override this via the dialog.
             recoverable: true,
+            electoral_districts: Vec::new(),
         }
     }
 }
@@ -44,6 +49,7 @@ impl From<Omission> for OmissionForm {
             description: value.description,
             help_text: value.help_text,
             recoverable: value.recoverable,
+            electoral_districts: Vec::new(),
         }
     }
 }

--- a/src/csb/examination/pages/candidate_list.rs
+++ b/src/csb/examination/pages/candidate_list.rs
@@ -44,7 +44,7 @@ pub async fn overview(
         })
         .collect::<Vec<_>>();
 
-    let omissions = store.get_candidate_list_omissions(list_id);
+    let omissions = store.get_candidate_list_omissions(list_id)?;
 
     Ok(HtmlTemplate(
         CsbCandidateListTemplate {
@@ -119,7 +119,7 @@ mod tests {
         let list_id = CandidateListId::new();
         store.set_candidate_list(sample_candidate_list(list_id));
         Omission::new(
-            OmissionCategory::CandidateList(list_id),
+            OmissionCategory::CandidateList(vec![crate::ElectoralDistrict::UT]),
             "Too many candidates".to_string(),
             "The list holds more candidates than allowed.".to_string(),
             String::new(),

--- a/src/csb/examination/pages/general_information.html
+++ b/src/csb/examination/pages/general_information.html
@@ -116,9 +116,9 @@
           </div>
           <div class="card-content">
             <p>{{ "csb.general.overview_text"|trans }}</p>
-            {% if !general_omissions.is_empty() %}
+            {% if !political_group_omissions.is_empty() %}
               <ul class="omission-badges">
-                {% for omission in general_omissions %}
+                {% for omission in political_group_omissions %}
                   <li class="omission-badge{% if !omission.recoverable %} omission-badge-unrecoverable{% endif %}">{{ omission.title }}</li>
                 {% endfor %}
               </ul>

--- a/src/csb/examination/pages/general_information.rs
+++ b/src/csb/examination/pages/general_information.rs
@@ -20,8 +20,7 @@ struct CsbGeneralInformationTemplate {
     name_authorisations: Vec<NameAuthorisation>,
     list_submitter: ListSubmitter,
     substitute_submitters: Vec<ListSubmitter>,
-    /// Omissions added at the political group's general information level.
-    general_omissions: Vec<Omission>,
+    political_group_omissions: Vec<Omission>,
     restoration_count: usize,
 }
 
@@ -36,7 +35,7 @@ pub async fn overview(
     let name_authorisations = store.get_name_authorisations();
     let list_submitter = store.get_list_submitter();
     let substitute_submitters = store.get_substitute_submitters();
-    let general_omissions = store.get_general_omissions();
+    let political_group_omissions = store.get_political_group_omissions();
 
     Ok(HtmlTemplate(
         CsbGeneralInformationTemplate {
@@ -44,7 +43,7 @@ pub async fn overview(
             name_authorisations,
             list_submitter,
             substitute_submitters,
-            general_omissions,
+            political_group_omissions,
             restoration_count: rng().random_range(0..=20),
         },
         context,
@@ -105,13 +104,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn renders_added_general_omissions_as_badges() {
+    async fn renders_added_political_group_omissions_as_badges() {
         use crate::csb::OmissionCategory;
 
         let store = CsbStore::new_for_test();
         let stream_id = store.stream_id;
         Omission::new(
-            OmissionCategory::General,
+            OmissionCategory::PoliticalGroup,
             "Deposit missing".to_string(),
             "The deposit has not been paid.".to_string(),
             String::new(),
@@ -146,7 +145,7 @@ mod tests {
         let store = CsbStore::new_for_test();
         let stream_id = store.stream_id;
         let mut omission = Omission::new(
-            OmissionCategory::General,
+            OmissionCategory::PoliticalGroup,
             "Unregistered designation".to_string(),
             "The designation is not registered.".to_string(),
             String::new(),

--- a/src/csb/examination/pages/omission.html
+++ b/src/csb/examination/pages/omission.html
@@ -72,6 +72,7 @@
                   rows="5"
                   data-omission-description>{{ form.data.description }}</textarea>
         {% for error in form|error("description") %}<span class="error">{{ error }}</span>{% endfor %}
+        <span class="warning hidden" data-omission-placeholder-warning>{{ "csb.omission.form.placeholder_warning"|trans }}</span>
       </p>
     </div>
     <div class="form-row">

--- a/src/csb/examination/pages/omission.html
+++ b/src/csb/examination/pages/omission.html
@@ -8,6 +8,32 @@
 {% endblock %}
 {% block overlay_form %}
   <fieldset class="omission-form">
+    {% if show_districts %}
+      <div class="form-row card">
+        <p>{{ "csb.omission.form.districts_intro"|trans }}</p>
+        <div class="checkbox select-all-checkbox">
+          <input type="checkbox"
+                 for-checklist="omission_district_list"
+                 id="select-all-districts" />
+          <label for="select-all-districts">{{ "candidate_list.actions.select_all_districts"|trans }}</label>
+        </div>
+        {% let election = "election"|election_value %}
+        <div class="checklist grid" id="omission_district_list">
+          {% for d in election.electoral_districts() %}
+            <div class="checkbox">
+              <input type="checkbox"
+                     name="electoral_districts"
+                     id="omission_district_{{ d.code() }}"
+                     value="{{ d.serde_name() }}"
+                     data-district-nl="{{ d|district_title_nl }}"
+                     {% if form.data.electoral_districts.contains(&d) %}checked{% endif %} />
+              <label for="omission_district_{{ d.code() }}">{{ d|district_name }}</label>
+            </div>
+          {% endfor %}
+        </div>
+        {% for error in form|error("electoral_districts") %}<span class="error">{{ error }}</span>{% endfor %}
+      </div>
+    {% endif %}
     {% if !presets.is_empty() %}
       <p class="form-field">
         <span class="label">{{ "csb.omission.form.presets_heading"|trans }}</span>

--- a/src/csb/examination/pages/omission.html
+++ b/src/csb/examination/pages/omission.html
@@ -8,7 +8,7 @@
 {% endblock %}
 {% block overlay_form %}
   <fieldset class="omission-form">
-    {% if show_districts %}
+    {% if !available_districts.is_empty() %}
       <div class="form-row card">
         <p>{{ "csb.omission.form.districts_intro"|trans }}</p>
         <div class="checkbox select-all-checkbox">
@@ -20,13 +20,14 @@
         {% let election = "election"|election_value %}
         <div class="checklist grid" id="omission_district_list">
           {% for d in election.electoral_districts() %}
-            <div class="checkbox">
+            <div class="checkbox {% if !available_districts.contains(&d) %}disabled{% endif %}">
               <input type="checkbox"
                      name="electoral_districts"
                      id="omission_district_{{ d.code() }}"
                      value="{{ d.serde_name() }}"
                      data-district-nl="{{ d|district_title_nl }}"
-                     {% if form.data.electoral_districts.contains(&d) %}checked{% endif %} />
+                     {% if form.data.electoral_districts.contains(&d) %}checked{% endif %}
+                     {% if !available_districts.contains(&d) %}disabled{% endif %} />
               <label for="omission_district_{{ d.code() }}">{{ d|district_name }}</label>
             </div>
           {% endfor %}

--- a/src/csb/examination/pages/omission/mod.rs
+++ b/src/csb/examination/pages/omission/mod.rs
@@ -18,7 +18,7 @@ use crate::{
             },
         },
     },
-    form::FormData,
+    form::{FormData, ValidationError},
 };
 
 mod urls;
@@ -76,9 +76,10 @@ impl OmissionTarget {
                 form,
                 overlay: Overlay::new(query),
                 close_action: return_path(self, &political_group),
-                presets: preset_views(self, store, context.session.locale),
+                presets: preset_views(self, store),
                 add_tab_url: add_url(self),
                 overview_tab_url: overview_url(self),
+                show_districts: self.omission_type == OmissionType::CandidateList,
             },
             context,
         )
@@ -116,7 +117,7 @@ pub async fn overview(
         CsbOmissionOverviewTemplate {
             overlay: Overlay::new(&query),
             close_action: return_path(&target, &political_group),
-            omissions: omission_views(&target, &store, &overview_tab_url),
+            omissions: omission_views(&target, &store, &overview_tab_url)?,
             add_tab_url: add_url(&target),
             overview_tab_url,
         },
@@ -137,18 +138,37 @@ pub async fn add_omission_submit(
 ) -> Result<Response, AppError> {
     let target = OmissionTarget::from_add_path(path, list_query);
 
+    // For candidate list omissions the districts are required
+    let districts = form.electoral_districts.clone();
+    if target.omission_type == OmissionType::CandidateList && districts.is_empty() {
+        let errors = vec![(
+            "electoral_districts".to_string(),
+            ValidationError::ChooseAtLeastOneOption,
+        )];
+        return Ok(target.render_add_form(
+            FormData::new_with_errors(form, errors),
+            &query,
+            context,
+            &store,
+        ));
+    }
+
     match form.validate_create() {
         Err(form_data) => Ok(target.render_add_form(form_data, &query, context, &store)),
         Ok(mut omission) => {
-            // A general candidate omission applies to the person on every list,
-            // so the list context is dropped from the persisted category even
-            // though it still drives the return path below.
-            let category_list = if target.general { None } else { target.list };
-            omission.category = OmissionCategory::from_type_and_reference(
-                target.omission_type,
-                target.reference,
-                category_list,
-            );
+            omission.category = if target.omission_type == OmissionType::CandidateList {
+                OmissionCategory::CandidateList(districts)
+            } else {
+                // A general candidate omission applies to the person on every list,
+                // so the list context is dropped from the persisted category even
+                // though it still drives the return path below.
+                let category_list = if target.general { None } else { target.list };
+                OmissionCategory::from_type_and_reference(
+                    target.omission_type,
+                    target.reference,
+                    category_list,
+                )
+            };
             omission.create(&store).await?;
 
             let political_group = CsbPoliticalGroup::new_from_csb_store(&store);
@@ -186,7 +206,7 @@ mod tests {
         candidate_lists::CandidateListId,
         csb::{Omission, OmissionType},
         persons::PersonId,
-        test_utils::response_body_string,
+        test_utils::{response_body_string, sample_candidate_list},
     };
 
     fn sample_form() -> OmissionForm {
@@ -195,6 +215,7 @@ mod tests {
             description: "De waarborgsom ontbreekt.".to_string(),
             help_text: "Please pay the deposit.".to_string(),
             recoverable: true,
+            electoral_districts: Vec::new(),
         }
     }
 
@@ -260,9 +281,12 @@ mod tests {
         let stream_id = store.stream_id;
         let list = CandidateListId::new();
 
-        // A recoverable and an irreparable omission on the same candidate list.
+        // Store the list so get_candidate_list_omissions can look up its districts.
+        store.set_candidate_list(sample_candidate_list(list));
+
+        // A recoverable and an irreparable omission covering the list's district.
         Omission::new(
-            OmissionCategory::CandidateList(list),
+            OmissionCategory::CandidateList(vec![crate::ElectoralDistrict::UT]),
             "Waarborgsom ontbreekt".to_string(),
             "De waarborgsom ontbreekt.".to_string(),
             "Betaal de waarborgsom.".to_string(),
@@ -271,7 +295,7 @@ mod tests {
         .await
         .unwrap();
         let mut irreparable = Omission::new(
-            OmissionCategory::CandidateList(list),
+            OmissionCategory::CandidateList(vec![crate::ElectoralDistrict::UT]),
             "Aanduiding niet geregistreerd".to_string(),
             "De aanduiding is niet geregistreerd.".to_string(),
             String::new(),
@@ -323,16 +347,17 @@ mod tests {
         let store = CsbStore::new_for_test();
         let stream_id = store.stream_id;
         let list = CandidateListId::new();
+        store.set_candidate_list(sample_candidate_list(list));
 
         let omission = Omission::new(
-            OmissionCategory::CandidateList(list),
+            OmissionCategory::CandidateList(vec![crate::ElectoralDistrict::UT]),
             "Waarborgsom ontbreekt".to_string(),
             "De waarborgsom ontbreekt.".to_string(),
             String::new(),
         );
         omission.create(&store).await.unwrap();
         let omission_id = omission.id;
-        assert_eq!(store.get_candidate_list_omissions(list).len(), 1);
+        assert_eq!(store.get_candidate_list_omissions(list).unwrap().len(), 1);
 
         let response = delete_omission(
             CsbDeleteOmissionPath {
@@ -349,9 +374,8 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::SEE_OTHER);
         // The omission is gone...
-        assert!(store.get_candidate_list_omissions(list).is_empty());
-        // ...and without an explicit redirect we fall back to the candidate list
-        // overview it belonged to.
+        assert!(store.get_candidate_list_omissions(list).unwrap().is_empty());
+        // ...and without an explicit redirect we fall back to the political group overview
         let location = response
             .headers()
             .get("Location")
@@ -359,7 +383,7 @@ mod tests {
             .to_str()
             .unwrap();
         assert!(location.contains(&format!(
-            "/csb/examination/{stream_id}/omission/candidate-list/{list}/overview"
+            "/csb/examination/{stream_id}/omission/political-group/{stream_id}/overview"
         )));
     }
 
@@ -432,7 +456,10 @@ mod tests {
         let stream_id = store.stream_id;
         let list = CandidateListId::new();
         let context = CsbContext::new_test();
-        let form = sample_form();
+        let form = OmissionForm {
+            electoral_districts: vec![crate::ElectoralDistrict::GR, crate::ElectoralDistrict::DR],
+            ..sample_form()
+        };
 
         let response = add_omission_submit(
             CsbAddOmissionPath {
@@ -464,9 +491,39 @@ mod tests {
         assert_eq!(omission.title, "Waarborgsom ontbreekt");
         assert_eq!(omission.description, "De waarborgsom ontbreekt.");
         assert!(matches!(
-            omission.category,
-            OmissionCategory::CandidateList(id) if id == list
+            &omission.category,
+            OmissionCategory::CandidateList(districts)
+                if districts == &[crate::ElectoralDistrict::GR, crate::ElectoralDistrict::DR]
         ));
+    }
+
+    #[tokio::test]
+    async fn add_candidate_list_omission_without_districts_rerenders_form() {
+        let store = CsbStore::new_for_test();
+        let stream_id = store.stream_id;
+        let list = CandidateListId::new();
+        let context = CsbContext::new_test();
+        // No districts selected: should re-render the form with an error
+        let form = sample_form();
+
+        let response = add_omission_submit(
+            CsbAddOmissionPath {
+                stream_id,
+                omission_type: OmissionType::CandidateList,
+                reference: list.into(),
+            },
+            context,
+            store.clone(),
+            Query(QueryParamState::default()),
+            Query(OmissionListQuery::default()),
+            Form(form),
+        )
+        .await
+        .unwrap()
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(store.get_political_group_omissions().is_empty());
     }
 
     #[tokio::test]

--- a/src/csb/examination/pages/omission/mod.rs
+++ b/src/csb/examination/pages/omission/mod.rs
@@ -70,6 +70,15 @@ impl OmissionTarget {
         context: CsbContext,
         store: &CsbStore,
     ) -> Response {
+        let available_districts = if self.omission_type == OmissionType::CandidateList {
+            store
+                .get_candidate_lists()
+                .into_iter()
+                .flat_map(|l| l.electoral_districts)
+                .collect()
+        } else {
+            vec![]
+        };
         let political_group = CsbPoliticalGroup::new_from_csb_store(store);
         HtmlTemplate(
             CsbAddOmissionTemplate {
@@ -79,7 +88,7 @@ impl OmissionTarget {
                 presets: preset_views(self, store),
                 add_tab_url: add_url(self),
                 overview_tab_url: overview_url(self),
-                show_districts: self.omission_type == OmissionType::CandidateList,
+                available_districts,
             },
             context,
         )
@@ -96,7 +105,20 @@ pub async fn add_omission(
     Query(list_query): Query<OmissionListQuery>,
 ) -> Result<Response, AppError> {
     let target = OmissionTarget::from_add_path(path, list_query);
-    Ok(target.render_add_form(FormData::new(), &query, context, &store))
+    let form = if target.omission_type == OmissionType::CandidateList {
+        // Pre-fill current candidate list's electoral districts
+        let districts = store
+            .get_candidate_list(CandidateListId::from(target.reference))
+            .map(|l| l.electoral_districts)
+            .unwrap_or_default();
+        FormData::new_with_data(OmissionForm {
+            electoral_districts: districts,
+            ..Default::default()
+        })
+    } else {
+        FormData::new()
+    };
+    Ok(target.render_add_form(form, &query, context, &store))
 }
 
 /// Render the omissions overview page for an entity: the list of omissions

--- a/src/csb/examination/pages/omission/mod.rs
+++ b/src/csb/examination/pages/omission/mod.rs
@@ -369,7 +369,7 @@ mod tests {
         let stream_id = store.stream_id;
 
         let omission = Omission::new(
-            OmissionCategory::General,
+            OmissionCategory::PoliticalGroup,
             "Deposit missing".to_string(),
             "The deposit is missing.".to_string(),
             String::new(),
@@ -391,7 +391,7 @@ mod tests {
         .into_response();
 
         assert_eq!(response.status(), StatusCode::SEE_OTHER);
-        assert!(store.get_general_omissions().is_empty());
+        assert!(store.get_political_group_omissions().is_empty());
         let location = response
             .headers()
             .get("Location")
@@ -427,7 +427,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn add_candidate_list_omission_persists_the_right_category() {
+    async fn add_candidate_list_omission_persists_category() {
         let store = CsbStore::new_for_test();
         let stream_id = store.stream_id;
         let list = CandidateListId::new();
@@ -470,7 +470,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn add_general_omission_persists_general_category() {
+    async fn add_political_group_omission_persists_category() {
         let store = CsbStore::new_for_test();
         let stream_id = store.stream_id;
         let context = CsbContext::new_test();
@@ -491,7 +491,7 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(store.get_general_omissions().len(), 1);
+        assert_eq!(store.get_political_group_omissions().len(), 1);
     }
 
     #[tokio::test]
@@ -549,7 +549,7 @@ mod tests {
         .into_response();
 
         assert_eq!(response.status(), StatusCode::OK);
-        assert!(store.get_general_omissions().is_empty());
+        assert!(store.get_political_group_omissions().is_empty());
     }
 
     #[tokio::test]

--- a/src/csb/examination/pages/omission/urls.rs
+++ b/src/csb/examination/pages/omission/urls.rs
@@ -79,13 +79,6 @@ pub(super) fn overview_url(target: &OmissionTarget) -> String {
 /// its category. Used only when the request carries no explicit `redirect_to`.
 pub(super) fn overview_url_for(category: &OmissionCategory, stream_id: StreamId) -> String {
     let target = match category {
-        OmissionCategory::CandidateList(id) => OmissionTarget {
-            stream_id,
-            omission_type: OmissionType::CandidateList,
-            reference: (*id).into(),
-            list: None,
-            general: false,
-        },
         OmissionCategory::Candidate { person, list } => OmissionTarget {
             stream_id,
             omission_type: OmissionType::Candidate,

--- a/src/csb/examination/pages/omission/views.rs
+++ b/src/csb/examination/pages/omission/views.rs
@@ -2,7 +2,7 @@ use askama::Template;
 use axum_extra::routing::TypedPath;
 
 use crate::{
-    Context, CsbStore, Locale, Overlay, QueryParamState,
+    AppError, Context, CsbStore, Overlay, QueryParamState,
     candidate_lists::CandidateListId,
     csb::{
         Omission, OmissionPlaceholders, OmissionType,
@@ -28,6 +28,8 @@ pub(super) struct CsbAddOmissionTemplate {
     /// The dialog opened on its two tabs, for the steps sidebar.
     pub(super) add_tab_url: String,
     pub(super) overview_tab_url: String,
+    /// Whether to show the electoral-districts checkbox fieldset
+    pub(super) show_districts: bool,
 }
 
 /// The overview tab of the dialog: the omissions already added to this entity.
@@ -62,11 +64,7 @@ pub(super) struct PresetView {
 }
 
 /// Resolve the placeholder values that can be derived from the referenced item.
-fn placeholders_for(
-    target: &OmissionTarget,
-    store: &CsbStore,
-    locale: Locale,
-) -> OmissionPlaceholders {
+fn placeholders_for(target: &OmissionTarget, store: &CsbStore) -> OmissionPlaceholders {
     match target.omission_type {
         OmissionType::Candidate => {
             let person = PersonId::from(target.reference);
@@ -81,25 +79,19 @@ fn placeholders_for(
                 districts: None,
             }
         }
-        OmissionType::CandidateList => OmissionPlaceholders {
-            districts: store
-                .get_candidate_list(CandidateListId::from(target.reference))
-                .map(|list| list.districts_name(locale.into())),
-            ..Default::default()
-        },
-        OmissionType::PoliticalGroup => OmissionPlaceholders::default(),
+        // The {district}/{districts} tokens in candidate-list presets are filled
+        // in by the front-end
+        OmissionType::CandidateList | OmissionType::PoliticalGroup => {
+            OmissionPlaceholders::default()
+        }
     }
 }
 
 /// The presets for this type with their descriptions interpolated. A `general`
 /// candidate omission (applying to the person on every list) offers a different
 /// set than one scoped to the candidate on a specific list.
-pub(super) fn preset_views(
-    target: &OmissionTarget,
-    store: &CsbStore,
-    locale: Locale,
-) -> Vec<PresetView> {
-    let placeholders = placeholders_for(target, store, locale);
+pub(super) fn preset_views(target: &OmissionTarget, store: &CsbStore) -> Vec<PresetView> {
+    let placeholders = placeholders_for(target, store);
 
     target
         .omission_type
@@ -122,16 +114,16 @@ pub(super) fn omission_views(
     target: &OmissionTarget,
     store: &CsbStore,
     overview_url: &str,
-) -> Vec<OmissionView> {
+) -> Result<Vec<OmissionView>, AppError> {
     let omissions = match target.omission_type {
         OmissionType::PoliticalGroup => store.get_political_group_omissions(),
         OmissionType::CandidateList => {
-            store.get_candidate_list_omissions(CandidateListId::from(target.reference))
+            store.get_candidate_list_omissions(CandidateListId::from(target.reference))?
         }
         OmissionType::Candidate => store.get_candidate_omissions(PersonId::from(target.reference)),
     };
 
-    omissions
+    Ok(omissions
         .into_iter()
         .map(|omission| OmissionView {
             remove_url: CsbDeleteOmissionPath {
@@ -142,5 +134,5 @@ pub(super) fn omission_views(
             .to_string(),
             omission,
         })
-        .collect()
+        .collect())
 }

--- a/src/csb/examination/pages/omission/views.rs
+++ b/src/csb/examination/pages/omission/views.rs
@@ -2,7 +2,7 @@ use askama::Template;
 use axum_extra::routing::TypedPath;
 
 use crate::{
-    AppError, Context, CsbStore, Overlay, QueryParamState,
+    AppError, Context, CsbStore, ElectoralDistrict, Overlay, QueryParamState,
     candidate_lists::CandidateListId,
     csb::{
         Omission, OmissionPlaceholders, OmissionType,
@@ -28,8 +28,10 @@ pub(super) struct CsbAddOmissionTemplate {
     /// The dialog opened on its two tabs, for the steps sidebar.
     pub(super) add_tab_url: String,
     pub(super) overview_tab_url: String,
-    /// Whether to show the electoral-districts checkbox fieldset
-    pub(super) show_districts: bool,
+    /// Districts that appear on at least one candidate list of this political
+    /// group. The districts section is hidden when this is empty. Districts
+    /// absent from all lists are shown disabled so the user cannot select them.
+    pub(super) available_districts: Vec<ElectoralDistrict>,
 }
 
 /// The overview tab of the dialog: the omissions already added to this entity.

--- a/src/csb/examination/pages/omission/views.rs
+++ b/src/csb/examination/pages/omission/views.rs
@@ -124,7 +124,7 @@ pub(super) fn omission_views(
     overview_url: &str,
 ) -> Vec<OmissionView> {
     let omissions = match target.omission_type {
-        OmissionType::PoliticalGroup => store.get_general_omissions(),
+        OmissionType::PoliticalGroup => store.get_political_group_omissions(),
         OmissionType::CandidateList => {
             store.get_candidate_list_omissions(CandidateListId::from(target.reference))
         }

--- a/src/csb/examination/pages/political_group.html
+++ b/src/csb/examination/pages/political_group.html
@@ -74,7 +74,7 @@
           </div>
         </div>
         <div class="card-content">
-          {{ omission_count_badge(general_omission_count) }}
+          {{ omission_count_badge(political_group_omission_count) }}
           <ul class="card-instruction">
             <li>{{ "csb.group.instruction_group"|trans }}</li>
             <li>{{ "csb.group.instruction_submitter"|trans }}</li>

--- a/src/csb/examination/pages/political_group.rs
+++ b/src/csb/examination/pages/political_group.rs
@@ -20,7 +20,7 @@ struct CsbPoliticalGroupTemplate {
     political_group: CsbPoliticalGroup,
     all_brp_error_count: usize,
     candidate_lists: Vec<CsbCandidateList>,
-    general_omission_count: usize,
+    political_group_omission_count: usize,
     restoration_count: usize,
 }
 
@@ -40,14 +40,14 @@ pub async fn overview(
         .iter()
         .map(|cl| cl.brp_error_count)
         .sum::<usize>();
-    let general_omission_count = store.get_general_omissions().len();
+    let political_group_omission_count = store.get_political_group_omissions().len();
 
     Ok(HtmlTemplate(
         CsbPoliticalGroupTemplate {
             political_group,
             all_brp_error_count,
             candidate_lists,
-            general_omission_count,
+            political_group_omission_count,
             restoration_count: rng().random_range(0..=20),
         },
         context,
@@ -118,13 +118,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn renders_general_omission_count_badge() {
+    async fn renders_political_group_omission_count_badge() {
         use crate::csb::{Omission, OmissionCategory};
 
         let store = CsbStore::new_for_test();
         let stream_id = store.stream_id;
         Omission::new(
-            OmissionCategory::General,
+            OmissionCategory::PoliticalGroup,
             "Deposit missing".to_string(),
             "The deposit has not been paid.".to_string(),
             String::new(),

--- a/src/csb/omission.rs
+++ b/src/csb/omission.rs
@@ -138,8 +138,9 @@ pub enum OmissionCategory {
     /// or problems with authorised agent and/or statutory name (H 3-1 / H 3-2)
     #[default]
     PoliticalGroup,
-    /// E.g. too many candidates on a list (H 1), or missing or incorrect "ondersteuningsverklaringen" (H 4)
-    CandidateList(CandidateListId),
+    /// E.g. missing or incorrect "ondersteuningsverklaringen" (H 4), which are per kieskring.
+    /// Stores the specific electoral districts affected by the omission.
+    CandidateList(Vec<ElectoralDistrict>),
     /// E.g. missing or invalid candidate data, missing or invalid "instemmingsverklaring" (H 9),
     /// missing copy of identity document
     Candidate {
@@ -153,10 +154,9 @@ const ALL_DISTRICTS: &str = "alle kieskringen";
 
 impl OmissionCategory {
     /// Build the category for a newly added omission from the parameters of the
-    /// "add omission" dialog: the [`OmissionType`], the id of the item the
-    /// omission is added to, and (for candidates) the list the candidate is on.
-    /// For a political group the reference is unused (the stream already
-    /// identifies the group).
+    /// "add omission" dialog for [`OmissionType::PoliticalGroup`] and
+    /// [`OmissionType::Candidate`]. For candidate list omissions, construct the
+    /// category directly with the selected districts.
     pub fn from_type_and_reference(
         omission_type: OmissionType,
         reference: uuid::Uuid,
@@ -164,7 +164,9 @@ impl OmissionCategory {
     ) -> Self {
         match omission_type {
             OmissionType::PoliticalGroup => OmissionCategory::PoliticalGroup,
-            OmissionType::CandidateList => OmissionCategory::CandidateList(reference.into()),
+            OmissionType::CandidateList => {
+                unreachable!("CandidateList omissions must be created with explicit districts")
+            }
             OmissionType::Candidate => OmissionCategory::Candidate {
                 person: reference.into(),
                 list,
@@ -182,8 +184,10 @@ impl OmissionCategory {
             OmissionCategory::PoliticalGroup | OmissionCategory::Candidate { list: None, .. } => {
                 Ok(ALL_DISTRICTS.to_string())
             }
-            OmissionCategory::CandidateList(id)
-            | OmissionCategory::Candidate { list: Some(id), .. } => store
+            OmissionCategory::CandidateList(districts) => {
+                Ok(format_districts_for_districts(districts, election))
+            }
+            OmissionCategory::Candidate { list: Some(id), .. } => store
                 .get_candidate_list(*id)
                 .as_ref()
                 .map(|list| format_districts_for_list(list, election))
@@ -193,10 +197,21 @@ impl OmissionCategory {
 }
 
 fn format_districts_for_list(list: &CandidateList, election: &ElectionConfig) -> String {
-    if list.contains_all_districts(election) {
+    format_districts_for_districts(&list.electoral_districts, election)
+}
+
+fn format_districts_for_districts(
+    districts: &[ElectoralDistrict],
+    election: &ElectionConfig,
+) -> String {
+    if election
+        .electoral_districts()
+        .iter()
+        .all(|d| districts.contains(d))
+    {
         ALL_DISTRICTS.to_string()
     } else {
-        format_districts(&list.electoral_districts)
+        format_districts(districts)
     }
 }
 
@@ -331,7 +346,7 @@ pub mod tests {
         // deserialize as recoverable rather than as errors.
         let json = r#"{
             "id": "00000000-0000-0000-0000-000000000000",
-            "category": "General",
+            "category": "PoliticalGroup",
             "title": "t",
             "description": "d",
             "help_text": "",
@@ -454,9 +469,9 @@ pub mod tests {
 
         #[test]
         fn candidate_list_with_all_districts_maps_to_all() {
-            let (store, id) = store_with_list(EK.electoral_districts().to_vec());
+            let store = CsbStore::new_for_test();
             assert_eq!(
-                OmissionCategory::CandidateList(id)
+                OmissionCategory::CandidateList(EK.electoral_districts().to_vec())
                     .electoral_district(&store, &EK)
                     .unwrap(),
                 "alle kieskringen"
@@ -465,9 +480,9 @@ pub mod tests {
 
         #[test]
         fn candidate_list_with_one_district() {
-            let (store, id) = store_with_list(vec![ElectoralDistrict::BO]);
+            let store = CsbStore::new_for_test();
             assert_eq!(
-                OmissionCategory::CandidateList(id)
+                OmissionCategory::CandidateList(vec![ElectoralDistrict::BO])
                     .electoral_district(&store, &EK)
                     .unwrap(),
                 "kieskring 13 (Bonaire)"
@@ -476,9 +491,9 @@ pub mod tests {
 
         #[test]
         fn candidate_list_with_multiple_districts() {
-            let (store, id) = store_with_list(vec![ElectoralDistrict::GR, ElectoralDistrict::DR]);
+            let store = CsbStore::new_for_test();
             assert_eq!(
-                OmissionCategory::CandidateList(id)
+                OmissionCategory::CandidateList(vec![ElectoralDistrict::GR, ElectoralDistrict::DR])
                     .electoral_district(&store, &EK)
                     .unwrap(),
                 "kieskring 1 (Groningen), 3 (Drenthe)"
@@ -486,13 +501,14 @@ pub mod tests {
         }
 
         #[test]
-        fn candidate_list_not_found_returns_error() {
+        fn candidate_list_with_no_districts_maps_to_all() {
             let store = CsbStore::new_for_test();
-            let missing_id = CandidateListId::new();
-            assert!(
-                OmissionCategory::CandidateList(missing_id)
+            // An empty district list is treated as "all districts" in format_districts.
+            assert_eq!(
+                OmissionCategory::CandidateList(vec![])
                     .electoral_district(&store, &EK)
-                    .is_err()
+                    .unwrap(),
+                "alle kieskringen"
             );
         }
 

--- a/src/csb/omission.rs
+++ b/src/csb/omission.rs
@@ -8,7 +8,6 @@ use crate::{
     common::UtcDateTime,
     form::ValidationError,
     id_newtype,
-    name_authorisations::NameAuthorisationId,
     persons::PersonId,
 };
 
@@ -135,14 +134,11 @@ impl<'de> Deserialize<'de> for OmissionType {
 
 #[derive(Default, Debug, Serialize, Eq, PartialEq, Deserialize, Clone)]
 pub enum OmissionCategory {
-    /// E.g. missing deposit ("waarborgsom"), unidentified submitter
+    /// E.g. missing deposit ("waarborgsom"), unidentified submitter,
+    /// or problems with authorised agent and/or statutory name (H 3-1 / H 3-2)
     #[default]
     General,
-    /// Missing, invalid or unregistered authorised agent and/or statutory name (H 3-1 / H 3-2)
-    NameAuthorisation(Option<NameAuthorisationId>),
-    /// Missing or incorrect "ondersteuningsverklaringen" for some "kieskringen" (H 4)
-    DeclarationOfSupport(Vec<ElectoralDistrict>),
-    /// E.g. too many candidates on a list
+    /// E.g. too many candidates on a list (H 1), or missing or incorrect "ondersteuningsverklaringen" (H 4)
     CandidateList(CandidateListId),
     /// E.g. missing or invalid candidate data, missing or invalid "instemmingsverklaring" (H 9),
     /// missing copy of identity document
@@ -183,10 +179,9 @@ impl OmissionCategory {
         election: &ElectionConfig,
     ) -> Result<String, AppError> {
         match self {
-            OmissionCategory::General
-            | OmissionCategory::NameAuthorisation(_)
-            | OmissionCategory::Candidate { list: None, .. } => Ok(ALL_DISTRICTS.to_string()),
-            OmissionCategory::DeclarationOfSupport(districts) => Ok(format_districts(districts)),
+            OmissionCategory::General | OmissionCategory::Candidate { list: None, .. } => {
+                Ok(ALL_DISTRICTS.to_string())
+            }
             OmissionCategory::CandidateList(id)
             | OmissionCategory::Candidate { list: Some(id), .. } => store
                 .get_candidate_list(*id)
@@ -445,56 +440,12 @@ pub mod tests {
         }
 
         #[test]
-        fn name_authorisation_maps_to_all_districts() {
-            let store = CsbStore::new_for_test();
-            assert_eq!(
-                OmissionCategory::NameAuthorisation(None)
-                    .electoral_district(&store, &EK)
-                    .unwrap(),
-                "alle kieskringen"
-            );
-        }
-
-        #[test]
         fn candidate_without_list_maps_to_all_districts() {
             let store = CsbStore::new_for_test();
             let category = OmissionCategory::Candidate {
                 person: crate::persons::PersonId::new(),
                 list: None,
             };
-            assert_eq!(
-                category.electoral_district(&store, &EK).unwrap(),
-                "alle kieskringen"
-            );
-        }
-
-        #[test]
-        fn declaration_of_support_single_district() {
-            let store = CsbStore::new_for_test();
-            let category = OmissionCategory::DeclarationOfSupport(vec![ElectoralDistrict::GR]);
-            assert_eq!(
-                category.electoral_district(&store, &EK).unwrap(),
-                "kieskring 1 (Groningen)"
-            );
-        }
-
-        #[test]
-        fn declaration_of_support_multiple_districts() {
-            let store = CsbStore::new_for_test();
-            let category = OmissionCategory::DeclarationOfSupport(vec![
-                ElectoralDistrict::GR,
-                ElectoralDistrict::DR,
-            ]);
-            assert_eq!(
-                category.electoral_district(&store, &EK).unwrap(),
-                "kieskring 1 (Groningen), 3 (Drenthe)"
-            );
-        }
-
-        #[test]
-        fn declaration_of_support_empty_maps_to_all_districts() {
-            let store = CsbStore::new_for_test();
-            let category = OmissionCategory::DeclarationOfSupport(vec![]);
             assert_eq!(
                 category.electoral_district(&store, &EK).unwrap(),
                 "alle kieskringen"
@@ -513,13 +464,24 @@ pub mod tests {
         }
 
         #[test]
-        fn candidate_list_with_specific_district() {
+        fn candidate_list_with_one_district() {
             let (store, id) = store_with_list(vec![ElectoralDistrict::BO]);
             assert_eq!(
                 OmissionCategory::CandidateList(id)
                     .electoral_district(&store, &EK)
                     .unwrap(),
                 "kieskring 13 (Bonaire)"
+            );
+        }
+
+        #[test]
+        fn candidate_list_with_multiple_districts() {
+            let (store, id) = store_with_list(vec![ElectoralDistrict::GR, ElectoralDistrict::DR]);
+            assert_eq!(
+                OmissionCategory::CandidateList(id)
+                    .electoral_district(&store, &EK)
+                    .unwrap(),
+                "kieskring 1 (Groningen), 3 (Drenthe)"
             );
         }
 

--- a/src/csb/omission.rs
+++ b/src/csb/omission.rs
@@ -137,7 +137,7 @@ pub enum OmissionCategory {
     /// E.g. missing deposit ("waarborgsom"), unidentified submitter,
     /// or problems with authorised agent and/or statutory name (H 3-1 / H 3-2)
     #[default]
-    General,
+    PoliticalGroup,
     /// E.g. too many candidates on a list (H 1), or missing or incorrect "ondersteuningsverklaringen" (H 4)
     CandidateList(CandidateListId),
     /// E.g. missing or invalid candidate data, missing or invalid "instemmingsverklaring" (H 9),
@@ -156,14 +156,14 @@ impl OmissionCategory {
     /// "add omission" dialog: the [`OmissionType`], the id of the item the
     /// omission is added to, and (for candidates) the list the candidate is on.
     /// For a political group the reference is unused (the stream already
-    /// identifies the group), so it maps to [`Self::General`].
+    /// identifies the group).
     pub fn from_type_and_reference(
         omission_type: OmissionType,
         reference: uuid::Uuid,
         list: Option<CandidateListId>,
     ) -> Self {
         match omission_type {
-            OmissionType::PoliticalGroup => OmissionCategory::General,
+            OmissionType::PoliticalGroup => OmissionCategory::PoliticalGroup,
             OmissionType::CandidateList => OmissionCategory::CandidateList(reference.into()),
             OmissionType::Candidate => OmissionCategory::Candidate {
                 person: reference.into(),
@@ -179,7 +179,7 @@ impl OmissionCategory {
         election: &ElectionConfig,
     ) -> Result<String, AppError> {
         match self {
-            OmissionCategory::General | OmissionCategory::Candidate { list: None, .. } => {
+            OmissionCategory::PoliticalGroup | OmissionCategory::Candidate { list: None, .. } => {
                 Ok(ALL_DISTRICTS.to_string())
             }
             OmissionCategory::CandidateList(id)
@@ -370,7 +370,7 @@ pub mod tests {
     #[tokio::test]
     async fn create_and_get_omission() -> Result<(), AppError> {
         let store = CsbStore::new_for_test();
-        let omission = sample_omission(OmissionCategory::General);
+        let omission = sample_omission(OmissionCategory::PoliticalGroup);
 
         omission.create(&store).await?;
 
@@ -384,7 +384,7 @@ pub mod tests {
     #[tokio::test]
     async fn update_omission_overwrites_fields() -> Result<(), AppError> {
         let store = CsbStore::new_for_test();
-        let mut omission = sample_omission(OmissionCategory::General);
+        let mut omission = sample_omission(OmissionCategory::PoliticalGroup);
 
         omission.create(&store).await?;
 
@@ -400,7 +400,7 @@ pub mod tests {
     #[tokio::test]
     async fn delete_omission_removes_record() -> Result<(), AppError> {
         let store = CsbStore::new_for_test();
-        let omission = sample_omission(OmissionCategory::General);
+        let omission = sample_omission(OmissionCategory::PoliticalGroup);
 
         omission.create(&store).await?;
         omission.delete(&store).await?;
@@ -429,10 +429,10 @@ pub mod tests {
         }
 
         #[test]
-        fn general_maps_to_all_districts() {
+        fn political_group_maps_to_all_districts() {
             let store = CsbStore::new_for_test();
             assert_eq!(
-                OmissionCategory::General
+                OmissionCategory::PoliticalGroup
                     .electoral_district(&store, &EK)
                     .unwrap(),
                 "alle kieskringen"

--- a/src/csb/store_csb/getters.rs
+++ b/src/csb/store_csb/getters.rs
@@ -34,12 +34,12 @@ impl CsbStore {
             .collect()
     }
 
-    pub fn get_general_omissions(&self) -> Vec<Omission> {
+    pub fn get_political_group_omissions(&self) -> Vec<Omission> {
         let data = self.data.read();
 
         data.omissions
             .values()
-            .filter(|o| matches!(o.category, OmissionCategory::General))
+            .filter(|o| matches!(o.category, OmissionCategory::PoliticalGroup))
             .cloned()
             .collect()
     }
@@ -208,29 +208,32 @@ mod tests {
     }
 
     #[test]
-    fn get_general_omissions_returns_only_general() {
+    fn get_political_group_omissions_returns_only_political_group() {
         let store = CsbStore::new_for_test();
-        insert(&store, OmissionCategory::General);
+        insert(&store, OmissionCategory::PoliticalGroup);
         insert(
             &store,
             OmissionCategory::CandidateList(CandidateListId::new()),
         );
 
-        let result = store.get_general_omissions();
+        let result = store.get_political_group_omissions();
 
         assert_eq!(result.len(), 1);
-        assert!(matches!(result[0].category, OmissionCategory::General));
+        assert!(matches!(
+            result[0].category,
+            OmissionCategory::PoliticalGroup
+        ));
     }
 
     #[test]
-    fn get_general_omissions_returns_empty_when_none() {
+    fn get_political_group_omissions_returns_empty_when_none() {
         let store = CsbStore::new_for_test();
         insert(
             &store,
             OmissionCategory::CandidateList(CandidateListId::new()),
         );
 
-        assert!(store.get_general_omissions().is_empty());
+        assert!(store.get_political_group_omissions().is_empty());
     }
 
     #[test]
@@ -252,7 +255,7 @@ mod tests {
                 list: None,
             },
         );
-        insert(&store, OmissionCategory::General);
+        insert(&store, OmissionCategory::PoliticalGroup);
 
         let result = store.get_candidate_omissions(person_a);
 
@@ -283,7 +286,7 @@ mod tests {
         let store = CsbStore::new_for_test();
         insert(&store, OmissionCategory::CandidateList(list_a));
         insert(&store, OmissionCategory::CandidateList(list_b));
-        insert(&store, OmissionCategory::General);
+        insert(&store, OmissionCategory::PoliticalGroup);
 
         let result = store.get_candidate_list_omissions(list_a);
 

--- a/src/csb/store_csb/getters.rs
+++ b/src/csb/store_csb/getters.rs
@@ -54,16 +54,30 @@ impl CsbStore {
             .collect()
     }
 
-    pub fn get_candidate_list_omissions(&self, list_id: CandidateListId) -> Vec<Omission> {
+    /// Return all candidate-list omissions that are linked to at least one
+    /// electoral district covered by the given list.
+    pub fn get_candidate_list_omissions(
+        &self,
+        list_id: CandidateListId,
+    ) -> Result<Vec<Omission>, AppError> {
         let data = self.data.read();
 
-        data.omissions
+        let list_districts = &data
+            .imported_data
+            .candidate_lists
+            .get(&list_id)
+            .ok_or(AppError::GenericNotFound)?
+            .electoral_districts;
+
+        Ok(data
+            .omissions
             .values()
-            .filter(
-                |o| matches!(&o.category, OmissionCategory::CandidateList(id) if *id == list_id),
-            )
+            .filter(|o| {
+                matches!(&o.category, OmissionCategory::CandidateList(districts)
+                    if districts.iter().any(|d| list_districts.contains(d)))
+            })
             .cloned()
-            .collect()
+            .collect())
     }
 
     /// Return the single stored omission. Test-only helper for asserting on
@@ -196,7 +210,8 @@ impl CsbStore {
 mod tests {
     use super::*;
     use crate::{
-        CsbStore,
+        CsbStore, ElectoralDistrict,
+        candidate_lists::CandidateList,
         csb::omission::{OmissionCategory, tests::sample_omission},
         list_designation::ListDesignation,
         test_utils::{sample_candidate_list, sample_person_with},
@@ -207,13 +222,27 @@ mod tests {
         store.data.write().omissions.insert(omission.id, omission);
     }
 
+    fn insert_list(store: &CsbStore, list_id: CandidateListId, districts: Vec<ElectoralDistrict>) {
+        let list = CandidateList {
+            id: list_id,
+            electoral_districts: districts,
+            ..Default::default()
+        };
+        store
+            .data
+            .write()
+            .imported_data
+            .candidate_lists
+            .insert(list_id, list);
+    }
+
     #[test]
     fn get_political_group_omissions_returns_only_political_group() {
         let store = CsbStore::new_for_test();
         insert(&store, OmissionCategory::PoliticalGroup);
         insert(
             &store,
-            OmissionCategory::CandidateList(CandidateListId::new()),
+            OmissionCategory::CandidateList(vec![ElectoralDistrict::GR]),
         );
 
         let result = store.get_political_group_omissions();
@@ -230,7 +259,7 @@ mod tests {
         let store = CsbStore::new_for_test();
         insert(
             &store,
-            OmissionCategory::CandidateList(CandidateListId::new()),
+            OmissionCategory::CandidateList(vec![ElectoralDistrict::GR]),
         );
 
         assert!(store.get_political_group_omissions().is_empty());
@@ -280,32 +309,84 @@ mod tests {
     }
 
     #[test]
-    fn get_candidate_list_omissions_returns_only_omissions_for_the_given_list() {
+    fn get_candidate_list_omissions_returns_omissions_sharing_a_district_with_the_list() {
         let list_a = CandidateListId::new();
         let list_b = CandidateListId::new();
         let store = CsbStore::new_for_test();
-        insert(&store, OmissionCategory::CandidateList(list_a));
-        insert(&store, OmissionCategory::CandidateList(list_b));
+        insert_list(&store, list_a, vec![ElectoralDistrict::GR]);
+        insert_list(&store, list_b, vec![ElectoralDistrict::DR]);
+        // Omission for GR: should appear in list_a but not list_b.
+        insert(
+            &store,
+            OmissionCategory::CandidateList(vec![ElectoralDistrict::GR]),
+        );
+        // Omission for DR: should appear in list_b but not list_a.
+        insert(
+            &store,
+            OmissionCategory::CandidateList(vec![ElectoralDistrict::DR]),
+        );
         insert(&store, OmissionCategory::PoliticalGroup);
 
-        let result = store.get_candidate_list_omissions(list_a);
+        let result_a = store.get_candidate_list_omissions(list_a).unwrap();
+        let result_b = store.get_candidate_list_omissions(list_b).unwrap();
 
-        assert_eq!(result.len(), 1);
-        assert!(matches!(result[0].category, OmissionCategory::CandidateList(id) if id == list_a));
+        assert_eq!(result_a.len(), 1);
+        assert!(
+            matches!(&result_a[0].category, OmissionCategory::CandidateList(d) if d == &[ElectoralDistrict::GR])
+        );
+        assert_eq!(result_b.len(), 1);
+        assert!(
+            matches!(&result_b[0].category, OmissionCategory::CandidateList(d) if d == &[ElectoralDistrict::DR])
+        );
     }
 
     #[test]
-    fn get_candidate_list_omissions_returns_empty_when_no_match() {
+    fn get_candidate_list_omissions_includes_omission_covering_multiple_districts() {
+        let list_id = CandidateListId::new();
+        let store = CsbStore::new_for_test();
+        insert_list(&store, list_id, vec![ElectoralDistrict::GR]);
+        // Omission for both GR and DR: overlaps with the list, so it should appear.
+        insert(
+            &store,
+            OmissionCategory::CandidateList(vec![ElectoralDistrict::GR, ElectoralDistrict::DR]),
+        );
+
+        assert_eq!(
+            store.get_candidate_list_omissions(list_id).unwrap().len(),
+            1
+        );
+    }
+
+    #[test]
+    fn get_candidate_list_omissions_returns_empty_when_no_district_overlap() {
+        let list_id = CandidateListId::new();
+        let store = CsbStore::new_for_test();
+        insert_list(&store, list_id, vec![ElectoralDistrict::GR]);
+        insert(
+            &store,
+            OmissionCategory::CandidateList(vec![ElectoralDistrict::DR]),
+        );
+
+        assert!(
+            store
+                .get_candidate_list_omissions(list_id)
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn get_candidate_list_omissions_errors_for_unknown_list() {
         let store = CsbStore::new_for_test();
         insert(
             &store,
-            OmissionCategory::CandidateList(CandidateListId::new()),
+            OmissionCategory::CandidateList(vec![ElectoralDistrict::GR]),
         );
 
         assert!(
             store
                 .get_candidate_list_omissions(CandidateListId::new())
-                .is_empty()
+                .is_err()
         );
     }
 

--- a/src/csb/store_csb/getters.rs
+++ b/src/csb/store_csb/getters.rs
@@ -44,26 +44,6 @@ impl CsbStore {
             .collect()
     }
 
-    pub fn get_name_authorisation_omissions(&self) -> Vec<Omission> {
-        let data = self.data.read();
-
-        data.omissions
-            .values()
-            .filter(|o| matches!(o.category, OmissionCategory::NameAuthorisation(_)))
-            .cloned()
-            .collect()
-    }
-
-    pub fn get_declaration_of_support_omissions(&self) -> Vec<Omission> {
-        let data = self.data.read();
-
-        data.omissions
-            .values()
-            .filter(|o| matches!(o.category, OmissionCategory::DeclarationOfSupport(_)))
-            .cloned()
-            .collect()
-    }
-
     pub fn get_candidate_omissions(&self, person_id: PersonId) -> Vec<Omission> {
         let data = self.data.read();
 
@@ -231,7 +211,10 @@ mod tests {
     fn get_general_omissions_returns_only_general() {
         let store = CsbStore::new_for_test();
         insert(&store, OmissionCategory::General);
-        insert(&store, OmissionCategory::NameAuthorisation(None));
+        insert(
+            &store,
+            OmissionCategory::CandidateList(CandidateListId::new()),
+        );
 
         let result = store.get_general_omissions();
 
@@ -242,38 +225,12 @@ mod tests {
     #[test]
     fn get_general_omissions_returns_empty_when_none() {
         let store = CsbStore::new_for_test();
+        insert(
+            &store,
+            OmissionCategory::CandidateList(CandidateListId::new()),
+        );
 
         assert!(store.get_general_omissions().is_empty());
-    }
-
-    #[test]
-    fn get_name_authorisation_omissions_returns_only_name_authorisation() {
-        let store = CsbStore::new_for_test();
-        insert(&store, OmissionCategory::NameAuthorisation(None));
-        insert(&store, OmissionCategory::General);
-
-        let result = store.get_name_authorisation_omissions();
-
-        assert_eq!(result.len(), 1);
-        assert!(matches!(
-            result[0].category,
-            OmissionCategory::NameAuthorisation(_)
-        ));
-    }
-
-    #[test]
-    fn get_declaration_of_support_omissions_returns_only_declaration_of_support() {
-        let store = CsbStore::new_for_test();
-        insert(&store, OmissionCategory::DeclarationOfSupport(vec![]));
-        insert(&store, OmissionCategory::General);
-
-        let result = store.get_declaration_of_support_omissions();
-
-        assert_eq!(result.len(), 1);
-        assert!(matches!(
-            result[0].category,
-            OmissionCategory::DeclarationOfSupport(_)
-        ));
     }
 
     #[test]

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -96,6 +96,14 @@ pub fn initials_as_printed_on_list(
 }
 
 #[askama::filter_fn]
+pub fn district_title_nl(
+    value: &ElectoralDistrict,
+    _: &dyn askama::Values,
+) -> askama::Result<String> {
+    Ok(value.title(AnyLocale::Nl).to_string())
+}
+
+#[askama::filter_fn]
 pub fn district_name(
     value: &ElectoralDistrict,
     values: &dyn askama::Values,


### PR DESCRIPTION
Closes #942

# [DOD](/docs/definition-of-done.md) checklist

<img width="2880" height="1920" alt="image" src="https://github.com/user-attachments/assets/434ea221-b5f2-4537-9f7c-e95ea505853c" />

## For PR maintainer

Perform these checks before marking the PR as ready:

- [x] I have linked the PR to at least one issue.
- [x] I assigned the PR to myself.
- [x] I have added a description how to test this PR (see "Review Instructions").
- [x] I have added documentation where necessary.

## For reviewer

- I have read all code changes.
- I have audited the code quality.
- I have tested the changes either or both:
  - locally
  - on the test environment (preferred)
- I have validated that the PR is functionally correct (use-cases, figma designs, etc.)

### Review instructions

Adding an omission to a candidate list now requires you to select which districts it applies to. By default, the districts of the current list are selected. The districts are automatically filled in to the presets. I also added a warning for unfilled placeholders in the presets.

Linking candidate/person omissions to candidate lists will be done in a separate PR (see #966)