### PR TITLE
[#1005] Make security.txt and robots.txt always public

### DIFF
--- a/src/middleware/maintenance.rs
+++ b/src/middleware/maintenance.rs
@@ -18,10 +18,12 @@ struct MaintenanceTemplate {
 }
 
 /// Paths that must keep working while the database is unavailable: the health
-/// probe (so orchestration can still read liveness) and static assets / live
-/// reload (so the maintenance page can load its style sheet).
+/// probe (so orchestration can still read liveness), static assets / live
+/// reload (so the maintenance page can load its style sheet), and the
+/// always-public files (robots.txt, .well-known).
 fn is_exempt(path: &str) -> bool {
     path == "/health"
+        || path == "/robots.txt"
         || path.starts_with("/static/")
         || path.starts_with("/.well-known/")
         || path.starts_with("/livereload/")
@@ -89,6 +91,7 @@ mod tests {
     #[test]
     fn exempts_health_static_and_wellknown() {
         assert!(is_exempt("/health"));
+        assert!(is_exempt("/robots.txt"));
         assert!(is_exempt("/static/index.css"));
         assert!(is_exempt("/.well-known/security.txt"));
         assert!(!is_exempt("/"));

--- a/src/pg/common/mod.rs
+++ b/src/pg/common/mod.rs
@@ -23,7 +23,7 @@ pub use crate::structs::common::{
     RVIG_COUNTRY_CODES_URL, Severity, StateOrProvince, StreetName, UtcDateTime, WithProblems,
 };
 
-pub use pages::{not_found, public_router, router, session_only_router, wellknown_router};
+pub use pages::{always_public_router, not_found, public_router, router, session_only_router};
 pub use paths::{
     HideDownloadWarningPath, IndexPath, LoginStartPath, LogoutPath, SelectElectionPath,
     SwitchElectionPath, SwitchLanguagePath,

--- a/src/pg/common/pages/mod.rs
+++ b/src/pg/common/pages/mod.rs
@@ -7,6 +7,7 @@ mod auth;
 mod hide_download_warning;
 mod index;
 mod not_found;
+mod robots;
 mod select_election;
 mod switch_election;
 mod switch_locale;
@@ -40,9 +41,15 @@ pub fn session_only_router() -> Router<AppState> {
         .typed_post(auth::logout_submit)
 }
 
-/// Routes for paths under .well-known
-pub fn wellknown_router() -> Router<AppState> {
-    Router::new().typed_get(well_known::security_txt)
+/// Routes that need no session and no database: `/robots.txt` must always
+/// answer crawlers, and RFC 9116 requires `/.well-known/security.txt` to be
+/// retrievable anonymously. They stay behind the `eks-key` gate like every
+/// other route, since that gate only ensures requests come through our CDN.
+pub fn always_public_router() -> Router<AppState> {
+    Router::new().typed_get(robots::robots_txt).nest(
+        "/.well-known",
+        Router::new().typed_get(well_known::security_txt),
+    )
 }
 
 /// Routes mounted outside the session middleware (no session required):

--- a/src/pg/common/pages/robots.rs
+++ b/src/pg/common/pages/robots.rs
@@ -1,0 +1,26 @@
+use axum_extra::routing::TypedPath;
+use serde::Deserialize;
+
+#[derive(TypedPath, Deserialize)]
+#[typed_path("/robots.txt")]
+pub struct RobotsTxt {}
+
+/// Emit a robots.txt that disallows all crawling
+pub(super) async fn robots_txt(_: RobotsTxt) -> &'static str {
+    "User-agent: *\nDisallow: /\n"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::test_utils::response_body_string;
+    use axum::response::IntoResponse;
+
+    #[tokio::test]
+    async fn robots_disallows_everything() {
+        let text = robots_txt(RobotsTxt {}).await;
+        let body = response_body_string(text.into_response()).await;
+        assert_eq!(body, "User-agent: *\nDisallow: /\n");
+    }
+}

--- a/src/router.rs
+++ b/src/router.rs
@@ -89,7 +89,7 @@ pub fn create(state: AppState) -> Router<AppState> {
     #[cfg(feature = "livereload")]
     let router = router.merge(crate::utils::livereload::livereload_router());
 
-    let router = mount_static_assets(router).nest("/.well-known", common::wellknown_router());
+    let router = mount_static_assets(router).merge(common::always_public_router());
 
     router
         .layer(csrf_layer())
@@ -319,6 +319,43 @@ mod tests {
         let response = app.oneshot(request).await.expect("response");
 
         assert_ne!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    /// robots.txt and security.txt must answer requests without a session
+    /// cookie (they are served to anonymous visitors through the CDN).
+    #[tokio::test]
+    async fn robots_and_security_txt_need_no_session() {
+        let state = AppState::new_for_tests().await;
+        let app: Router = create(state.clone()).with_state(state.clone());
+
+        for (uri, expected) in [
+            ("/robots.txt", "Disallow: /"),
+            ("/.well-known/security.txt", "Contact: mailto:"),
+        ] {
+            let request = Request::builder().uri(uri).body(Body::empty()).unwrap();
+            let response = app.clone().oneshot(request).await.expect("response");
+
+            assert_eq!(response.status(), StatusCode::OK, "{uri} must be public");
+            let body = response_body_string(response).await;
+            assert!(body.contains(expected), "{uri} body: {body}");
+        }
+    }
+
+    /// The eks-key gate guards robots.txt and security.txt like every other
+    /// route: it exists so only our CDN can reach the server directly.
+    #[tokio::test]
+    async fn robots_and_security_txt_stay_behind_eks_key_gate() {
+        let mut config = crate::Config::new_test();
+        config.eks_key = Some(secrecy::SecretString::from("s3cret"));
+        let state = AppState::new_for_tests_with_config(config).await;
+        let app: Router = create(state.clone()).with_state(state.clone());
+
+        for uri in ["/robots.txt", "/.well-known/security.txt"] {
+            let request = Request::builder().uri(uri).body(Body::empty()).unwrap();
+            let response = app.clone().oneshot(request).await.expect("response");
+
+            assert_eq!(response.status(), StatusCode::UNAUTHORIZED, "{uri}");
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #1005

# [DOD](/docs/definition-of-done.md) checklist

## For PR maintainer

Perform these checks before marking the PR as ready:

- [x] I have linked the PR to at least one issue.
- [x] I assigned the PR to myself.
- [x] I have added a description how to test this PR (see "Review Instructions").
- [x] I have added documentation where necessary.

## For reviewer

- I have read all code changes.
- I have audited the code quality.
- I have tested the changes either or both:
  - locally
  - on the test environment (preferred)
- I have validated that the PR is functionally correct (use-cases, figma designs, etc.)

### Review instructions

Make security.txt and robots.txt always available.
