### PR TITLE
[#966] Link candidate omissions to candidate lists

### DIFF
--- a/frontend/styles/csb-overview.css
+++ b/frontend/styles/csb-overview.css
@@ -278,16 +278,6 @@
   }
 }
 
-.omission-cards--split {
-  .cards {
-    grid-template-columns: 1fr 1fr;
-  }
-
-  .omission-card--overview {
-    grid-column: 1 / -1;
-  }
-}
-
 .overlay.omission-overlay {
   background-color: var(--orange-50);
 

--- a/locales/en/candidate_list.yml
+++ b/locales/en/candidate_list.yml
@@ -10,6 +10,7 @@ actions:
   export_csv_template: Download CSV template
   import_csv: Upload CSV file
   import_export: Import and export candidate list
+  select_all_candidate_lists: Select all candidate lists
   select_all_districts: Select all electoral districts
 add_all: Add all candidates
 add_candidate: Add candidate

--- a/locales/en/csb.yml
+++ b/locales/en/csb.yml
@@ -8,10 +8,7 @@ brp:
   correct: Correct
   errors: Errors
 candidate:
-  add_candidate_text: Add omissions for this candidate on this list only
-  add_candidate_title: Candidate
-  add_person_text: Add omissions for this person on all their lists
-  add_person_title: Person
+  add_candidate_text: Add omissions for this candidate
   overview_text: Added omissions for this candidate
   personal_details: Personal details
   status: Status
@@ -100,10 +97,10 @@ omission:
     plural: "{} omissions"
     singular: 1 omission
   form:
+    applies_to: "This omission applies to:"
     description_label: Add I 1 omission
-    districts_intro: "This omission applies to:"
-    placeholder_warning: "The text still contains unfilled placeholders."
     help_text_label: Add omission letter note
+    placeholder_warning: The text still contains unfilled placeholders.
     presets_heading: Add one of these omissions
     recoverable_label: Recoverable omission
     submit: Add and close

--- a/locales/nl/candidate_list.yml
+++ b/locales/nl/candidate_list.yml
@@ -10,6 +10,7 @@ actions:
   export_csv_template: Download CSV sjabloon
   import_csv: Upload CSV bestand
   import_export: Import en export kandidatenlijst
+  select_all_candidate_lists: Selecteer alle kandidatenlijsten
   select_all_districts: Selecteer alle kieskringen
 add_all: Alle kandidaten toevoegen
 add_candidate: Kandidaat toevoegen

--- a/locales/nl/csb.yml
+++ b/locales/nl/csb.yml
@@ -8,10 +8,7 @@ brp:
   correct: Correct
   errors: Fouten
 candidate:
-  add_candidate_text: Voeg verzuimen toe voor deze kandidaat op alleen deze lijst
-  add_candidate_title: Kandidaat
-  add_person_text: Voeg verzuimen toe voor deze persoon op al hun lijsten
-  add_person_title: Persoon
+  add_candidate_text: Voeg verzuimen toe voor deze kandidaat
   overview_text: Toegevoegde verzuimen kandidaat
   personal_details: Persoonsgegevens
   status: Status
@@ -100,10 +97,10 @@ omission:
     plural: "{} verzuimen"
     singular: 1 verzuim
   form:
+    applies_to: "Dit verzuim geldt voor:"
     description_label: I1 verzuim toevoegen
-    districts_intro: "Dit verzuim geldt voor:"
-    placeholder_warning: "De tekst bevat nog niet ingevulde placeholders."
     help_text_label: Verzuimbriefnotitie toevoegen
+    placeholder_warning: De tekst bevat nog niet ingevulde placeholders.
     presets_heading: Voeg één van deze verzuimen toe
     recoverable_label: Herstelbaar verzuim
     submit: Toevoegen en sluiten

--- a/src/csb/examination/forms/omission_form.rs
+++ b/src/csb/examination/forms/omission_form.rs
@@ -1,7 +1,7 @@
 use serde::Deserialize;
 use validate::Validate;
 
-use crate::{ElectoralDistrict, csb::Omission};
+use crate::{ElectoralDistrict, candidate_lists::CandidateListId, csb::Omission};
 
 /// Form backing the "add omission" dialog. The category is not part of the form:
 /// it is derived from the dialog's path parameters and set on the resulting
@@ -26,6 +26,10 @@ pub struct OmissionForm {
     /// Ignored for other omission types; validated in the handler.
     #[validate(ignore)]
     pub electoral_districts: Vec<ElectoralDistrict>,
+    /// The candidate lists selected for a Candidate omission.
+    /// Ignored for other omission types; validated in the handler.
+    #[validate(ignore)]
+    pub candidate_lists: Vec<CandidateListId>,
 }
 
 impl Default for OmissionForm {
@@ -38,6 +42,7 @@ impl Default for OmissionForm {
             // otherwise (the common case); presets override this via the dialog.
             recoverable: true,
             electoral_districts: Vec::new(),
+            candidate_lists: Vec::new(),
         }
     }
 }
@@ -50,6 +55,7 @@ impl From<Omission> for OmissionForm {
             help_text: value.help_text,
             recoverable: value.recoverable,
             electoral_districts: Vec::new(),
+            candidate_lists: Vec::new(),
         }
     }
 }

--- a/src/csb/examination/pages/candidate.html
+++ b/src/csb/examination/pages/candidate.html
@@ -55,30 +55,17 @@
 {% endmacro %}
 {% block content %}
   <section class="general-information">
-    <div class="omission-cards omission-cards--split">
+    <div class="omission-cards">
       <h3>
         <span class="omission-icon" aria-hidden="true"></span>
         {{ "csb.omission.title"|trans }}
       </h3>
       <div class="cards">
         <div class="card omission-card"
-             data-href="{{ political_group.add_person_omission_path(candidate.id, list_id) }}">
-          <div class="card-header">
-            <div>
-              <h3 class="h4">{{ "csb.candidate.add_person_title"|trans }}</h3>
-            </div>
-          </div>
-          <div class="card-content">
-            <p>{{ "csb.candidate.add_person_text"|trans }}</p>
-          </div>
-          <a class="card-footer"
-             href="{{ political_group.add_person_omission_path(candidate.id, list_id) }}">{{ "csb.omission.action.add"|trans }}</a>
-        </div>
-        <div class="card omission-card"
              data-href="{{ political_group.add_candidate_omission_path(candidate.id, list_id) }}">
           <div class="card-header">
             <div>
-              <h3 class="h4">{{ "csb.candidate.add_candidate_title"|trans }}</h3>
+              <h3 class="h4">{{ "csb.omission.add.title"|trans }}</h3>
             </div>
           </div>
           <div class="card-content">
@@ -87,7 +74,7 @@
           <a class="card-footer"
              href="{{ political_group.add_candidate_omission_path(candidate.id, list_id) }}">{{ "csb.omission.action.add"|trans }}</a>
         </div>
-        <div class="card omission-card omission-card--overview"
+        <div class="card omission-card"
              data-href="{{ political_group.manage_candidate_omissions_path(candidate.id, list_id) }}">
           <div class="card-header">
             <div>

--- a/src/csb/examination/pages/candidate.rs
+++ b/src/csb/examination/pages/candidate.rs
@@ -96,16 +96,12 @@ mod tests {
         // The candidate's imported details render.
         assert!(body.contains("Jansen"));
         assert!(body.contains("Juinen"));
-        // Both add-omission buttons target the candidate omission dialog,
+        // The add-omission button targets the candidate omission dialog,
         // carrying the list so the candidate's position can be resolved.
         assert!(body.contains(&format!(
             "/csb/examination/{stream_id}/omission/candidate/{person_id}"
         )));
         assert!(body.contains(&format!("list={list_id}")));
-        // One button adds an omission for the person on every list (general),
-        // the other for the candidate on this specific list. Only the general
-        // one carries the `general` flag.
-        assert!(body.contains("general=true"));
         // The header shows the electoral districts of the candidate's list
         // (the sample list covers Utrecht).
         assert!(body.contains("Electoral districts"));
@@ -128,7 +124,7 @@ mod tests {
         Omission::new(
             OmissionCategory::Candidate {
                 person: person_id,
-                list: Some(list_id),
+                lists: vec![list_id],
             },
             "Missing consent".to_string(),
             "The declaration of consent is missing.".to_string(),

--- a/src/csb/examination/pages/mod.rs
+++ b/src/csb/examination/pages/mod.rs
@@ -104,10 +104,6 @@ pub struct OmissionListQuery {
     /// candidate detail page, which is always scoped to a list.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub list: Option<CandidateListId>,
-    /// When set, the omission applies to the person on every list rather than to
-    /// their candidacy on `list` (which is then only the page to return to).
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    pub general: bool,
 }
 
 impl CsbPoliticalGroup {
@@ -184,46 +180,20 @@ impl CsbPoliticalGroup {
         }
     }
 
-    /// Path to the dialog that adds an omission to a candidate on a specific
-    /// list. The list is carried as a query parameter so the candidate's
-    /// position on it can be resolved for the preset placeholders.
+    /// Path to the dialog that adds an omission to a candidate. The list is
+    /// carried as a query parameter so the candidate's position on it can be
+    /// resolved for the preset placeholders and to return to this page after.
     pub fn add_candidate_omission_path(
         &self,
         person: &PersonId,
         list: &CandidateListId,
-    ) -> impl TypedPath {
-        self.add_candidate_omission_path_for(person, list, false)
-    }
-
-    /// Path to the dialog that adds an omission covering the person on every
-    /// list (a general candidate omission). The `list` is carried only so the
-    /// dialog can return to the candidate detail page it was opened from.
-    pub fn add_person_omission_path(
-        &self,
-        person: &PersonId,
-        list: &CandidateListId,
-    ) -> impl TypedPath {
-        self.add_candidate_omission_path_for(person, list, true)
-    }
-
-    /// The add-omission dialog for a candidate, keeping the `list` context. A
-    /// `general` omission covers the person on every list; otherwise it is
-    /// scoped to the candidate on this list.
-    fn add_candidate_omission_path_for(
-        &self,
-        person: &PersonId,
-        list: &CandidateListId,
-        general: bool,
     ) -> impl TypedPath {
         CsbAddOmissionPath {
             stream_id: self.stream_id,
             omission_type: OmissionType::Candidate,
             reference: (*person).into(),
         }
-        .with_query_params(OmissionListQuery {
-            list: Some(*list),
-            general,
-        })
+        .with_query_params(OmissionListQuery { list: Some(*list) })
     }
 
     /// Path to the overview page listing the omissions already added for this
@@ -239,10 +209,7 @@ impl CsbPoliticalGroup {
             omission_type: OmissionType::Candidate,
             reference: (*person).into(),
         }
-        .with_query_params(OmissionListQuery {
-            list: Some(*list),
-            general: false,
-        })
+        .with_query_params(OmissionListQuery { list: Some(*list) })
     }
 
     pub fn after_toggle_finish_examination_path(&self) -> impl TypedPath {

--- a/src/csb/examination/pages/omission.html
+++ b/src/csb/examination/pages/omission.html
@@ -8,9 +8,33 @@
 {% endblock %}
 {% block overlay_form %}
   <fieldset class="omission-form">
+    {% if !available_candidate_lists.is_empty() %}
+      <div class="form-row card">
+        <p>{{ "csb.omission.form.applies_to"|trans }}</p>
+        <div class="checkbox select-all-checkbox">
+          <input type="checkbox"
+                 for-checklist="omission_candidate_list"
+                 id="select-all-candidate-lists" />
+          <label for="select-all-candidate-lists">{{ "candidate_list.actions.select_all_candidate_lists"|trans }}</label>
+        </div>
+        <div class="checklist" id="omission_candidate_list">
+          {% for option in available_candidate_lists %}
+            <div class="checkbox">
+              <input type="checkbox"
+                     name="candidate_lists"
+                     id="omission_candidate_list_{{ option.id }}"
+                     value="{{ option.id }}"
+                     {% if form.data.candidate_lists.contains(&option.id) %}checked{% endif %} />
+              <label for="omission_candidate_list_{{ option.id }}">{{ option.label }}</label>
+            </div>
+          {% endfor %}
+        </div>
+        {% for error in form|error("candidate_lists") %}<span class="error">{{ error }}</span>{% endfor %}
+      </div>
+    {% endif %}
     {% if !available_districts.is_empty() %}
       <div class="form-row card">
-        <p>{{ "csb.omission.form.districts_intro"|trans }}</p>
+        <p>{{ "csb.omission.form.applies_to"|trans }}</p>
         <div class="checkbox select-all-checkbox">
           <input type="checkbox"
                  for-checklist="omission_district_list"

--- a/src/csb/examination/pages/omission/mod.rs
+++ b/src/csb/examination/pages/omission/mod.rs
@@ -27,17 +27,16 @@ mod views;
 use urls::{add_url, overview_url, overview_url_for, return_path};
 use views::{CsbAddOmissionTemplate, CsbOmissionOverviewTemplate, omission_views, preset_views};
 
-/// The entity an omission dialog operates on, together with the list/general
-/// context carried through its URLs and presets. Bundled so the handlers and the
-/// URL/preset helpers pass one value around instead of repeating the same set of
-/// fields in every signature.
+/// The entity an omission dialog operates on, together with the list context
+/// carried through its URLs and presets. Bundled so the handlers and the
+/// URL/preset helpers pass one value around instead of repeating the same set
+/// of fields in every signature.
 #[derive(Clone, Copy)]
 pub(super) struct OmissionTarget {
     pub(super) stream_id: StreamId,
     pub(super) omission_type: OmissionType,
     pub(super) reference: Uuid,
     pub(super) list: Option<CandidateListId>,
-    pub(super) general: bool,
 }
 
 impl OmissionTarget {
@@ -47,7 +46,6 @@ impl OmissionTarget {
             omission_type: path.omission_type,
             reference: path.reference,
             list: query.list,
-            general: query.general,
         }
     }
 
@@ -57,7 +55,6 @@ impl OmissionTarget {
             omission_type: path.omission_type,
             reference: path.reference,
             list: query.list,
-            general: query.general,
         }
     }
 
@@ -77,7 +74,12 @@ impl OmissionTarget {
                 .flat_map(|l| l.electoral_districts)
                 .collect()
         } else {
-            vec![]
+            Vec::new()
+        };
+        let available_candidate_lists = if self.omission_type == OmissionType::Candidate {
+            views::candidate_list_options(store, context.session.locale)
+        } else {
+            Vec::new()
         };
         let political_group = CsbPoliticalGroup::new_from_csb_store(store);
         HtmlTemplate(
@@ -89,6 +91,7 @@ impl OmissionTarget {
                 add_tab_url: add_url(self),
                 overview_tab_url: overview_url(self),
                 available_districts,
+                available_candidate_lists,
             },
             context,
         )
@@ -113,6 +116,13 @@ pub async fn add_omission(
             .unwrap_or_default();
         FormData::new_with_data(OmissionForm {
             electoral_districts: districts,
+            ..Default::default()
+        })
+    } else if target.omission_type == OmissionType::Candidate {
+        // Pre-fill the list the dialog was opened from
+        let candidate_lists = target.list.map(|id| vec![id]).unwrap_or_default();
+        FormData::new_with_data(OmissionForm {
+            candidate_lists,
             ..Default::default()
         })
     } else {
@@ -160,11 +170,26 @@ pub async fn add_omission_submit(
 ) -> Result<Response, AppError> {
     let target = OmissionTarget::from_add_path(path, list_query);
 
-    // For candidate list omissions the districts are required
+    // For candidate list omissions at least one district muse be selected
     let districts = form.electoral_districts.clone();
     if target.omission_type == OmissionType::CandidateList && districts.is_empty() {
         let errors = vec![(
             "electoral_districts".to_string(),
+            ValidationError::ChooseAtLeastOneOption,
+        )];
+        return Ok(target.render_add_form(
+            FormData::new_with_errors(form, errors),
+            &query,
+            context,
+            &store,
+        ));
+    }
+
+    // For candidate omissions at least one list must be selected
+    let candidate_lists = form.candidate_lists.clone();
+    if target.omission_type == OmissionType::Candidate && candidate_lists.is_empty() {
+        let errors = vec![(
+            "candidate_lists".to_string(),
             ValidationError::ChooseAtLeastOneOption,
         )];
         return Ok(target.render_add_form(
@@ -181,14 +206,10 @@ pub async fn add_omission_submit(
             omission.category = if target.omission_type == OmissionType::CandidateList {
                 OmissionCategory::CandidateList(districts)
             } else {
-                // A general candidate omission applies to the person on every list,
-                // so the list context is dropped from the persisted category even
-                // though it still drives the return path below.
-                let category_list = if target.general { None } else { target.list };
                 OmissionCategory::from_type_and_reference(
                     target.omission_type,
                     target.reference,
-                    category_list,
+                    candidate_lists,
                 )
             };
             omission.create(&store).await?;
@@ -238,6 +259,7 @@ mod tests {
             help_text: "Please pay the deposit.".to_string(),
             recoverable: true,
             electoral_districts: Vec::new(),
+            candidate_lists: Vec::new(),
         }
     }
 
@@ -658,7 +680,6 @@ mod tests {
             Query(QueryParamState::default()),
             Query(OmissionListQuery {
                 list: Some(list_id),
-                general: false,
             }),
         )
         .await
@@ -672,52 +693,10 @@ mod tests {
         // The unresolved token is left for the committee to fill in manually.
         assert!(body.contains("{designation}"));
         assert!(!body.contains("{candidate_name}"));
-    }
-
-    #[tokio::test]
-    async fn person_dialog_offers_the_person_presets() {
-        use crate::test_utils::{sample_candidate_list, sample_person};
-
-        let store = CsbStore::new_for_test();
-        let stream_id = store.stream_id;
-
-        let person = sample_person(PersonId::new());
-        let person_id = person.id;
-        let list_id = CandidateListId::new();
-        let mut list = sample_candidate_list(list_id);
-        list.candidates = vec![person_id];
-        store.set_person(person);
-        store.set_candidate_list(list);
-
-        // `general` opens the person dialog, which draws from the "person" preset
-        // set rather than the candidate-on-this-list set.
-        let response = add_omission(
-            CsbAddOmissionPath {
-                stream_id,
-                omission_type: OmissionType::Candidate,
-                reference: person_id.into(),
-            },
-            CsbContext::new_test(),
-            store,
-            Query(QueryParamState::default()),
-            Query(OmissionListQuery {
-                list: Some(list_id),
-                general: true,
-            }),
-        )
-        .await
-        .unwrap()
-        .into_response();
-
-        assert_eq!(response.status(), StatusCode::OK);
-        let body = response_body_string(response).await;
-        // A person preset shows up...
+        // Both former "candidate" and "person" presets are shown.
         assert!(body.contains("Kopie ID ontbreekt"));
         // ...while a preset scoped to the listing on the list does not.
         assert!(!body.contains("onjuiste nadere aanduidingen"));
-        // The list context still resolves the candidate placeholders.
-        assert!(body.contains("Jansen"));
-        assert!(!body.contains("{candidate_name}"));
     }
 
     #[tokio::test]
@@ -754,7 +733,6 @@ mod tests {
             Query(QueryParamState::default()),
             Query(OmissionListQuery {
                 list: Some(second_list_id),
-                general: false,
             }),
         )
         .await
@@ -768,13 +746,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn add_candidate_omission_persists_the_list() {
+    async fn add_candidate_omission_persists_the_selected_lists() {
         use crate::test_utils::{sample_candidate_list, sample_person};
 
         let store = CsbStore::new_for_test();
         let stream_id = store.stream_id;
         let context = CsbContext::new_test();
-        let form = sample_form();
 
         let person = sample_person(PersonId::new());
         let person_id = person.id;
@@ -783,6 +760,11 @@ mod tests {
         list.candidates = vec![person_id];
         store.set_person(person);
         store.set_candidate_list(list);
+
+        let form = OmissionForm {
+            candidate_lists: vec![list_id],
+            ..sample_form()
+        };
 
         let response = add_omission_submit(
             CsbAddOmissionPath {
@@ -795,7 +777,6 @@ mod tests {
             Query(QueryParamState::default()),
             Query(OmissionListQuery {
                 list: Some(list_id),
-                general: false,
             }),
             Form(form),
         )
@@ -804,8 +785,7 @@ mod tests {
         .into_response();
 
         assert_eq!(response.status(), StatusCode::SEE_OTHER);
-        // The dialog redirects back to the candidate detail page it was opened
-        // from, scoped to the list the candidate was examined on.
+        // The dialog redirects back to the candidate detail page it was opened from.
         let location = response
             .headers()
             .get("Location")
@@ -817,19 +797,18 @@ mod tests {
         let omission = store.get_omission_for_test();
         assert!(matches!(
             omission.category,
-            OmissionCategory::Candidate { person, list }
-                if person == person_id && list == Some(list_id)
+            OmissionCategory::Candidate { person, ref lists }
+                if person == person_id && lists == &[list_id]
         ));
     }
 
     #[tokio::test]
-    async fn add_person_omission_persists_a_general_candidate_category() {
+    async fn add_candidate_omission_without_lists_rerenders_form() {
         use crate::test_utils::{sample_candidate_list, sample_person};
 
         let store = CsbStore::new_for_test();
         let stream_id = store.stream_id;
         let context = CsbContext::new_test();
-        let form = sample_form();
 
         let person = sample_person(PersonId::new());
         let person_id = person.id;
@@ -839,6 +818,7 @@ mod tests {
         store.set_person(person);
         store.set_candidate_list(list);
 
+        // No lists selected: should re-render the form with an error
         let response = add_omission_submit(
             CsbAddOmissionPath {
                 stream_id,
@@ -848,35 +828,16 @@ mod tests {
             context,
             store.clone(),
             Query(QueryParamState::default()),
-            // `general` marks the omission as applying to the person on every
-            // list; `list` is still carried so we return to the page we're on.
             Query(OmissionListQuery {
                 list: Some(list_id),
-                general: true,
             }),
-            Form(form),
+            Form(sample_form()),
         )
         .await
         .unwrap()
         .into_response();
 
-        assert_eq!(response.status(), StatusCode::SEE_OTHER);
-        // Even a general omission returns to the candidate detail page it was
-        // opened from.
-        let location = response
-            .headers()
-            .get("Location")
-            .unwrap()
-            .to_str()
-            .unwrap();
-        assert!(location.contains(&format!("/list/{list_id}/candidate/{person_id}")));
-
-        // The persisted category applies to the whole person, not this list.
-        let omission = store.get_omission_for_test();
-        assert!(matches!(
-            omission.category,
-            OmissionCategory::Candidate { person, list }
-                if person == person_id && list.is_none()
-        ));
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(store.get_omission_count(), 0);
     }
 }

--- a/src/csb/examination/pages/omission/urls.rs
+++ b/src/csb/examination/pages/omission/urls.rs
@@ -36,19 +36,19 @@ pub(super) fn return_path(target: &OmissionTarget, political_group: &CsbPolitica
     }
 }
 
-/// Append the list/general context as a query string, but only when there is
+/// Append the list context as a query string, but only when there is
 /// something to carry (an empty query would otherwise leave a trailing `?`).
-fn with_context(path: impl TypedPath, list: Option<CandidateListId>, general: bool) -> String {
-    if list.is_none() && !general {
-        path.to_string()
-    } else {
-        path.with_query_params(OmissionListQuery { list, general })
-            .to_string()
+fn with_context(path: impl TypedPath, list: Option<CandidateListId>) -> String {
+    match list {
+        None => path.to_string(),
+        Some(_) => path
+            .with_query_params(OmissionListQuery { list })
+            .to_string(),
     }
 }
 
-/// The URL of the add-omission form for this entity, keeping the list/general
-/// context (the sidebar links here from the overview page).
+/// The URL of the add-omission form for this entity, keeping the list context
+/// (the sidebar links here from the overview page).
 pub(super) fn add_url(target: &OmissionTarget) -> String {
     with_context(
         CsbAddOmissionPath {
@@ -57,12 +57,11 @@ pub(super) fn add_url(target: &OmissionTarget) -> String {
             reference: target.reference,
         },
         target.list,
-        target.general,
     )
 }
 
-/// The URL of the overview page for this entity, keeping the list/general
-/// context (the sidebar links here from the add form).
+/// The URL of the overview page for this entity, keeping the list context
+/// (the sidebar links here from the add form).
 pub(super) fn overview_url(target: &OmissionTarget) -> String {
     with_context(
         CsbOmissionOverviewPath {
@@ -71,7 +70,6 @@ pub(super) fn overview_url(target: &OmissionTarget) -> String {
             reference: target.reference,
         },
         target.list,
-        target.general,
     )
 }
 
@@ -79,19 +77,17 @@ pub(super) fn overview_url(target: &OmissionTarget) -> String {
 /// its category. Used only when the request carries no explicit `redirect_to`.
 pub(super) fn overview_url_for(category: &OmissionCategory, stream_id: StreamId) -> String {
     let target = match category {
-        OmissionCategory::Candidate { person, list } => OmissionTarget {
+        OmissionCategory::Candidate { person, lists } => OmissionTarget {
             stream_id,
             omission_type: OmissionType::Candidate,
             reference: (*person).into(),
-            list: *list,
-            general: list.is_none(),
+            list: lists.first().copied(),
         },
         _ => OmissionTarget {
             stream_id,
             omission_type: OmissionType::PoliticalGroup,
             reference: stream_id.into(),
             list: None,
-            general: false,
         },
     };
     overview_url(&target)

--- a/src/csb/examination/pages/omission/views.rs
+++ b/src/csb/examination/pages/omission/views.rs
@@ -89,7 +89,6 @@ fn placeholders_for(target: &OmissionTarget, store: &CsbStore) -> OmissionPlaceh
                     .list
                     .and_then(|list| store.candidate_position(list, person))
                     .map(|nr| nr.to_string()),
-                districts: None,
             }
         }
         // The {district}/{districts} tokens in candidate-list presets are filled

--- a/src/csb/examination/pages/omission/views.rs
+++ b/src/csb/examination/pages/omission/views.rs
@@ -2,7 +2,7 @@ use askama::Template;
 use axum_extra::routing::TypedPath;
 
 use crate::{
-    AppError, Context, CsbStore, ElectoralDistrict, Overlay, QueryParamState,
+    AppError, Context, CsbStore, ElectoralDistrict, Locale, Overlay, QueryParamState,
     candidate_lists::CandidateListId,
     csb::{
         Omission, OmissionPlaceholders, OmissionType,
@@ -14,6 +14,13 @@ use crate::{
 };
 
 use super::OmissionTarget;
+
+/// One selectable candidate list in the add-omission dialog for candidate omissions.
+pub(super) struct CandidateListOption {
+    pub(super) id: CandidateListId,
+    /// Dutch label derived from the list's electoral districts (e.g. "1. Groningen").
+    pub(super) label: String,
+}
 
 /// The add-omission form tab of the dialog.
 #[derive(Template)]
@@ -32,6 +39,8 @@ pub(super) struct CsbAddOmissionTemplate {
     /// group. The districts section is hidden when this is empty. Districts
     /// absent from all lists are shown disabled so the user cannot select them.
     pub(super) available_districts: Vec<ElectoralDistrict>,
+    /// Candidate lists for a Candidate omission. Hidden when empty.
+    pub(super) available_candidate_lists: Vec<CandidateListOption>,
 }
 
 /// The overview tab of the dialog: the omissions already added to this entity.
@@ -89,15 +98,25 @@ fn placeholders_for(target: &OmissionTarget, store: &CsbStore) -> OmissionPlaceh
     }
 }
 
-/// The presets for this type with their descriptions interpolated. A `general`
-/// candidate omission (applying to the person on every list) offers a different
-/// set than one scoped to the candidate on a specific list.
+/// All candidate lists of the political group for the candidate omission form
+pub(super) fn candidate_list_options(store: &CsbStore, locale: Locale) -> Vec<CandidateListOption> {
+    store
+        .get_candidate_lists()
+        .into_iter()
+        .map(|l| CandidateListOption {
+            id: l.id,
+            label: l.districts_name(locale.into()),
+        })
+        .collect()
+}
+
+/// The presets for this type with their descriptions interpolated.
 pub(super) fn preset_views(target: &OmissionTarget, store: &CsbStore) -> Vec<PresetView> {
     let placeholders = placeholders_for(target, store);
 
     target
         .omission_type
-        .presets(target.general)
+        .presets()
         .iter()
         .map(|preset| PresetView {
             title: preset.title.clone(),

--- a/src/csb/examination/pages/omission/views.rs
+++ b/src/csb/examination/pages/omission/views.rs
@@ -62,6 +62,8 @@ pub(super) struct CsbOmissionOverviewTemplate {
 pub(super) struct OmissionView {
     omission: Omission,
     remove_url: String,
+    /// Formatted district string for display (e.g. "1. Groningen, 2. Friesland").
+    districts: String,
 }
 
 /// A preset shown in the dialog, with `{token}` placeholders in its description
@@ -144,9 +146,12 @@ pub(super) fn omission_views(
         OmissionType::Candidate => store.get_candidate_omissions(PersonId::from(target.reference)),
     };
 
-    Ok(omissions
-        .into_iter()
-        .map(|omission| OmissionView {
+    let mut views = Vec::with_capacity(omissions.len());
+    for omission in omissions {
+        let districts = omission
+            .category
+            .electoral_district(store, &store.election)?;
+        views.push(OmissionView {
             remove_url: CsbDeleteOmissionPath {
                 stream_id: target.stream_id,
                 omission_id: omission.id,
@@ -154,6 +159,8 @@ pub(super) fn omission_views(
             .with_query_params(QueryParamState::redirect_to(overview_url.to_string()))
             .to_string(),
             omission,
-        })
-        .collect())
+            districts,
+        });
+    }
+    Ok(views)
 }

--- a/src/csb/examination/pages/omission_overview.html
+++ b/src/csb/examination/pages/omission_overview.html
@@ -23,6 +23,8 @@
             </div>
             <div class="row">
               <div class="omission-item-body">
+                <h5>{{ "common.electoral_districts"|trans }}</h5>
+                <p>In {{ view.districts }}</p>
                 <h5>{{ "csb.omission.overview.description"|trans }}</h5>
                 <p>{{ view.omission.description }}</p>
                 {% if !view.omission.help_text.is_empty() %}

--- a/src/csb/omission.rs
+++ b/src/csb/omission.rs
@@ -4,10 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     AnyLocale, AppError, CsbEvent, CsbStore, ElectionConfig, ElectoralDistrict,
-    candidate_lists::CandidateListId,
-    common::UtcDateTime,
-    form::ValidationError,
-    id_newtype,
+    candidate_lists::CandidateListId, common::UtcDateTime, form::ValidationError, id_newtype,
     persons::PersonId,
 };
 
@@ -175,9 +172,7 @@ impl OmissionCategory {
     ) -> Result<String, AppError> {
         match self {
             OmissionCategory::PoliticalGroup => Ok(ALL_DISTRICTS.to_string()),
-            OmissionCategory::CandidateList(districts) => {
-                Ok(format_districts_for_districts(districts, election))
-            }
+            OmissionCategory::CandidateList(districts) => Ok(format_districts(districts, election)),
             OmissionCategory::Candidate { lists, .. } => {
                 let mut districts: Vec<ElectoralDistrict> = Vec::new();
                 for id in lists {
@@ -190,36 +185,25 @@ impl OmissionCategory {
                         }
                     }
                 }
-                Ok(format_districts_for_districts(&districts, election))
+                Ok(format_districts(&districts, election))
             }
         }
     }
 }
 
-fn format_districts_for_districts(
-    districts: &[ElectoralDistrict],
-    election: &ElectionConfig,
-) -> String {
-    if election
-        .electoral_districts()
-        .iter()
-        .all(|d| districts.contains(d))
-    {
+fn format_districts(districts: &[ElectoralDistrict], election: &ElectionConfig) -> String {
+    let all_districts = election.electoral_districts();
+    if districts.is_empty() || all_districts.iter().all(|d| districts.contains(d)) {
         ALL_DISTRICTS.to_string()
     } else {
-        format_districts(districts)
+        let mut sorted = districts.to_vec();
+        sorted.sort_by_key(|d| d.region_number());
+        let parts: Vec<String> = sorted
+            .iter()
+            .map(|d| format!("{} ({})", d.region_number(), d.title(AnyLocale::Nl)))
+            .collect();
+        format!("kieskring {}", parts.join(", "))
     }
-}
-
-fn format_districts(districts: &[ElectoralDistrict]) -> String {
-    if districts.is_empty() {
-        return ALL_DISTRICTS.to_string();
-    }
-    let parts: Vec<String> = districts
-        .iter()
-        .map(|d| format!("{} ({})", d.region_number(), d.title(AnyLocale::Nl)))
-        .collect();
-    format!("kieskring {}", parts.join(", "))
 }
 
 /// An omission ("verzuim") signifies something was wrong with the submitted data
@@ -485,8 +469,9 @@ pub mod tests {
         #[test]
         fn candidate_list_with_multiple_districts() {
             let store = CsbStore::new_for_test();
+            // The districts should be sorted by region number.
             assert_eq!(
-                OmissionCategory::CandidateList(vec![ElectoralDistrict::GR, ElectoralDistrict::DR])
+                OmissionCategory::CandidateList(vec![ElectoralDistrict::DR, ElectoralDistrict::GR])
                     .electoral_district(&store, &EK)
                     .unwrap(),
                 "kieskring 1 (Groningen), 3 (Drenthe)"

--- a/src/csb/omission.rs
+++ b/src/csb/omission.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     AnyLocale, AppError, CsbEvent, CsbStore, ElectionConfig, ElectoralDistrict,
-    candidate_lists::{CandidateList, CandidateListId},
+    candidate_lists::CandidateListId,
     common::UtcDateTime,
     form::ValidationError,
     id_newtype,
@@ -86,18 +86,11 @@ impl OmissionType {
     }
 
     /// The predefined omissions offered as quick-fill suggestions for this type.
-    ///
-    /// A `general` candidate omission applies to the person on every list and
-    /// draws from a separate set (`person`) than one scoped to the candidate on
-    /// a specific list (`candidate`). `general` is meaningless for the other
-    /// types, which only have a single set.
-    pub fn presets(self, general: bool) -> &'static [PresetOmission] {
-        let key = match self {
-            OmissionType::Candidate if general => "person",
-            _ => self.as_str(),
-        };
-
-        PRESET_OMISSIONS.get(key).map(Vec::as_slice).unwrap_or(&[])
+    pub fn presets(self) -> &'static [PresetOmission] {
+        PRESET_OMISSIONS
+            .get(self.as_str())
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
     }
 }
 
@@ -145,8 +138,8 @@ pub enum OmissionCategory {
     /// missing copy of identity document
     Candidate {
         person: PersonId,
-        /// The candidate list to which this applies, leave None if it applies to all candidate lists
-        list: Option<CandidateListId>,
+        /// The candidate lists to which this applies.
+        lists: Vec<CandidateListId>,
     },
 }
 
@@ -160,7 +153,7 @@ impl OmissionCategory {
     pub fn from_type_and_reference(
         omission_type: OmissionType,
         reference: uuid::Uuid,
-        list: Option<CandidateListId>,
+        lists: Vec<CandidateListId>,
     ) -> Self {
         match omission_type {
             OmissionType::PoliticalGroup => OmissionCategory::PoliticalGroup,
@@ -169,7 +162,7 @@ impl OmissionCategory {
             }
             OmissionType::Candidate => OmissionCategory::Candidate {
                 person: reference.into(),
-                list,
+                lists,
             },
         }
     }
@@ -181,23 +174,26 @@ impl OmissionCategory {
         election: &ElectionConfig,
     ) -> Result<String, AppError> {
         match self {
-            OmissionCategory::PoliticalGroup | OmissionCategory::Candidate { list: None, .. } => {
-                Ok(ALL_DISTRICTS.to_string())
-            }
+            OmissionCategory::PoliticalGroup => Ok(ALL_DISTRICTS.to_string()),
             OmissionCategory::CandidateList(districts) => {
                 Ok(format_districts_for_districts(districts, election))
             }
-            OmissionCategory::Candidate { list: Some(id), .. } => store
-                .get_candidate_list(*id)
-                .as_ref()
-                .map(|list| format_districts_for_list(list, election))
-                .ok_or(AppError::GenericNotFound),
+            OmissionCategory::Candidate { lists, .. } => {
+                let mut districts: Vec<ElectoralDistrict> = Vec::new();
+                for id in lists {
+                    let list = store
+                        .get_candidate_list(*id)
+                        .ok_or(AppError::GenericNotFound)?;
+                    for d in list.electoral_districts {
+                        if !districts.contains(&d) {
+                            districts.push(d);
+                        }
+                    }
+                }
+                Ok(format_districts_for_districts(&districts, election))
+            }
         }
     }
-}
-
-fn format_districts_for_list(list: &CandidateList, election: &ElectionConfig) -> String {
-    format_districts_for_districts(&list.electoral_districts, election)
 }
 
 fn format_districts_for_districts(
@@ -292,24 +288,21 @@ pub mod tests {
 
     #[test]
     fn presets_are_loaded_from_json_per_type() {
-        assert_eq!(OmissionType::PoliticalGroup.presets(false).len(), 6);
-        assert_eq!(OmissionType::CandidateList.presets(false).len(), 4);
-        // A candidate omission draws from a different set depending on whether it
-        // is scoped to the candidate on a specific list or general to the person.
-        assert_eq!(OmissionType::Candidate.presets(false).len(), 3);
-        assert_eq!(OmissionType::Candidate.presets(true).len(), 9);
+        assert_eq!(OmissionType::PoliticalGroup.presets().len(), 6);
+        assert_eq!(OmissionType::CandidateList.presets().len(), 4);
+        assert_eq!(OmissionType::Candidate.presets().len(), 12);
 
         // Every preset carries a title and description; irreparable defects have
         // no help text.
         assert!(
             OmissionType::PoliticalGroup
-                .presets(false)
+                .presets()
                 .iter()
                 .all(|p| !p.title.is_empty() && !p.description.is_empty())
         );
         assert!(
             OmissionType::PoliticalGroup
-                .presets(false)
+                .presets()
                 .iter()
                 .any(|p| p.help_text.is_empty())
         );
@@ -320,7 +313,7 @@ pub mod tests {
         // Most omissions are recoverable ("herstelbaar").
         assert!(
             OmissionType::Candidate
-                .presets(false)
+                .presets()
                 .iter()
                 .any(|p| p.recoverable)
         );
@@ -328,13 +321,13 @@ pub mod tests {
         // flagged as non-recoverable.
         assert!(
             OmissionType::PoliticalGroup
-                .presets(false)
+                .presets()
                 .iter()
                 .any(|p| !p.recoverable)
         );
         assert!(
             OmissionType::PoliticalGroup
-                .presets(false)
+                .presets()
                 .iter()
                 .all(|p| p.recoverable || p.help_text.is_empty())
         );
@@ -455,11 +448,11 @@ pub mod tests {
         }
 
         #[test]
-        fn candidate_without_list_maps_to_all_districts() {
-            let store = CsbStore::new_for_test();
+        fn candidate_with_all_districts_maps_to_all() {
+            let (store, id) = store_with_list(EK.electoral_districts().to_vec());
             let category = OmissionCategory::Candidate {
                 person: crate::persons::PersonId::new(),
-                list: None,
+                lists: vec![id],
             };
             assert_eq!(
                 category.electoral_district(&store, &EK).unwrap(),
@@ -513,24 +506,11 @@ pub mod tests {
         }
 
         #[test]
-        fn candidate_with_list_all_districts_maps_to_all() {
-            let (store, id) = store_with_list(EK.electoral_districts().to_vec());
-            let category = OmissionCategory::Candidate {
-                person: crate::persons::PersonId::new(),
-                list: Some(id),
-            };
-            assert_eq!(
-                category.electoral_district(&store, &EK).unwrap(),
-                "alle kieskringen"
-            );
-        }
-
-        #[test]
         fn candidate_with_list_specific_district() {
             let (store, id) = store_with_list(vec![ElectoralDistrict::GR]);
             let category = OmissionCategory::Candidate {
                 person: crate::persons::PersonId::new(),
-                list: Some(id),
+                lists: vec![id],
             };
             assert_eq!(
                 category.electoral_district(&store, &EK).unwrap(),
@@ -543,7 +523,7 @@ pub mod tests {
             let store = CsbStore::new_for_test();
             let category = OmissionCategory::Candidate {
                 person: crate::persons::PersonId::new(),
-                list: Some(CandidateListId::new()),
+                lists: vec![CandidateListId::new()],
             };
             assert!(category.electoral_district(&store, &EK).is_err());
         }

--- a/src/csb/omission.rs
+++ b/src/csb/omission.rs
@@ -35,8 +35,6 @@ pub struct OmissionPlaceholders {
     pub candidate_number: Option<String>,
     /// `{candidate_name}`: the candidate's initials and last name.
     pub candidate_name: Option<String>,
-    /// `{districts}`: the electoral districts a candidate list was submitted for.
-    pub districts: Option<String>,
 }
 
 impl OmissionPlaceholders {
@@ -47,7 +45,6 @@ impl OmissionPlaceholders {
         for (token, value) in [
             ("{candidate_number}", &self.candidate_number),
             ("{candidate_name}", &self.candidate_name),
-            ("{districts}", &self.districts),
         ] {
             if let Some(value) = value {
                 result = result.replace(token, value);
@@ -338,7 +335,6 @@ pub mod tests {
         let placeholders = OmissionPlaceholders {
             candidate_number: Some("3".to_string()),
             candidate_name: Some("A.B. de Vries".to_string()),
-            districts: None,
         };
 
         let result = placeholders

--- a/src/csb/omissions.json
+++ b/src/csb/omissions.json
@@ -81,9 +81,7 @@
       "description": "Ten aanzien van kandidaat nr. {candidate_number} {candidate_name} ontbreekt de verklaring dat deze instemt met kandidaatstelling op de lijst. De verklaring wordt geacht te ontbreken omdat de lijst die daarop vermeld staat niet overeenkomt met de lijst zoals deze is ingediend.",
       "help_text": "Dit verzuim is te herstellen door van de kandidaat alsnog een instemmingsverklaring (model H 9) met de lijst zoals deze is ingediend in te leveren.",
       "recoverable": true
-    }
-  ],
-  "person": [
+    },
     {
       "title": "Gemachtigde kandidaat ontbreekt",
       "description": "De instemmingsverklaring van kandidaat nr. {candidate_number}, {candidate_name} wordt geacht te ontbreken, aangezien de aanwijzing van een gemachtigde ontbreekt nu is gebleken dat de kandidaat buiten het Europese deel van Nederland woont.",

--- a/src/csb/store_csb/getters.rs
+++ b/src/csb/store_csb/getters.rs
@@ -274,14 +274,14 @@ mod tests {
             &store,
             OmissionCategory::Candidate {
                 person: person_a,
-                list: None,
+                lists: Vec::new(),
             },
         );
         insert(
             &store,
             OmissionCategory::Candidate {
                 person: person_b,
-                list: None,
+                lists: Vec::new(),
             },
         );
         insert(&store, OmissionCategory::PoliticalGroup);
@@ -301,7 +301,7 @@ mod tests {
             &store,
             OmissionCategory::Candidate {
                 person: PersonId::new(),
-                list: None,
+                lists: Vec::new(),
             },
         );
 


### PR DESCRIPTION
Closes #966

# [DOD](/docs/definition-of-done.md) checklist

<img width="2880" height="1920" alt="image" src="https://github.com/user-attachments/assets/814c0312-05c0-4e6f-b574-78c7fee9dcd6" />

## For PR maintainer

Perform these checks before marking the PR as ready:

- [x] I have linked the PR to at least one issue.
- [x] I assigned the PR to myself.
- [x] I have added a description how to test this PR (see "Review Instructions").
- [x] I have added documentation where necessary.

## For reviewer

- I have read all code changes.
- I have audited the code quality.
- I have tested the changes either or both:
  - locally
  - on the test environment (preferred)
- I have validated that the PR is functionally correct (use-cases, figma designs, etc.)

### Review instructions

Builds on #965

Adding an omission to a candidate now requires you to select which candidate lists it applies to. By default, the current candidate list is selected. I also added the electoral districts to the omission overview pages.