### PR TITLE
[#1022] Automatic certificate renew

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -247,7 +247,7 @@ jobs:
 
       - name: Build
         env:
-          CARGO_SET_FEATURES: "memory-serve,database,migrations,fixtures,tls,tvs-mock"
+          CARGO_SET_FEATURES: "memory-serve,database,migrations,fixtures,tls,acme,tvs-mock"
         run: bin/build
 
       - name: Strip debug symbols

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,6 +315,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -428,6 +468,15 @@ name = "basic-toml"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 dependencies = [
  "serde",
 ]
@@ -796,6 +845,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,12 +943,14 @@ dependencies = [
  "hkdf",
  "http-body-util",
  "hyper-util",
+ "instant-acme",
  "memory-serve",
  "parking_lot",
  "phf 0.14.0",
  "phf_codegen",
  "postcard",
  "rand",
+ "rcgen",
  "regex",
  "reqwest",
  "rustls",
@@ -891,6 +962,7 @@ dependencies = [
  "sqlx",
  "subtle",
  "textris-pdf",
+ "time",
  "tokio",
  "tokio-util",
  "tower",
@@ -902,6 +974,7 @@ dependencies = [
  "urlencoding",
  "uuid",
  "validate",
+ "x509-parser",
  "zeroize",
 ]
 
@@ -977,7 +1050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1488,6 +1561,8 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1660,6 +1735,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "instant-acme"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f05ad37c421b962354c358d347d4a6130151df9407978372d3ad7f0c8f71a64"
+dependencies = [
+ "async-trait",
+ "aws-lc-rs",
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "httpdate",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "rcgen",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "x509-parser",
 ]
 
 [[package]]
@@ -1892,6 +1994,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1930,6 +2038,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1939,10 +2057,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1951,6 +2088,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -2013,6 +2159,16 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
 ]
 
 [[package]]
@@ -2228,7 +2384,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2276,6 +2432,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+dependencies = [
+ "aws-lc-rs",
+ "pem",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
 ]
 
 [[package]]
@@ -2387,7 +2557,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -2404,6 +2574,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -2461,7 +2640,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2479,7 +2658,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3488,6 +3667,12 @@ dependencies = [
 
 [[package]]
 name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -3708,7 +3893,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3887,10 +4072,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "aws-lc-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "xmp-writer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9440ea3e5aeabb0ac63af70daf835274065238cdd0cec83418f417eae38bacee"
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec",
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ axum = { version = "0.8.9" }
 axum-extra = { version = "0.12.6", features = ["cookie"] }
 axum-server = { version = "0.8.0", features = ["tls-rustls"] }
 rustls = "0.23.40"
+instant-acme = { version = "0.8.5", default-features = false, features = ["aws-lc-rs", "hyper-rustls", "rcgen", "x509-parser"] }
+x509-parser = { version = "0.18.1", default-features = false }
+rcgen = { version = "0.14.8", default-features = false, features = ["aws_lc_rs", "pem"] }
+time = { version = "0.3.53", default-features = false, features = ["std"] }
 hyper-util = { version = "0.1.20", features = ["client-legacy"] }
 tokio = { version = "1.52.1", features = ["fs", "io-util", "macros", "net", "parking_lot", "rt-multi-thread", "signal", "sync", "time"] }
 tower-http = { version = "0.7.0", features = ["csrf", "set-header", "trace"] }
@@ -119,6 +123,8 @@ livereload = []
 memory-serve = ["dep:memory-serve"]
 # Serve over HTTPS via rustls and connect to the database over TLS (production deployments)
 tls = ["dep:axum-server", "dep:rustls", "sqlx?/tls-rustls-aws-lc-rs", "reqwest/rustls"]
+# Renew the TLS certificate via ACME (Let's Encrypt)
+acme = ["tls", "database", "dep:instant-acme", "dep:x509-parser", "dep:rcgen", "dep:time"]
 
 [dependencies]
 aes-gcm = { workspace = true, features = ["zeroize"] }
@@ -137,11 +143,13 @@ eml-nl = { workspace = true }
 hkdf = { workspace = true }
 http-body-util = { workspace = true }
 hyper-util = { workspace = true }
+instant-acme = { workspace = true, optional = true }
 memory-serve = { workspace = true, optional = true }
 parking_lot = { workspace = true }
 phf = { workspace = true }
 postcard = { workspace = true }
 rand = { workspace = true }
+rcgen = { workspace = true, optional = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
 rustls = { workspace = true, optional = true }
@@ -153,6 +161,7 @@ sha2 = { workspace = true }
 sqlx = { workspace = true, optional = true }
 subtle = { workspace = true }
 textris-pdf = { workspace = true }
+time = { workspace = true, optional = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tower-http = { workspace = true }
@@ -162,6 +171,7 @@ url = { workspace = true }
 urlencoding = { workspace = true }
 uuid = { workspace = true }
 validate = { path = "validate" }
+x509-parser = { workspace = true, optional = true }
 zeroize = { workspace = true }
 
 [build-dependencies]

--- a/bin/build
+++ b/bin/build
@@ -20,7 +20,7 @@ fi
 cp frontend/favicon.svg frontend/static/favicon.svg
 
 cargo build \
-    --features "${CARGO_SET_FEATURES:-memory-serve,database,migrations,tls,fixtures}" \
+    --features "${CARGO_SET_FEATURES:-memory-serve,database,migrations,tls,acme,fixtures}" \
     --no-default-features \
     --release \
     --bin eks \

--- a/deploy/schema.sql
+++ b/deploy/schema.sql
@@ -1,0 +1,60 @@
+-- Full application database schema. Mirrors the runtime migration in
+-- src/store/database.rs plus the ACME challenge storage.
+
+-- Event stream bookkeeping: one row per (stream, election) pair.
+CREATE TABLE IF NOT EXISTS streams (
+  stream_id UUID NOT NULL,
+  election TEXT NOT NULL,
+  last_event_id BIGINT NOT NULL,
+  scope TEXT NOT NULL DEFAULT 'political_group',
+  encrypted_key BYTEA,
+  PRIMARY KEY (stream_id, election)
+);
+
+-- Encrypted, hash-chained event log.
+CREATE TABLE IF NOT EXISTS events (
+  stream_id UUID NOT NULL,
+  election TEXT NOT NULL,
+  event_id BIGINT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL,
+  hash BYTEA NOT NULL,
+  payload BYTEA NOT NULL,
+  PRIMARY KEY (stream_id, election, event_id)
+);
+-- Supports looking up an event (and its stream) by its chain hash.
+CREATE INDEX IF NOT EXISTS events_hash_idx ON events(hash);
+
+-- User sessions. `token` holds the token's SHA-256 hash, not the token itself.
+CREATE TABLE IF NOT EXISTS sessions (
+  token TEXT PRIMARY KEY,
+  stream_id UUID,
+  paper_correction_stream_id UUID,
+  current_election JSONB,
+  locale TEXT NOT NULL,
+  last_activity TIMESTAMPTZ NOT NULL,
+  saml_name_id TEXT NOT NULL DEFAULT '',
+  scope TEXT NOT NULL DEFAULT 'political_group',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  user_agent_hash TEXT,
+  csrf_token TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS sessions_last_activity_idx
+  ON sessions(last_activity);
+
+-- In-flight request deduplication.
+CREATE TABLE IF NOT EXISTS pending_requests (
+  id TEXT PRIMARY KEY,
+  created_at TIMESTAMPTZ NOT NULL
+);
+CREATE INDEX IF NOT EXISTS pending_requests_created_at_idx
+  ON pending_requests(created_at);
+
+-- http-01 challenge tokens, shared so any instance can answer a validation
+-- request. The key authorization is public by protocol.
+CREATE TABLE IF NOT EXISTS acme_challenges (
+  token TEXT PRIMARY KEY,
+  key_authorization TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS acme_challenges_created_at_idx
+  ON acme_challenges(created_at);

--- a/development/Cargo.toml
+++ b/development/Cargo.toml
@@ -21,6 +21,14 @@ test = false
 name = "pdf_diff"
 test = false
 
+[[bin]]
+name = "create_acme_account"
+test = false
+required-features = ["acme"]
+
+[features]
+acme = ["eks/acme"]
+
 [dependencies]
 anyhow = { workspace = true }
 tokio = { workspace = true, features = ["process"] }

--- a/development/src/bin/create_acme_account.rs
+++ b/development/src/bin/create_acme_account.rs
@@ -1,0 +1,29 @@
+//! One-shot tool that registers an ACME account and prints its credentials
+//! JSON to stdout, to be deployed as the `ACME_ACCOUNT_CREDENTIALS` secret.
+//! Reads `ACME_DIRECTORY_URL` (required), `ACME_CONTACT` and
+//! `ACME_ROOT_CA_PATH`
+
+use std::path::PathBuf;
+
+fn env_opt(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|s| !s.is_empty())
+}
+
+#[tokio::main]
+async fn main() {
+    let Some(directory_url) = env_opt("ACME_DIRECTORY_URL") else {
+        eprintln!("ACME_DIRECTORY_URL must be set to the CA directory to register with");
+        std::process::exit(1);
+    };
+    let contact = env_opt("ACME_CONTACT");
+    let root_ca_path = env_opt("ACME_ROOT_CA_PATH").map(PathBuf::from);
+
+    match eks::create_acme_account(directory_url, contact.as_deref(), root_ca_path.as_deref()).await
+    {
+        Ok(credentials_json) => println!("{credentials_json}"),
+        Err(err) => {
+            eprintln!("could not create the ACME account: {err}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/docs/code-architecture.md
+++ b/docs/code-architecture.md
@@ -358,6 +358,9 @@ Runtime configuration is read from environment variables once at startup into a
 | `ID_DERIVATION_KEY` | Master secret for stream-id derivation. |
 | `MASTER_ENCRYPTION_KEY` | Master secret from which the key-wrapping key for the per-stream encryption keys is derived. |
 | `TLS_CERT_PATH` / `TLS_KEY_PATH` | HTTPS certificate and key; both or neither. |
+| `ACME_DIRECTORY_URL` / `ACME_DOMAIN` | Enable ACME certificate renewal (`acme` feature): the CA directory (e.g. Let's Encrypt production or staging) and the FQDN to order for; both or neither, requires TLS. |
+| `ACME_ACCOUNT_CREDENTIALS` | ACME account credentials JSON from the `create_acme_account` tool; contains the account's private key, so supply it like the master secrets. Required when ACME is enabled. |
+| `ACME_ROOT_CA_PATH` | Optional extra trust root for the ACME directory's own TLS (pebble testing only). |
 | `SERVER_NAME` | Short server identifier shown in the page footer. |
 | `EKS_KEY` | Optional shared secret for the `x-eks-key` request gate. |
 | `BIND_ADDRESS` | Address the server binds to (also accepted as a CLI argument). |
@@ -388,7 +391,66 @@ and enables the embedding and TLS features.
 | `livereload` | Live-reload assets and templates during development. |
 | `memory-serve` | Serve the frontend assets embedded in the binary. |
 | `tls` | Serve over HTTPS via rustls. |
+| `acme` | Renew the TLS certificate via ACME (Let's Encrypt) http-01. |
 | `db-tests` / `net-tests` | Enable database- and network-dependent tests. |
+
+### ACME certificate renewal
+
+With the `acme` feature compiled in and `ACME_DIRECTORY_URL` + `ACME_DOMAIN`
+set, each instance renews its own certificate: a background task
+(`src/acme/renewer.rs`) checks daily whether the certificate at
+`TLS_CERT_PATH` expires within 30 days and, if so, orders a new one, writes
+the renewed cert/key back to the configured paths, and hot-reloads the running
+server without a restart. An instance may also start without provisioned
+cert/key files: at boot it writes a short-lived self-signed placeholder to
+the TLS paths (`src/acme/bootstrap.rs`) so the HTTPS server can come up, and
+the renewer replaces it with a real certificate on its first pass.
+
+Because the application is scaled horizontally, http-01 challenge tokens are
+stored in the database, so the CA's validation request to
+`/.well-known/acme-challenge/<token>` can be answered by any instance. That
+route is merged outside the `eks-key` gate, like `/lb-health`. Challenge
+tokens are public by protocol. Deployment prerequisites:
+
+- Provision `ACME_ACCOUNT_CREDENTIALS` (see below).
+- Apply `deploy/schema.sql` to the database manually before enabling
+  ACME (the `acme_challenges` table is not part of the startup migrations).
+- The CA dials `http://<domain>:80/.well-known/acme-challenge/...`; the load
+  balancer must forward that path to the instances, or redirect it to HTTPS
+  (the CA follows redirects and does not validate the certificate).
+- The cert/key files should be writable; on a read-only volume the renewed
+  certificate stays active in memory only and is lost on restart.
+
+#### Initializing the ACME account
+
+The ACME account is a deployment-level secret, not runtime state: it is
+created once per environment and deployed as configuration, like the master
+secrets. The application never registers accounts on its own; with ACME
+enabled it refuses to start without valid credentials.
+
+1. Create the account, from any machine with outbound HTTPS to the CA (no
+   inbound validation happens at registration):
+
+   ```sh
+   ACME_DIRECTORY_URL=https://acme-v02.api.letsencrypt.org/directory \
+   ACME_CONTACT=mailto:ops@example.nl \
+   cargo run -p eks-development --features acme --bin create_acme_account
+   ```
+
+   This registers an account (terms of service agreed, optional contact) and
+   prints its credentials as a single JSON line to stdout.
+2. Add that line to the environment file on every instance as
+   `ACME_ACCOUNT_CREDENTIALS=...`, alongside the other master secrets (never
+   on the command line). All instances share the one account; ACME accounts
+   are designed for concurrent reuse.
+3. At startup the application checks that the credentials parse and that
+   their embedded directory matches `ACME_DIRECTORY_URL`, so a staging
+   account can never be deployed against production (or vice versa); use a
+   separate account per directory.
+
+To rotate the account (e.g. after a suspected key leak), run step 1 again,
+replace the variable, and restart the instances. The old account can simply
+be abandoned; certificates it issued remain valid.
 
 ## Event storage and the event hash chain
 

--- a/locales/en/audit_log.yml
+++ b/locales/en/audit_log.yml
@@ -41,9 +41,8 @@ empty: No events have been recorded yet.
 event:
   add_candidate_to_list: Added candidate to list
   create_candidate_list: Created list of candidates
-  create_name_authorisation: Created statutory name and authorised agent
   create_empty: Created empty political group
-  paper_correction: Paper corrections
+  create_name_authorisation: Created statutory name and authorised agent
   create_omission: Created omission
   create_person: Created person
   create_substitute_submitter: Created substitute submitter of the list
@@ -59,6 +58,7 @@ event:
   hide_download_warning: Dismissed download warning
   import: Imported political group
   import_csv: Imported CSV
+  paper_correction: Paper corrections
   remove_candidate_from_list: Removed candidate from list
   set_finished: Set finished state
   update_candidate_list_districts: Updated electoral districts of list
@@ -87,9 +87,9 @@ filter:
     correction: Corrections
     import: Import
     list_submitter: List submitter
-    paper_correction: Paper corrections
     name_authorisation: Statutory name and authorised agent
     omission: Omission
+    paper_correction: Paper corrections
     person: Person
     political_group: Political group
     set_finished: Finished state

--- a/locales/nl/audit_log.yml
+++ b/locales/nl/audit_log.yml
@@ -41,9 +41,8 @@ empty: Er zijn nog geen gebeurtenissen vastgelegd.
 event:
   add_candidate_to_list: Kandidaat aan lijst toegevoegd
   create_candidate_list: Kandidatenlijst aangemaakt
-  create_name_authorisation: Statutaire naam en gemachtigde aangemaakt
   create_empty: Lege politieke groepering aangemaakt
-  paper_correction: Papieren correcties
+  create_name_authorisation: Statutaire naam en gemachtigde aangemaakt
   create_omission: Verzuim aangemaakt
   create_person: Persoon aangemaakt
   create_substitute_submitter: Vervanger herstel verzuim aangemaakt
@@ -59,6 +58,7 @@ event:
   hide_download_warning: Download\u00ADwaarschuwing gesloten
   import: Politieke groepering geïmporteerd
   import_csv: CSV geïmporteerd
+  paper_correction: Papieren correcties
   remove_candidate_from_list: Kandidaat van lijst verwijderd
   set_finished: Afgerond gezet
   update_candidate_list_districts: Kieskringen van lijst bijgewerkt
@@ -87,9 +87,9 @@ filter:
     correction: Ambtshalve correcties
     import: Import
     list_submitter: Lijstinleveraar
-    paper_correction: Papieren correcties
     name_authorisation: Statutaire naam en gemachtigde
     omission: Verzuim
+    paper_correction: Papieren correcties
     person: Persoon
     political_group: Politieke groepering
     set_finished: Afgerond

--- a/src/acme/account.rs
+++ b/src/acme/account.rs
@@ -1,0 +1,121 @@
+//! ACME account handling. The account is created once per environment with
+//! the `create_acme_account` tool (development crate) and deployed as the
+//! `ACME_ACCOUNT_CREDENTIALS` secret; the application never registers
+//! accounts on its own.
+
+use std::path::Path;
+
+use instant_acme::{Account, AccountBuilder, AccountCredentials, NewAccount};
+use secrecy::ExposeSecret;
+
+use crate::{AcmeConfig, AppError};
+
+fn builder(root_ca_path: Option<&Path>) -> Result<AccountBuilder, AppError> {
+    Ok(match root_ca_path {
+        Some(path) => Account::builder_with_root(path)?,
+        None => Account::builder()?,
+    })
+}
+
+/// Parse the configured credentials; called at startup to fail fast and by
+/// the renewer on every renewal.
+pub fn parse_acme_account_credentials(acme: &AcmeConfig) -> Result<AccountCredentials, AppError> {
+    serde_json::from_str(acme.account_credentials.expose_secret())
+        .map_err(|e| AppError::ConfigLoadError(format!("ACME_ACCOUNT_CREDENTIALS is invalid: {e}")))
+}
+
+/// Restore the configured account at the directory.
+pub(super) async fn load_account(acme: &AcmeConfig) -> Result<Account, AppError> {
+    let credentials = parse_acme_account_credentials(acme)?;
+    Ok(builder(acme.root_ca_path.as_deref())?
+        .from_credentials(credentials)
+        .await?)
+}
+
+/// Register a new account and return its credentials JSON; backs the
+/// `create_acme_account` tool.
+pub async fn create_acme_account(
+    directory_url: String,
+    contact: Option<&str>,
+    root_ca_path: Option<&Path>,
+) -> Result<String, AppError> {
+    let contact: Vec<&str> = contact.into_iter().collect();
+    let (_account, credentials) = builder(root_ca_path)?
+        .create(
+            &NewAccount {
+                contact: &contact,
+                terms_of_service_agreed: true,
+                only_return_existing: false,
+            },
+            directory_url,
+            None,
+        )
+        .await?;
+
+    serde_json::to_string(&credentials).map_err(|e| AppError::AcmeError(e.into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(credentials: &str) -> AcmeConfig {
+        AcmeConfig {
+            directory_url: "https://acme.example/dir".to_string(),
+            domain: "eks.example.nl".to_string(),
+            account_credentials: secrecy::SecretString::from(credentials),
+            root_ca_path: None,
+        }
+    }
+
+    #[test]
+    fn parse_rejects_invalid_credentials() {
+        let Err(err) = parse_acme_account_credentials(&config("not json")) else {
+            panic!("invalid JSON must not parse");
+        };
+        assert!(matches!(err, AppError::ConfigLoadError(_)));
+        assert!(err.to_string().contains("ACME_ACCOUNT_CREDENTIALS"));
+
+        // Valid JSON, but not the credentials shape.
+        assert!(parse_acme_account_credentials(&config("{}")).is_err());
+    }
+
+    #[test]
+    fn parse_accepts_the_credentials_shape() {
+        let credentials = r#"{
+            "id": "https://acme.example/acct/1",
+            "key_pkcs8": "AAAA",
+            "directory": "https://acme.example/dir"
+        }"#;
+        let _credentials =
+            parse_acme_account_credentials(&config(credentials)).expect("valid credentials");
+    }
+
+    #[tokio::test]
+    async fn load_account_fails_fast_on_invalid_credentials() {
+        // Parsing happens before any network traffic.
+        let Err(err) = load_account(&config("{}")).await else {
+            panic!("invalid credentials must not load");
+        };
+        assert!(matches!(err, AppError::ConfigLoadError(_)));
+    }
+
+    #[test]
+    fn builder_rejects_a_missing_root_ca() {
+        assert!(builder(Some(Path::new("/nonexistent/root-ca.pem"))).is_err());
+        builder(None).expect("default builder");
+    }
+
+    #[tokio::test]
+    async fn create_account_rejects_a_missing_root_ca() {
+        // The root CA is read before any network traffic.
+        let err = create_acme_account(
+            "https://acme.example/dir".to_string(),
+            Some("mailto:beheer@example.nl"),
+            Some(Path::new("/nonexistent/root-ca.pem")),
+        )
+        .await
+        .expect_err("err");
+        assert!(matches!(err, AppError::AcmeError(_)));
+    }
+}

--- a/src/acme/acme_db.rs
+++ b/src/acme/acme_db.rs
@@ -1,0 +1,125 @@
+//! Postgres persistence for ACME challenge tokens.
+//! Requires the manually applied `deploy/schema.sql`.
+
+use chrono::{DateTime, Duration, Utc};
+
+use crate::AppError;
+
+/// Expiry cutoff for challenge rows; an hour covers CA retries.
+fn cutoff() -> DateTime<Utc> {
+    Utc::now() - Duration::hours(1)
+}
+
+/// Record a challenge token, sweeping expired rows first.
+pub async fn put_challenge(
+    pool: &sqlx::PgPool,
+    token: &str,
+    key_authorization: &str,
+) -> Result<(), AppError> {
+    sqlx::query("DELETE FROM acme_challenges WHERE created_at < $1")
+        .bind(cutoff())
+        .execute(pool)
+        .await?;
+
+    sqlx::query(
+        r#"INSERT INTO acme_challenges (token, key_authorization, created_at)
+           VALUES ($1, $2, $3)
+           ON CONFLICT (token) DO UPDATE
+           SET key_authorization = EXCLUDED.key_authorization,
+               created_at = EXCLUDED.created_at"#,
+    )
+    .bind(token)
+    .bind(key_authorization)
+    .bind(Utc::now())
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+pub async fn find_challenge(pool: &sqlx::PgPool, token: &str) -> Result<Option<String>, AppError> {
+    let row: Option<(String,)> = sqlx::query_as(
+        r#"SELECT key_authorization FROM acme_challenges
+           WHERE token = $1 AND created_at >= $2"#,
+    )
+    .bind(token)
+    .bind(cutoff())
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(row.map(|(key_authorization,)| key_authorization))
+}
+
+pub async fn delete_challenge(pool: &sqlx::PgPool, token: &str) -> Result<(), AppError> {
+    sqlx::query("DELETE FROM acme_challenges WHERE token = $1")
+        .bind(token)
+        .execute(pool)
+        .await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Apply the shipped schema file, so these tests keep it honest.
+    async fn apply_schema(pool: &sqlx::PgPool) {
+        sqlx::raw_sql(include_str!("../../deploy/schema.sql"))
+            .execute(pool)
+            .await
+            .expect("apply deploy/schema.sql");
+    }
+
+    #[cfg_attr(not(feature = "db-tests"), ignore = "requires database")]
+    #[sqlx::test(migrations = false)]
+    async fn challenge_roundtrip(pool: sqlx::PgPool) {
+        apply_schema(&pool).await;
+
+        put_challenge(&pool, "tok", "tok.thumbprint").await.unwrap();
+        assert_eq!(
+            find_challenge(&pool, "tok").await.unwrap().as_deref(),
+            Some("tok.thumbprint")
+        );
+        assert_eq!(find_challenge(&pool, "other").await.unwrap(), None);
+
+        // Upsert replaces the key authorization for a re-used token.
+        put_challenge(&pool, "tok", "tok.renewed").await.unwrap();
+        assert_eq!(
+            find_challenge(&pool, "tok").await.unwrap().as_deref(),
+            Some("tok.renewed")
+        );
+
+        delete_challenge(&pool, "tok").await.unwrap();
+        assert_eq!(find_challenge(&pool, "tok").await.unwrap(), None);
+    }
+
+    #[cfg_attr(not(feature = "db-tests"), ignore = "requires database")]
+    #[sqlx::test(migrations = false)]
+    async fn expired_challenges_are_invisible_and_swept(pool: sqlx::PgPool) {
+        apply_schema(&pool).await;
+
+        sqlx::query(
+            "INSERT INTO acme_challenges (token, key_authorization, created_at) VALUES ($1, $2, $3)",
+        )
+        .bind("stale")
+        .bind("stale.thumbprint")
+        .bind(Utc::now() - Duration::hours(2))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(find_challenge(&pool, "stale").await.unwrap(), None);
+
+        // A write sweeps expired rows.
+        put_challenge(&pool, "fresh", "fresh.thumbprint")
+            .await
+            .unwrap();
+        let (count,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM acme_challenges WHERE token = 'stale'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(count, 0);
+    }
+}

--- a/src/acme/acme_store.rs
+++ b/src/acme/acme_store.rs
@@ -1,0 +1,155 @@
+//! Storage for ACME http-01 challenge tokens. Mirrors
+//! [`crate::PendingRequestStore`]: in-memory by default, Postgres when
+//! `STORAGE_URL` is `postgres://`. Challenge tokens are public by protocol.
+
+use std::{collections::HashMap, sync::Arc};
+
+use parking_lot::RwLock;
+use tracing::error;
+
+use crate::{AppError, acme::acme_db, utils::StorageScheme};
+
+/// ACME challenge-token storage backend.
+#[derive(Clone)]
+pub enum AcmeStore {
+    /// Single instance only; cleared on restart.
+    InMemory(Arc<RwLock<HashMap<String, String>>>),
+    /// Shared across instances.
+    Database(sqlx::PgPool),
+}
+
+impl Default for AcmeStore {
+    fn default() -> Self {
+        Self::InMemory(Arc::default())
+    }
+}
+
+impl AcmeStore {
+    /// Construct from `STORAGE_URL`; same scheme rules as
+    /// [`crate::SessionStore`], with disk falling back to in-memory.
+    pub fn from_storage_url(storage_url: &str) -> Result<Self, AppError> {
+        match StorageScheme::parse(storage_url)? {
+            StorageScheme::Memory | StorageScheme::Local => Ok(Self::default()),
+            StorageScheme::Postgres => Ok(Self::Database(sqlx::PgPool::connect_lazy(storage_url)?)),
+        }
+    }
+
+    pub async fn put_challenge(
+        &self,
+        token: &str,
+        key_authorization: &str,
+    ) -> Result<(), AppError> {
+        match self {
+            AcmeStore::InMemory(inner) => {
+                inner
+                    .write()
+                    .insert(token.to_string(), key_authorization.to_string());
+                Ok(())
+            }
+            AcmeStore::Database(pool) => {
+                acme_db::put_challenge(pool, token, key_authorization).await
+            }
+        }
+    }
+
+    /// Storage errors are logged and fail closed.
+    pub async fn find_challenge(&self, token: &str) -> Option<String> {
+        match self {
+            AcmeStore::InMemory(inner) => inner.read().get(token).cloned(),
+            AcmeStore::Database(pool) => match acme_db::find_challenge(pool, token).await {
+                Ok(key_authorization) => key_authorization,
+                Err(err) => {
+                    error!("failed to look up ACME challenge: {err}");
+                    None
+                }
+            },
+        }
+    }
+
+    /// Best effort: a leftover row is swept on the next renewal.
+    pub async fn delete_challenge(&self, token: &str) {
+        match self {
+            AcmeStore::InMemory(inner) => {
+                inner.write().remove(token);
+            }
+            AcmeStore::Database(pool) => {
+                if let Err(err) = acme_db::delete_challenge(pool, token).await {
+                    error!("failed to delete ACME challenge: {err}");
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn in_memory_challenge_roundtrip() {
+        let store = AcmeStore::default();
+        store.put_challenge("tok", "tok.thumbprint").await.unwrap();
+
+        assert_eq!(
+            store.find_challenge("tok").await.as_deref(),
+            Some("tok.thumbprint")
+        );
+        assert_eq!(store.find_challenge("other").await, None);
+
+        store.delete_challenge("tok").await;
+        assert_eq!(store.find_challenge("tok").await, None);
+    }
+
+    #[test]
+    fn from_storage_url_memory_is_in_memory() {
+        let store = AcmeStore::from_storage_url("memory://").unwrap();
+        assert!(matches!(store, AcmeStore::InMemory(_)));
+    }
+
+    #[test]
+    fn from_storage_url_local_falls_back_to_memory() {
+        let store = AcmeStore::from_storage_url("local:///whatever").unwrap();
+        assert!(matches!(store, AcmeStore::InMemory(_)));
+    }
+
+    #[test]
+    fn from_storage_url_rejects_unsupported_scheme() {
+        assert!(matches!(
+            AcmeStore::from_storage_url("s3://bucket"),
+            Err(AppError::ConfigLoadError(_))
+        ));
+    }
+
+    #[cfg_attr(not(feature = "db-tests"), ignore = "requires database")]
+    #[sqlx::test(migrations = false)]
+    async fn database_challenge_roundtrip(pool: sqlx::PgPool) {
+        sqlx::raw_sql(include_str!("../../deploy/schema.sql"))
+            .execute(&pool)
+            .await
+            .expect("apply deploy/schema.sql");
+        let store = AcmeStore::Database(pool);
+
+        store.put_challenge("tok", "tok.thumbprint").await.unwrap();
+        assert_eq!(
+            store.find_challenge("tok").await.as_deref(),
+            Some("tok.thumbprint")
+        );
+
+        store.delete_challenge("tok").await;
+        assert_eq!(store.find_challenge("tok").await, None);
+    }
+
+    #[tokio::test]
+    async fn database_errors_fail_closed() {
+        // Nothing listens on port 1, so every query errors.
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .acquire_timeout(std::time::Duration::from_secs(1))
+            .connect_lazy("postgres://nobody@127.0.0.1:1/nothing")
+            .unwrap();
+        let store = AcmeStore::Database(pool);
+
+        assert!(store.put_challenge("tok", "tok.thumbprint").await.is_err());
+        assert_eq!(store.find_challenge("tok").await, None);
+        store.delete_challenge("tok").await;
+    }
+}

--- a/src/acme/bootstrap.rs
+++ b/src/acme/bootstrap.rs
@@ -1,0 +1,165 @@
+//! Self-signed placeholder certificate for a first boot without provisioned
+//! cert/key files; the renewer replaces it with a real one right away.
+
+use crate::{
+    AcmeConfig, AppError, TlsConfig,
+    acme::renewer::{cert_not_after, renewal_due, write_atomic},
+};
+
+/// Within the renewal window, so the renewer replaces the placeholder on its
+/// first pass.
+const PLACEHOLDER_VALIDITY: time::Duration = time::Duration::days(7);
+
+/// Write a self-signed placeholder for `acme.domain` when neither TLS file
+/// exists. Exactly one existing file is ambiguous: fail, overwrite nothing.
+pub async fn bootstrap_certificate(acme: &AcmeConfig, tls: &TlsConfig) -> Result<(), AppError> {
+    let cert_exists = tokio::fs::try_exists(&tls.cert_path)
+        .await
+        .map_err(AppError::ServerError)?;
+    let key_exists = tokio::fs::try_exists(&tls.key_path)
+        .await
+        .map_err(AppError::ServerError)?;
+
+    match (cert_exists, key_exists) {
+        (true, true) => return Ok(()),
+        (false, false) => {}
+        _ => {
+            return Err(AppError::ConfigLoadError(format!(
+                "one of {} / {} exists without the other; provision both or remove both",
+                tls.cert_path.display(),
+                tls.key_path.display(),
+            )));
+        }
+    }
+
+    let (cert_pem, key_pem) = self_signed_placeholder(&acme.domain)?;
+    write_atomic(&tls.key_path, key_pem.as_bytes(), 0o600)
+        .await
+        .map_err(AppError::ServerError)?;
+    write_atomic(&tls.cert_path, cert_pem.as_bytes(), 0o644)
+        .await
+        .map_err(AppError::ServerError)?;
+
+    tracing::info!(
+        "no TLS certificate found at {}; wrote a self-signed placeholder for {} — \
+         the ACME renewer will order a real certificate right away",
+        tls.cert_path.display(),
+        acme.domain
+    );
+
+    Ok(())
+}
+
+fn self_signed_placeholder(domain: &str) -> Result<(String, String), AppError> {
+    let mut params =
+        rcgen::CertificateParams::new(vec![domain.to_string()]).map_err(placeholder_error)?;
+    params.not_before = time::OffsetDateTime::now_utc();
+    params.not_after = params.not_before + PLACEHOLDER_VALIDITY;
+
+    let key = rcgen::KeyPair::generate().map_err(placeholder_error)?;
+    let cert = params.self_signed(&key).map_err(placeholder_error)?;
+
+    let cert_pem = cert.pem();
+    debug_assert!(
+        renewal_due(cert_not_after(cert_pem.as_bytes())?, chrono::Utc::now()),
+        "placeholder must trigger an immediate renewal"
+    );
+
+    Ok((cert_pem, key.serialize_pem()))
+}
+
+fn placeholder_error(err: rcgen::Error) -> AppError {
+    AppError::ConfigLoadError(format!(
+        "could not generate a self-signed placeholder certificate: {err}"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::server;
+
+    fn test_config(dir: &std::path::Path) -> (AcmeConfig, TlsConfig) {
+        (
+            AcmeConfig {
+                directory_url: "https://acme.example/dir".to_string(),
+                domain: "eks.example.nl".to_string(),
+                account_credentials: secrecy::SecretString::from("{}"),
+                root_ca_path: None,
+            },
+            TlsConfig {
+                cert_path: dir.join("cert.pem"),
+                key_path: dir.join("key.pem"),
+            },
+        )
+    }
+
+    async fn temp_dir(name: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("eks-acme-boot-{name}-{}", std::process::id()));
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        dir
+    }
+
+    #[tokio::test]
+    async fn writes_a_placeholder_the_server_accepts_and_the_renewer_replaces() {
+        let dir = temp_dir("fresh").await;
+        let (acme, tls) = test_config(&dir);
+
+        bootstrap_certificate(&acme, &tls).await.unwrap();
+
+        let cert = tokio::fs::read(&tls.cert_path).await.unwrap();
+        let key = tokio::fs::read(&tls.key_path).await.unwrap();
+        server::server_config_from_pem(&cert, &key).expect("valid cert/key pair");
+        assert!(renewal_due(
+            cert_not_after(&cert).unwrap(),
+            chrono::Utc::now()
+        ));
+
+        tokio::fs::remove_dir_all(&dir).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn leaves_existing_files_untouched() {
+        let dir = temp_dir("existing").await;
+        let (acme, tls) = test_config(&dir);
+        tokio::fs::write(&tls.cert_path, b"provisioned cert")
+            .await
+            .unwrap();
+        tokio::fs::write(&tls.key_path, b"provisioned key")
+            .await
+            .unwrap();
+
+        bootstrap_certificate(&acme, &tls).await.unwrap();
+
+        assert_eq!(
+            tokio::fs::read(&tls.cert_path).await.unwrap(),
+            b"provisioned cert"
+        );
+        assert_eq!(
+            tokio::fs::read(&tls.key_path).await.unwrap(),
+            b"provisioned key"
+        );
+
+        tokio::fs::remove_dir_all(&dir).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn rejects_half_provisioned_state() {
+        let dir = temp_dir("half").await;
+        let (acme, tls) = test_config(&dir);
+        tokio::fs::write(&tls.cert_path, b"provisioned cert")
+            .await
+            .unwrap();
+
+        let err = bootstrap_certificate(&acme, &tls).await.expect_err("err");
+        assert!(matches!(err, AppError::ConfigLoadError(_)));
+        assert_eq!(
+            tokio::fs::read(&tls.cert_path).await.unwrap(),
+            b"provisioned cert"
+        );
+        assert!(!tokio::fs::try_exists(&tls.key_path).await.unwrap());
+
+        tokio::fs::remove_dir_all(&dir).await.unwrap();
+    }
+}

--- a/src/acme/challenge.rs
+++ b/src/acme/challenge.rs
@@ -1,0 +1,70 @@
+//! Public http-01 challenge endpoint, dialled by the CA's validation servers.
+
+use axum::{
+    Router,
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use axum_extra::routing::{RouterExt, TypedPath};
+use serde::Deserialize;
+
+use crate::{AppError, AppState, acme::AcmeStore};
+
+#[derive(TypedPath, Deserialize)]
+#[typed_path("/.well-known/acme-challenge/{token}", rejection(AppError))]
+pub struct AcmeChallengePath {
+    pub token: String,
+}
+
+pub fn acme_challenge_router() -> Router<AppState> {
+    Router::new().typed_get(acme_challenge)
+}
+
+/// Public by protocol; unknown or expired tokens 404.
+async fn acme_challenge(
+    AcmeChallengePath { token }: AcmeChallengePath,
+    State(store): State<AcmeStore>,
+) -> Response {
+    match store.find_challenge(&token).await {
+        Some(key_authorization) => key_authorization.into_response(),
+        None => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::test_utils::response_body_string;
+
+    #[tokio::test]
+    async fn serves_stored_key_authorization() {
+        let store = AcmeStore::default();
+        store.put_challenge("tok", "tok.thumbprint").await.unwrap();
+
+        let response = acme_challenge(
+            AcmeChallengePath {
+                token: "tok".to_string(),
+            },
+            State(store),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response_body_string(response).await, "tok.thumbprint");
+    }
+
+    #[tokio::test]
+    async fn unknown_token_is_not_found() {
+        let response = acme_challenge(
+            AcmeChallengePath {
+                token: "unknown".to_string(),
+            },
+            State(AcmeStore::default()),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/src/acme/mod.rs
+++ b/src/acme/mod.rs
@@ -1,0 +1,22 @@
+//! ACME (Let's Encrypt) certificate renewal via http-01.
+//!
+//! Each instance renews its own certificate and hot-reloads the server;
+//! challenge tokens live in the database so any instance behind the load
+//! balancer can answer a validation request. The shared account is deployed
+//! as configuration (`ACME_ACCOUNT_CREDENTIALS`), created once with the
+//! `create_acme_account` tool. A first boot without cert/key files gets a
+//! self-signed placeholder. Apply `deploy/schema.sql` manually before
+//! enabling.
+
+mod account;
+mod acme_db;
+mod acme_store;
+mod bootstrap;
+mod challenge;
+mod renewer;
+
+pub use account::{create_acme_account, parse_acme_account_credentials};
+pub(crate) use acme_store::AcmeStore;
+pub use bootstrap::bootstrap_certificate;
+pub(crate) use challenge::acme_challenge_router;
+pub use renewer::run_acme_renewer;

--- a/src/acme/renewer.rs
+++ b/src/acme/renewer.rs
@@ -1,0 +1,435 @@
+//! Background task that renews this instance's TLS certificate via ACME
+//! http-01 and hot-reloads the running server.
+
+use std::{path::Path, sync::Arc, time::Duration};
+
+use axum_server::tls_rustls::RustlsConfig;
+use chrono::{DateTime, Utc};
+use instant_acme::{
+    Account, AuthorizationStatus, CertificateIdentifier, ChallengeType, Identifier, NewOrder,
+    Order, OrderStatus, RetryPolicy,
+};
+use rustls::pki_types::{CertificateDer, pem::PemObject};
+use tokio::io::AsyncWriteExt;
+
+use crate::{
+    AcmeConfig, AppError, TlsConfig,
+    acme::{AcmeStore, account},
+    server,
+};
+
+/// Renew when NotAfter is this close; Let's Encrypt certificates last 90 days.
+const RENEW_BEFORE_DAYS: i64 = 30;
+/// Daily renewal check time (UTC hour).
+const CHECK_HOUR_UTC: u32 = 2;
+/// Failure backoff (seconds); the last value repeats.
+const BACKOFF_SECS: [u64; 4] = [60, 300, 900, 3600];
+
+/// Renew this instance's certificate before it expires. `rustls_config` is a
+/// clone of the serving handle, so renewals go live without a restart.
+pub async fn run_acme_renewer(
+    acme: &'static AcmeConfig,
+    tls: &'static TlsConfig,
+    rustls_config: RustlsConfig,
+    store: AcmeStore,
+) {
+    let mut consecutive_failures: usize = 0;
+
+    loop {
+        match renew_if_due(acme, tls, &rustls_config, &store).await {
+            Ok(()) => {
+                consecutive_failures = 0;
+                let now = Utc::now();
+                let wait = (next_check_at(now) - now).to_std().unwrap_or_default();
+                tokio::time::sleep(wait).await;
+            }
+            Err(err) => {
+                log_renewal_error(&err);
+                let idx = consecutive_failures.min(BACKOFF_SECS.len() - 1);
+                consecutive_failures = consecutive_failures.saturating_add(1);
+                tokio::time::sleep(Duration::from_secs(BACKOFF_SECS[idx])).await;
+            }
+        }
+    }
+}
+
+fn log_renewal_error(err: &AppError) {
+    match err {
+        AppError::DatabaseError(_) => tracing::error!(
+            "ACME renewal failed: {err} (is the ACME schema installed? see deploy/schema.sql)"
+        ),
+        _ => tracing::error!("ACME renewal failed: {err}"),
+    }
+}
+
+async fn renew_if_due(
+    acme: &AcmeConfig,
+    tls: &TlsConfig,
+    rustls_config: &RustlsConfig,
+    store: &AcmeStore,
+) -> Result<(), AppError> {
+    let cert_pem = tokio::fs::read(&tls.cert_path)
+        .await
+        .map_err(AppError::ServerError)?;
+    let not_after = cert_not_after(&cert_pem)?;
+    if !renewal_due(not_after, Utc::now()) {
+        return Ok(());
+    }
+
+    tracing::info!(
+        "TLS certificate for {} expires {not_after}; starting ACME renewal",
+        acme.domain
+    );
+    renew(acme, tls, rustls_config, store, &cert_pem).await
+}
+
+/// NotAfter of the first (end-entity) certificate in a PEM bundle.
+pub(super) fn cert_not_after(cert_pem: &[u8]) -> Result<DateTime<Utc>, AppError> {
+    let cert = CertificateDer::pem_slice_iter(cert_pem)
+        .next()
+        .ok_or_else(|| {
+            AppError::ConfigLoadError("TLS cert PEM contains no certificate".to_string())
+        })?
+        .map_err(|e| AppError::ConfigLoadError(format!("invalid TLS cert PEM: {e}")))?;
+    let (_, parsed) = x509_parser::parse_x509_certificate(cert.as_ref())
+        .map_err(|e| AppError::ConfigLoadError(format!("invalid TLS certificate: {e}")))?;
+
+    DateTime::from_timestamp(parsed.validity().not_after.timestamp(), 0).ok_or_else(|| {
+        AppError::ConfigLoadError("TLS certificate NotAfter out of range".to_string())
+    })
+}
+
+pub(super) fn renewal_due(not_after: DateTime<Utc>, now: DateTime<Utc>) -> bool {
+    not_after - now < chrono::Duration::days(RENEW_BEFORE_DAYS)
+}
+
+/// Next daily check moment at [`CHECK_HOUR_UTC`].
+pub(super) fn next_check_at(now: DateTime<Utc>) -> DateTime<Utc> {
+    let today = now
+        .date_naive()
+        .and_hms_opt(CHECK_HOUR_UTC, 0, 0)
+        .expect("valid check time")
+        .and_utc();
+    if today > now {
+        today
+    } else {
+        today + chrono::Duration::days(1)
+    }
+}
+
+async fn renew(
+    acme: &AcmeConfig,
+    tls: &TlsConfig,
+    rustls_config: &RustlsConfig,
+    store: &AcmeStore,
+    current_cert_pem: &[u8],
+) -> Result<(), AppError> {
+    let account = account::load_account(acme).await?;
+    let mut order = new_order(&account, acme, current_cert_pem).await?;
+
+    let mut tokens = Vec::new();
+    let result = complete_order(&mut order, acme, tls, rustls_config, store, &mut tokens).await;
+
+    // Tokens are single-use; clean up regardless of outcome.
+    for token in &tokens {
+        store.delete_challenge(token).await;
+    }
+
+    result
+}
+
+/// Order with an ARI `replaces` identifier (RFC 9773) when possible: it
+/// exempts the renewal from the duplicate-certificate rate limit.
+async fn new_order(
+    account: &Account,
+    acme: &AcmeConfig,
+    current_cert_pem: &[u8],
+) -> Result<Order, AppError> {
+    let identifiers = [Identifier::Dns(acme.domain.clone())];
+
+    let current_cert = CertificateDer::pem_slice_iter(current_cert_pem)
+        .next()
+        .and_then(|cert| cert.ok());
+    if let Some(cert) = &current_cert {
+        match CertificateIdentifier::try_from(cert) {
+            Ok(cert_id) => {
+                match account
+                    .new_order(&NewOrder::new(&identifiers).replaces(cert_id))
+                    .await
+                {
+                    Ok(order) => return Ok(order),
+                    Err(err) => tracing::info!(
+                        "ACME order with ARI `replaces` failed ({err}); retrying without"
+                    ),
+                }
+            }
+            Err(err) => tracing::info!(
+                "current certificate has no usable ARI identifier ({err}); ordering without"
+            ),
+        }
+    }
+
+    Ok(account.new_order(&NewOrder::new(&identifiers)).await?)
+}
+
+async fn complete_order(
+    order: &mut Order,
+    acme: &AcmeConfig,
+    tls: &TlsConfig,
+    rustls_config: &RustlsConfig,
+    store: &AcmeStore,
+    tokens: &mut Vec<String>,
+) -> Result<(), AppError> {
+    let mut authorizations = order.authorizations();
+    while let Some(result) = authorizations.next().await {
+        let mut authz = result?;
+        match authz.status {
+            AuthorizationStatus::Valid => continue,
+            AuthorizationStatus::Pending => {}
+            status => {
+                return Err(AppError::ConfigLoadError(format!(
+                    "unexpected ACME authorization status: {status:?}"
+                )));
+            }
+        }
+
+        let mut challenge = authz
+            .challenge(ChallengeType::Http01)
+            .ok_or(AppError::AcmeError(instant_acme::Error::Str(
+                "server offered no http-01 challenge",
+            )))?;
+
+        // Store the token before set_ready: the CA may validate immediately.
+        store
+            .put_challenge(&challenge.token, challenge.key_authorization().as_str())
+            .await?;
+        tokens.push(challenge.token.clone());
+
+        challenge.set_ready().await?;
+    }
+
+    let status = order.poll_ready(&RetryPolicy::default()).await?;
+    if status != OrderStatus::Ready {
+        return Err(order_failure(order, status).await);
+    }
+
+    let key_pem = order.finalize().await?;
+    let cert_pem = order.poll_certificate(&RetryPolicy::default()).await?;
+
+    // Same pinned builder as startup: a broken pair can never be installed.
+    let new_config = server::server_config_from_pem(cert_pem.as_bytes(), key_pem.as_bytes())?;
+
+    let persisted = async {
+        write_atomic(&tls.key_path, key_pem.as_bytes(), 0o600).await?;
+        write_atomic(&tls.cert_path, cert_pem.as_bytes(), 0o644).await
+    }
+    .await;
+    if let Err(err) = persisted {
+        tracing::warn!(
+            "could not persist the renewed TLS certificate to {} / {}: {err}; \
+             it is only active in memory until the next restart",
+            tls.cert_path.display(),
+            tls.key_path.display()
+        );
+    }
+
+    rustls_config.reload_from_config(Arc::new(new_config));
+
+    let not_after = cert_not_after(cert_pem.as_bytes())
+        .map(|t| t.to_string())
+        .unwrap_or_else(|_| "unknown".to_string());
+    tracing::info!(
+        "renewed TLS certificate for {}, valid until {not_after}",
+        acme.domain
+    );
+
+    Ok(())
+}
+
+// Collect problem details from the CA
+async fn order_failure(order: &mut Order, status: OrderStatus) -> AppError {
+    let mut problems = Vec::new();
+    let mut authorizations = order.authorizations();
+    while let Some(result) = authorizations.next().await {
+        let Ok(mut authz) = result else { continue };
+        let Ok(state) = authz.refresh().await else {
+            continue;
+        };
+        for challenge in &state.challenges {
+            if let Some(problem) = &challenge.error {
+                problems.push(problem.to_string());
+            }
+        }
+    }
+
+    let detail = match problems.is_empty() {
+        true => "the CA reported no problem details".to_string(),
+        false => problems.join("; "),
+    };
+    AppError::ConfigLoadError(format!("ACME order became {status:?}: {detail}"))
+}
+
+/// Write via temp file + rename so a partial PEM is never visible.
+pub(super) async fn write_atomic(path: &Path, bytes: &[u8], mode: u32) -> std::io::Result<()> {
+    let mut tmp_name = path.as_os_str().to_owned();
+    tmp_name.push(".tmp");
+    let tmp = std::path::PathBuf::from(tmp_name);
+
+    let mut options = tokio::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    options.mode(mode);
+    #[cfg(not(unix))]
+    let _ = mode;
+
+    let mut file = options.open(&tmp).await?;
+    file.write_all(bytes).await?;
+    file.sync_all().await?;
+    drop(file);
+
+    tokio::fs::rename(&tmp, path).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FIXTURE_CERT: &[u8] = include_bytes!("../fixtures/tls/cert.pem");
+
+    /// Self-signed pair for `eks.example.nl` expiring in `days`.
+    fn self_signed_pair(days: i64) -> (String, String) {
+        let mut params = rcgen::CertificateParams::new(vec!["eks.example.nl".to_string()]).unwrap();
+        params.not_before = time::OffsetDateTime::now_utc() - time::Duration::days(1);
+        params.not_after = time::OffsetDateTime::now_utc() + time::Duration::days(days);
+        let key = rcgen::KeyPair::generate().unwrap();
+        let cert = params.self_signed(&key).unwrap();
+        (cert.pem(), key.serialize_pem())
+    }
+
+    /// Config pointing at a fresh temp dir holding a cert expiring in `days`.
+    async fn renewer_setup(
+        name: &str,
+        days: i64,
+        credentials: &str,
+    ) -> (AcmeConfig, TlsConfig, RustlsConfig, std::path::PathBuf) {
+        let dir =
+            std::env::temp_dir().join(format!("eks-acme-renew-{name}-{}", std::process::id()));
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+
+        let (cert_pem, key_pem) = self_signed_pair(days);
+        let tls = TlsConfig {
+            cert_path: dir.join("cert.pem"),
+            key_path: dir.join("key.pem"),
+        };
+        tokio::fs::write(&tls.cert_path, &cert_pem).await.unwrap();
+        tokio::fs::write(&tls.key_path, &key_pem).await.unwrap();
+
+        let acme = AcmeConfig {
+            directory_url: "https://acme.example/dir".to_string(),
+            domain: "eks.example.nl".to_string(),
+            account_credentials: secrecy::SecretString::from(credentials),
+            root_ca_path: None,
+        };
+        let config = server::server_config_from_pem(cert_pem.as_bytes(), key_pem.as_bytes())
+            .expect("valid pair");
+        (acme, tls, RustlsConfig::from_config(Arc::new(config)), dir)
+    }
+
+    #[tokio::test]
+    async fn renew_if_due_skips_a_certificate_that_is_not_due() {
+        let (acme, tls, rustls_config, dir) = renewer_setup("not-due", 60, "{}").await;
+
+        // Returns before touching credentials or the network.
+        renew_if_due(&acme, &tls, &rustls_config, &AcmeStore::default())
+            .await
+            .expect("not due");
+
+        tokio::fs::remove_dir_all(&dir).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn renew_if_due_fails_fast_on_invalid_credentials() {
+        let (acme, tls, rustls_config, dir) = renewer_setup("due", 7, "not json").await;
+
+        // Due, so renewal starts; credential parsing fails before any traffic.
+        let err = renew_if_due(&acme, &tls, &rustls_config, &AcmeStore::default())
+            .await
+            .expect_err("err");
+        assert!(matches!(err, AppError::ConfigLoadError(_)));
+
+        tokio::fs::remove_dir_all(&dir).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn renew_if_due_reports_a_missing_certificate() {
+        let (acme, mut tls, rustls_config, dir) = renewer_setup("missing", 60, "{}").await;
+        tls.cert_path = dir.join("nonexistent.pem");
+
+        let err = renew_if_due(&acme, &tls, &rustls_config, &AcmeStore::default())
+            .await
+            .expect_err("err");
+        assert!(matches!(err, AppError::ServerError(_)));
+
+        tokio::fs::remove_dir_all(&dir).await.unwrap();
+    }
+
+    #[test]
+    fn log_renewal_error_handles_both_branches() {
+        log_renewal_error(&AppError::DatabaseError(sqlx::Error::PoolTimedOut));
+        log_renewal_error(&AppError::ConfigLoadError("other".to_string()));
+    }
+
+    #[test]
+    fn cert_not_after_parses_fixture_cert() {
+        let not_after = cert_not_after(FIXTURE_CERT).expect("fixture cert parses");
+        assert!(not_after > DateTime::from_timestamp(1_500_000_000, 0).unwrap());
+    }
+
+    #[test]
+    fn cert_not_after_rejects_garbage() {
+        assert!(cert_not_after(b"not a pem").is_err());
+        assert!(cert_not_after(b"").is_err());
+    }
+
+    #[test]
+    fn renewal_due_boundaries() {
+        let now = Utc::now();
+        let day = chrono::Duration::days(1);
+
+        assert!(!renewal_due(now + day * 31, now));
+        assert!(renewal_due(now + day * 29, now));
+        assert!(renewal_due(now - day, now));
+    }
+
+    #[test]
+    fn next_check_at_boundaries() {
+        let at = |h, m| {
+            DateTime::parse_from_rfc3339(&format!("2026-07-28T{h:02}:{m:02}:00Z"))
+                .unwrap()
+                .to_utc()
+        };
+
+        assert_eq!(next_check_at(at(1, 30)), at(2, 0));
+        assert_eq!(
+            next_check_at(at(2, 0)),
+            at(2, 0) + chrono::Duration::days(1)
+        );
+        assert_eq!(
+            next_check_at(at(14, 45)),
+            at(2, 0) + chrono::Duration::days(1)
+        );
+    }
+
+    #[tokio::test]
+    async fn write_atomic_replaces_content() {
+        let dir = std::env::temp_dir().join(format!("eks-acme-test-{}", std::process::id()));
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        let path = dir.join("cert.pem");
+
+        write_atomic(&path, b"first", 0o644).await.unwrap();
+        write_atomic(&path, b"second", 0o644).await.unwrap();
+
+        assert_eq!(tokio::fs::read(&path).await.unwrap(), b"second");
+        tokio::fs::remove_dir_all(&dir).await.unwrap();
+    }
+}

--- a/src/bin/eks.rs
+++ b/src/bin/eks.rs
@@ -67,6 +67,24 @@ async fn run(listener: TcpListener, config: Config) -> Result<(), AppError> {
 
     // Start the server
     let router = router::create(state.clone()).with_state(state.clone());
+
+    // The renewer hot-reloads renewed certificates through a clone of the
+    // TLS config the server listens with.
+    #[cfg(feature = "acme")]
+    if let (Some(tls), Some(acme)) = (state.config.tls.as_ref(), state.config.acme.as_ref()) {
+        // Fail fast on malformed account credentials.
+        let _ = eks::parse_acme_account_credentials(acme)?;
+        eks::bootstrap_certificate(acme, tls).await?;
+        let rustls_config = server::build_rustls_config(tls).await?;
+        tokio::spawn(eks::run_acme_renewer(
+            acme,
+            tls,
+            rustls_config.clone(),
+            state.acme_store.clone(),
+        ));
+        return server::serve_tls(router, listener, rustls_config).await;
+    }
+
     server::serve(router, listener, state.config).await?;
 
     Ok(())

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -39,6 +39,20 @@ pub struct TlsConfig {
     pub key_path: PathBuf,
 }
 
+/// ACME (Let's Encrypt) certificate-renewal configuration.
+#[derive(Debug, Clone)]
+pub struct AcmeConfig {
+    /// Deliberately no default, so production orders are always explicit.
+    pub directory_url: String,
+    /// FQDN to order the certificate for.
+    pub domain: String,
+    /// Account credentials JSON produced by the `create_acme_account` tool
+    /// (development crate); contains the account's private key.
+    pub account_credentials: SecretString,
+    /// Extra trust root for the directory's own TLS (pebble testing only).
+    pub root_ca_path: Option<PathBuf>,
+}
+
 /// Runtime configuration loaded from environment variables.
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -46,6 +60,8 @@ pub struct Config {
     pub id_derivation_key: SecretString,
     pub master_encryption_key: SecretString,
     pub tls: Option<TlsConfig>,
+    /// ACME certificate renewal; requires `tls`.
+    pub acme: Option<AcmeConfig>,
     /// Short identifier of the server this instance runs on (e.g. "S1"),
     /// rendered next to the version in the layout footer.
     pub server_name: Option<String>,
@@ -76,6 +92,22 @@ where
     }
 }
 
+/// Offline sanity check; the credentials are bound to their directory, so a
+/// staging account can never be deployed against production (or vice versa).
+fn check_account_credentials(credentials: &str, directory_url: &str) -> Result<(), AppError> {
+    let value: serde_json::Value = serde_json::from_str(credentials).map_err(|e| {
+        AppError::ConfigLoadError(format!("ACME_ACCOUNT_CREDENTIALS is not valid JSON: {e}"))
+    })?;
+    if value.get("directory").and_then(|v| v.as_str()) != Some(directory_url) {
+        return Err(AppError::ConfigLoadError(
+            "ACME_ACCOUNT_CREDENTIALS was not created for ACME_DIRECTORY_URL; \
+             run `create_acme_account` against this directory"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
 impl Config {
     pub fn from_env() -> Result<Self, AppError> {
         Self::from_env_with(env::var)
@@ -103,6 +135,40 @@ impl Config {
             }
         };
 
+        let acme = match (
+            lookup("ACME_DIRECTORY_URL").ok().filter(|s| !s.is_empty()),
+            lookup("ACME_DOMAIN").ok().filter(|s| !s.is_empty()),
+        ) {
+            (Some(directory_url), Some(domain)) => {
+                if tls.is_none() {
+                    return Err(AppError::ConfigLoadError(
+                        "ACME renewal requires TLS_CERT_PATH and TLS_KEY_PATH".to_string(),
+                    ));
+                }
+                let account_credentials = lookup("ACME_ACCOUNT_CREDENTIALS")
+                    .ok()
+                    .filter(|s| !s.is_empty())
+                    .ok_or(AppError::MissingEnvVar("ACME_ACCOUNT_CREDENTIALS"))?;
+                check_account_credentials(&account_credentials, &directory_url)?;
+                Some(AcmeConfig {
+                    directory_url,
+                    domain,
+                    account_credentials: SecretString::from(account_credentials),
+                    root_ca_path: lookup("ACME_ROOT_CA_PATH")
+                        .ok()
+                        .filter(|s| !s.is_empty())
+                        .map(PathBuf::from),
+                })
+            }
+            (None, None) => None,
+            _ => {
+                return Err(AppError::ConfigLoadError(
+                    "ACME_DIRECTORY_URL and ACME_DOMAIN must both be set, or both unset"
+                        .to_string(),
+                ));
+            }
+        };
+
         let server_name = lookup("SERVER_NAME").ok().filter(|s| !s.is_empty());
 
         let eks_key = lookup("EKS_KEY")
@@ -122,6 +188,7 @@ impl Config {
             id_derivation_key: SecretString::from(id_derivation_key),
             master_encryption_key: SecretString::from(master_encryption_key),
             tls,
+            acme,
             server_name,
             eks_key,
             disable_auth_service,
@@ -135,6 +202,7 @@ impl Config {
             id_derivation_key: SecretString::from("test-secret-123"),
             master_encryption_key: SecretString::from("test-encryption-secret-123"),
             tls: None,
+            acme: None,
             server_name: None,
             eks_key: None,
             disable_auth_service: false,
@@ -271,6 +339,123 @@ mod tests {
     #[test]
     fn from_env_errors_when_only_tls_key_set() {
         let map = HashMap::from([("TLS_KEY_PATH", "/etc/tls/key.pem")]);
+        let lookup = lookup_from(&map);
+
+        let err = Config::from_env_with(lookup).expect_err("err");
+        assert!(matches!(err, AppError::ConfigLoadError(_)));
+    }
+
+    #[test]
+    fn from_env_returns_no_acme_when_unset() {
+        let map = HashMap::new();
+        let lookup = lookup_from(&map);
+
+        let config = Config::from_env_with(lookup).expect("config");
+
+        assert!(config.acme.is_none());
+    }
+
+    const TEST_ACME_CREDENTIALS: &str = concat!(
+        r#"{"id":"https://acme-staging-v02.api.letsencrypt.org/acme/acct/123","#,
+        r#""key_pkcs8":"bm90LWEtcmVhbC1rZXk","#,
+        r#""directory":"https://acme-staging-v02.api.letsencrypt.org/directory"}"#
+    );
+
+    #[test]
+    fn from_env_returns_acme_when_set_with_tls() {
+        let map = HashMap::from([
+            ("TLS_CERT_PATH", "/etc/tls/cert.pem"),
+            ("TLS_KEY_PATH", "/etc/tls/key.pem"),
+            (
+                "ACME_DIRECTORY_URL",
+                "https://acme-staging-v02.api.letsencrypt.org/directory",
+            ),
+            ("ACME_DOMAIN", "example.nl"),
+            ("ACME_ACCOUNT_CREDENTIALS", TEST_ACME_CREDENTIALS),
+        ]);
+        let lookup = lookup_from(&map);
+
+        let config = Config::from_env_with(lookup).expect("config");
+        let acme = config.acme.expect("acme present");
+
+        assert_eq!(
+            acme.directory_url,
+            "https://acme-staging-v02.api.letsencrypt.org/directory"
+        );
+        assert_eq!(acme.domain, "example.nl");
+        assert_eq!(
+            acme.account_credentials.expose_secret(),
+            TEST_ACME_CREDENTIALS
+        );
+        assert!(acme.root_ca_path.is_none());
+    }
+
+    #[test]
+    fn from_env_errors_when_acme_credentials_missing() {
+        let map = HashMap::from([
+            ("TLS_CERT_PATH", "/etc/tls/cert.pem"),
+            ("TLS_KEY_PATH", "/etc/tls/key.pem"),
+            ("ACME_DIRECTORY_URL", "https://localhost:14000/dir"),
+            ("ACME_DOMAIN", "example.nl"),
+        ]);
+        let lookup = lookup_from(&map);
+
+        let err = Config::from_env_with(lookup).expect_err("err");
+        assert_eq!(
+            err.to_string(),
+            AppError::MissingEnvVar("ACME_ACCOUNT_CREDENTIALS").to_string()
+        );
+    }
+
+    #[test]
+    fn from_env_errors_when_acme_credentials_are_not_json() {
+        let map = HashMap::from([
+            ("TLS_CERT_PATH", "/etc/tls/cert.pem"),
+            ("TLS_KEY_PATH", "/etc/tls/key.pem"),
+            ("ACME_DIRECTORY_URL", "https://localhost:14000/dir"),
+            ("ACME_DOMAIN", "example.nl"),
+            ("ACME_ACCOUNT_CREDENTIALS", "not json"),
+        ]);
+        let lookup = lookup_from(&map);
+
+        let err = Config::from_env_with(lookup).expect_err("err");
+        assert!(matches!(err, AppError::ConfigLoadError(_)));
+    }
+
+    #[test]
+    fn from_env_errors_when_acme_credentials_are_for_another_directory() {
+        let map = HashMap::from([
+            ("TLS_CERT_PATH", "/etc/tls/cert.pem"),
+            ("TLS_KEY_PATH", "/etc/tls/key.pem"),
+            ("ACME_DIRECTORY_URL", "https://localhost:14000/dir"),
+            ("ACME_DOMAIN", "example.nl"),
+            ("ACME_ACCOUNT_CREDENTIALS", TEST_ACME_CREDENTIALS),
+        ]);
+        let lookup = lookup_from(&map);
+
+        let err = Config::from_env_with(lookup).expect_err("err");
+        assert!(matches!(err, AppError::ConfigLoadError(_)));
+    }
+
+    #[test]
+    fn from_env_errors_when_only_acme_directory_set() {
+        let map = HashMap::from([
+            ("TLS_CERT_PATH", "/etc/tls/cert.pem"),
+            ("TLS_KEY_PATH", "/etc/tls/key.pem"),
+            ("ACME_DIRECTORY_URL", "https://localhost:14000/dir"),
+        ]);
+        let lookup = lookup_from(&map);
+
+        let err = Config::from_env_with(lookup).expect_err("err");
+        assert!(matches!(err, AppError::ConfigLoadError(_)));
+    }
+
+    #[test]
+    fn from_env_errors_when_acme_set_without_tls() {
+        let map = HashMap::from([
+            ("ACME_DIRECTORY_URL", "https://localhost:14000/dir"),
+            ("ACME_DOMAIN", "example.nl"),
+        ]);
         let lookup = lookup_from(&map);
 
         let err = Config::from_env_with(lookup).expect_err("err");

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -16,6 +16,8 @@ pub mod logging;
 pub mod server;
 pub mod translate;
 
+#[cfg(feature = "acme")]
+pub use config::AcmeConfig;
 pub use config::Config;
 #[cfg(feature = "tls")]
 pub use config::TlsConfig;

--- a/src/core/server.rs
+++ b/src/core/server.rs
@@ -14,7 +14,8 @@ use crate::{AppError, Config};
 pub async fn serve(router: Router, listener: TcpListener, config: &Config) -> Result<(), AppError> {
     #[cfg(feature = "tls")]
     if let Some(tls_config) = config.tls.as_ref() {
-        return tls::serve(router, listener, tls_config).await;
+        let rustls_config = build_rustls_config(tls_config).await?;
+        return serve_tls(router, listener, rustls_config).await;
     }
 
     #[cfg(not(feature = "tls"))]
@@ -31,6 +32,11 @@ pub async fn serve(router: Router, listener: TcpListener, config: &Config) -> Re
 
     Ok(())
 }
+
+#[cfg(feature = "acme")]
+pub(crate) use tls::server_config_from_pem;
+#[cfg(feature = "tls")]
+pub use tls::{build_rustls_config, serve_tls};
 
 #[cfg(feature = "tls")]
 mod tls {
@@ -53,15 +59,21 @@ mod tls {
 
     use crate::{AppError, TlsConfig};
 
-    pub async fn serve(
+    /// Rustls listener config from the configured cert/key files; the ACME
+    /// renewer hot-reloads renewed certificates through a clone.
+    pub async fn build_rustls_config(tls: &TlsConfig) -> Result<RustlsConfig, AppError> {
+        Ok(RustlsConfig::from_config(Arc::new(
+            build_server_config(tls).await?,
+        )))
+    }
+
+    /// Serve HTTPS with a pre-built [`RustlsConfig`] (HSTS + graceful shutdown).
+    pub async fn serve_tls(
         router: Router,
         listener: TcpListener,
-        tls: &TlsConfig,
+        config: RustlsConfig,
     ) -> Result<(), AppError> {
         let addr = listener.local_addr().map_err(AppError::ServerError)?;
-
-        let server_config = build_server_config(tls).await?;
-        let config = RustlsConfig::from_config(Arc::new(server_config));
 
         // HSTS: served only over TLS, so the header is meaningful here.
         // 1 year + includeSubDomains matches NCSC HTTPS guidance; preload is
@@ -88,9 +100,6 @@ mod tls {
         Ok(())
     }
 
-    /// Builds a rustls `ServerConfig` aligned with NCSC TLS 2025-05:
-    /// TLS 1.3 only ("Goed"), AEAD cipher suites, post-quantum hybrid key
-    /// exchange (X25519MLKEM768) preferred.
     async fn build_server_config(tls: &TlsConfig) -> Result<ServerConfig, AppError> {
         let cert_bytes = tokio::fs::read(&tls.cert_path)
             .await
@@ -99,10 +108,20 @@ mod tls {
             .await
             .map_err(AppError::ServerError)?;
 
-        let cert_chain: Vec<CertificateDer<'static>> = CertificateDer::pem_slice_iter(&cert_bytes)
+        server_config_from_pem(&cert_bytes, &key_bytes)
+    }
+
+    /// Builds a rustls `ServerConfig` aligned with NCSC TLS 2025-05:
+    /// TLS 1.3 only ("Goed"), AEAD cipher suites, post-quantum hybrid key
+    /// exchange (X25519MLKEM768) preferred.
+    pub(crate) fn server_config_from_pem(
+        cert_bytes: &[u8],
+        key_bytes: &[u8],
+    ) -> Result<ServerConfig, AppError> {
+        let cert_chain: Vec<CertificateDer<'static>> = CertificateDer::pem_slice_iter(cert_bytes)
             .collect::<Result<_, _>>()
             .map_err(|e| AppError::ConfigLoadError(format!("invalid TLS cert PEM: {e}")))?;
-        let key = PrivateKeyDer::from_pem_slice(&key_bytes)
+        let key = PrivateKeyDer::from_pem_slice(key_bytes)
             .map_err(|e| AppError::ConfigLoadError(format!("invalid TLS key PEM: {e}")))?;
 
         let mut provider = aws_lc_rs::default_provider();
@@ -197,6 +216,17 @@ mod tests {
         let mut config = Config::new_test();
         config.tls = Some(tls);
         config
+    }
+
+    #[test]
+    fn server_config_from_pem_accepts_fixture_and_rejects_garbage() {
+        let tls = fixture_tls();
+        let cert = std::fs::read(&tls.cert_path).unwrap();
+        let key = std::fs::read(&tls.key_path).unwrap();
+
+        super::tls::server_config_from_pem(&cert, &key).expect("fixture cert/key");
+        assert!(super::tls::server_config_from_pem(b"garbage", &key).is_err());
+        assert!(super::tls::server_config_from_pem(&cert, b"garbage").is_err());
     }
 
     #[tokio::test]

--- a/src/error/app_error.rs
+++ b/src/error/app_error.rs
@@ -47,6 +47,9 @@ pub enum AppError {
 
     AuthError(auth_service::error::AuthError),
 
+    #[cfg(feature = "acme")]
+    AcmeError(instant_acme::Error),
+
     NoStorageConfigured,
     IntegrityViolation,
 
@@ -97,6 +100,8 @@ impl Display for AppError {
             AppError::EventDecodeError(err) => write!(f, "Event decode error: {err}"),
             AppError::EmlError(err) => write!(f, "EML error: {err}"),
             AppError::AuthError(err) => write!(f, "Authentication error: {err}"),
+            #[cfg(feature = "acme")]
+            AppError::AcmeError(err) => write!(f, "ACME error: {err}"),
         }
     }
 }
@@ -248,6 +253,13 @@ impl From<auth_service::error::AuthError> for AppError {
         AppError::AuthError(err)
     }
 }
+
+#[cfg(feature = "acme")]
+impl From<instant_acme::Error> for AppError {
+    fn from(err: instant_acme::Error) -> Self {
+        AppError::AcmeError(err)
+    }
+}
 #[cfg(test)]
 mod tests {
     use crate::AppError;
@@ -298,5 +310,14 @@ mod tests {
         // Non-database errors are never infrastructure failures.
         assert!(!AppError::Unauthorised.is_infrastructure_failure());
         assert!(!AppError::GenericNotFound.is_infrastructure_failure());
+    }
+
+    #[cfg(feature = "acme")]
+    #[test]
+    fn converts_and_displays_acme_errors() {
+        let err = AppError::from(instant_acme::Error::Str("no http-01 challenge"));
+        assert!(err.to_string().starts_with("ACME error:"));
+        assert!(err.to_string().contains("no http-01 challenge"));
+        assert!(!err.is_infrastructure_failure());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,8 @@
 //! This layout keeps domain-specific routing and UI close to each other while
 //! sharing generic infrastructure via `core`, `auth`, `state`, and `store`.
 
+#[cfg(feature = "acme")]
+mod acme;
 mod auth;
 mod core;
 mod crypto;
@@ -86,14 +88,23 @@ pub mod router;
 #[cfg(feature = "fixtures")]
 mod fixtures;
 
-// The crate's public API is exactly what the `eks` binary needs; everything
+// The crate's public API is exactly what the binaries need; everything
 // else is re-exported `pub(crate)` so the flat `crate::X` import style keeps
 // working internally without growing the external interface.
+#[cfg(feature = "acme")]
+pub use acme::{
+    bootstrap_certificate, create_acme_account, parse_acme_account_credentials, run_acme_renewer,
+};
 pub use auth::session_store::run_session_sweeper;
 pub use core::{Config, logging, server};
 pub use error::AppError;
 pub use state::AppState;
 pub use store::run_db_prober;
+
+#[cfg(feature = "acme")]
+pub(crate) use acme::AcmeStore;
+#[cfg(feature = "acme")]
+pub(crate) use core::AcmeConfig;
 
 pub(crate) use middleware::{
     csb_store_middleware, db_gate_middleware, eks_key_middleware, health_router, lb_health_router,

--- a/src/pg/common/pages/maintenance.html
+++ b/src/pg/common/pages/maintenance.html
@@ -5,7 +5,7 @@
     <div class="container auth-container">
       <h2>{{ "common.maintenance.title"|trans }}</h2>
       <p>{{ "common.maintenance.message"|trans }}</p>
-      <p>
+      <p class="mt-lg">
         <a href="{{ retry_path }}" class="button">{{ "common.maintenance.retry"|trans }}</a>
       </p>
     </div>

--- a/src/pg/error_response.rs
+++ b/src/pg/error_response.rs
@@ -201,6 +201,8 @@ impl ErrorResponse {
             ),
             #[cfg(feature = "database")]
             AppError::DatabaseError(_) => internal(),
+            #[cfg(feature = "acme")]
+            AppError::AcmeError(_) => internal(),
             AppError::InternalServerError
             | AppError::NoStorageConfigured
             | AppError::IntegrityViolation

--- a/src/pg/error_response_tests.rs
+++ b/src/pg/error_response_tests.rs
@@ -59,6 +59,27 @@ async fn database_error_maps_to_internal_server_error() {
     assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }
 
+#[cfg(feature = "acme")]
+#[tokio::test]
+async fn acme_error_maps_to_internal_server_error() {
+    let state = AppState::new_for_tests().await;
+    let store = crate::PgStore::new_for_test();
+    let app = Router::new()
+        .route(
+            "/",
+            get(|| async { AppError::AcmeError(instant_acme::Error::Str("boom")) }),
+        )
+        .layer(middleware::from_fn_with_state(state, render_error_pages));
+    let mut request = Request::builder().uri("/").body(Body::empty()).unwrap();
+    let mut session = crate::Session::new_test_with_locale(Locale::En);
+    session.set_stream_id(crate::StreamId::new());
+    request.extensions_mut().insert(session);
+    request.extensions_mut().insert(store);
+    let response = app.oneshot(request).await.expect("response");
+
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
 fn get_multipart_error_request() -> Request<Body> {
     let body = "--boundary\r\n\
             Content-Disposition: form-data; name=\"fiel";

--- a/src/router.rs
+++ b/src/router.rs
@@ -101,7 +101,14 @@ pub fn create(state: AppState) -> Router<AppState> {
 
     // The load balancer only checks that this process is up, and holds no
     // `x-eks-key`: its probe is merged last so it sits outside that gate.
-    router.merge(lb_health_router())
+    let router = router.merge(lb_health_router());
+
+    // The CA's http-01 validators hold no `x-eks-key` either: merged outside
+    // that gate the same way.
+    #[cfg(feature = "acme")]
+    let router = router.merge(crate::acme::acme_challenge_router());
+
+    router
 }
 
 /// Global fetch-metadata CSRF protection, backstopping the session
@@ -371,6 +378,39 @@ mod tests {
             let body = response_body_string(response).await;
             assert!(body.contains(expected), "{uri} body: {body}");
         }
+    }
+
+    /// The challenge route must answer without an `x-eks-key` even when the
+    /// gate is configured.
+    #[cfg(feature = "acme")]
+    #[tokio::test]
+    async fn acme_challenge_answers_without_eks_key() {
+        let mut config = crate::Config::new_test();
+        config.eks_key = Some(secrecy::SecretString::from("s3cret"));
+        let state = AppState::new_for_tests_with_config(config).await;
+        state
+            .acme_store
+            .put_challenge("tok", "tok.thumbprint")
+            .await
+            .unwrap();
+        let app: Router = create(state.clone()).with_state(state.clone());
+
+        let request = Request::builder()
+            .uri("/.well-known/acme-challenge/tok")
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response_body_string(response).await, "tok.thumbprint");
+
+        let request = Request::builder()
+            .uri("/.well-known/acme-challenge/unknown")
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(request).await.expect("response");
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 
     /// The eks-key gate guards robots.txt and security.txt like every other

--- a/src/state.rs
+++ b/src/state.rs
@@ -31,6 +31,9 @@ pub struct AppState {
     /// (eID §9.7), backed by the configured storage so they survive restarts
     /// and are shared across instances.
     pub pending_requests: PendingRequestStore,
+    /// ACME challenge tokens, shared across instances.
+    #[cfg(feature = "acme")]
+    pub acme_store: crate::AcmeStore,
     pub id_deriver: IdDeriver,
     pub auth_service_state: AuthServiceState,
     pub db_health: DbHealth,
@@ -80,6 +83,9 @@ impl AppState {
             AuthServiceState::new_from_env().await?
         };
 
+        #[cfg(feature = "acme")]
+        let acme_store = crate::AcmeStore::from_storage_url(config.storage_url.expose_secret())?;
+
         Ok(Self {
             config: Box::leak(Box::new(config)),
             store_registry,
@@ -87,6 +93,8 @@ impl AppState {
             csb_main_store_registry,
             sessions,
             pending_requests,
+            #[cfg(feature = "acme")]
+            acme_store,
             id_deriver,
             auth_service_state,
             db_health: DbHealth::default(),
@@ -178,6 +186,10 @@ impl AppState {
         let csb_main_store_registry =
             StoreRegistry::with_persistence(store_registry.persistence().clone(), master);
 
+        #[cfg(feature = "acme")]
+        let acme_store = crate::AcmeStore::from_storage_url(config.storage_url.expose_secret())
+            .expect("test AcmeStore must initialize");
+
         Self {
             store_registry,
             csb_store_registry,
@@ -185,6 +197,8 @@ impl AppState {
             config: Box::leak(Box::new(config)),
             sessions,
             pending_requests,
+            #[cfg(feature = "acme")]
+            acme_store,
             id_deriver,
             auth_service_state,
             db_health: DbHealth::default(),


### PR DESCRIPTION
Closes #1022

Our backend applications sit behind a TCP load balancer and terminate TLS connections coming from the CDN themselves. This requires a valid TLS certificate. Since these have an increasingly short validity period we must automate the renewal process. Using an existing tool is not straight forward - each of our backend applications we run in parallel might receive the ACME challenge request. Therefore we need a mechanism to allow all backend servers to serve the challenge responses. 

This PR adds the ACME request / renew mechanism using the `instant-acme` crate by our friend DJO. A small database table is used to synchronize challenges across all backend servers.

# [DOD](/docs/definition-of-done.md) checklist

## For PR maintainer

Perform these checks before marking the PR as ready:

- [x] I have linked the PR to at least one issue.
- [x] I assigned the PR to myself.
- [x] I have added a description how to test this PR (see "Review Instructions").
- [x] I have added documentation where necessary.

## For reviewer

- I have read all code changes.
- I have audited the code quality.
- I have tested the changes either or both:
  - locally
  - on the test environment (preferred)
- I have validated that the PR is functionally correct (use-cases, figma designs, etc.)

### Review instructions

Do not try to request random certificates using the acme feature - ask Marlon to demo the feature in our preview environment.
