### PR TITLE
[#842] Validate addresses on CSV import

### DIFF
--- a/src/pg/candidate_lists/importer.rs
+++ b/src/pg/candidate_lists/importer.rs
@@ -113,13 +113,25 @@ fn validate_record(
     candidate_number: usize,
     locale: Locale,
 ) -> Result<Person, ImportCandidateListError> {
-    record.validate_create().map_err(|error| {
-        ImportCandidateListError::Messages(field_error_messages(
-            candidate_number,
-            error.errors(),
-            locale,
-        ))
-    })
+    record
+        .validate_create()
+        .map(refresh_bag_checks)
+        .map_err(|error| {
+            ImportCandidateListError::Messages(field_error_messages(
+                candidate_number,
+                error.errors(),
+                locale,
+            ))
+        })
+}
+
+/// Imported addresses bypass the address forms, so refresh their BAG flags here.
+fn refresh_bag_checks(mut person: Person) -> Person {
+    person.address.update_is_known_in_bag();
+    if let Some(representative) = &mut person.representative {
+        representative.address.update_is_known_in_bag();
+    }
+    person
 }
 
 fn upsert_person(
@@ -523,6 +535,78 @@ mod tests {
             store.get_candidate_list(list_id)?.candidates.len(),
             MAX_CANDIDATES
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn import_runs_bag_check_on_correspondence_address() -> Result<(), AppError> {
+        let store = PgStore::new_for_test();
+        let list_id = CandidateListId::new();
+        let mut list = sample_candidate_list(list_id);
+
+        list.create(&store).await?;
+
+        let csv = format!(
+            "{}\r\n{}{}",
+            csv_headers(),
+            "H.A.H.A.,Henk,,Jansen,Amsterdam,NL,kandidaat heeft geen BSN,01-02-1990,v,1012JS,1,,Dam,Amsterdam,,,,,,,,,\r\n",
+            "H.A.H.A.,Piet,,Pietersen,Juinen,NL,kandidaat heeft geen BSN,01-02-1990,v,1234AB,10,A,Stationsstraat,Juinen,,,,,,,,,\r\n"
+        );
+
+        import_candidate_list_csv(
+            &mut list,
+            &store,
+            csv.as_bytes(),
+            Locale::En,
+            "test.csv".to_string(),
+            0,
+        )
+        .await
+        .expect("import should succeed");
+
+        let candidates = store.get_candidate_list(list_id)?.candidates;
+        let known = store.get_person(candidates[0])?;
+        let unknown = store.get_person(candidates[1])?;
+
+        assert_eq!(known.address.known_in_bag, Some(true));
+        assert_eq!(unknown.address.known_in_bag, Some(false));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn import_runs_bag_check_on_representative_address() -> Result<(), AppError> {
+        let store = PgStore::new_for_test();
+        let list_id = CandidateListId::new();
+        let mut list = sample_candidate_list(list_id);
+
+        list.create(&store).await?;
+
+        let csv = format!(
+            "{}\r\n{}",
+            csv_headers(),
+            "H.A.H.A.,Henk,,Jansen,Antwerp,BE,kandidaat heeft geen BSN,01-02-1990,v,,,,,,P.,Pietje,,Puk,1012JS,1,,Dam,Amsterdam\r\n"
+        );
+
+        import_candidate_list_csv(
+            &mut list,
+            &store,
+            csv.as_bytes(),
+            Locale::En,
+            "test.csv".to_string(),
+            0,
+        )
+        .await
+        .expect("import should succeed");
+
+        let candidate_id = store.get_candidate_list(list_id)?.candidates[0];
+        let representative = store
+            .get_person(candidate_id)?
+            .representative
+            .expect("representative should be present");
+
+        assert_eq!(representative.address.known_in_bag, Some(true));
 
         Ok(())
     }

--- a/src/structs/candidate_lists/candidate_record.rs
+++ b/src/structs/candidate_lists/candidate_record.rs
@@ -116,7 +116,7 @@ impl From<CandidateRecordCsv> for CandidateRecord {
                 date_of_birth: csv.geboortedatum,
                 bsn: bsn_from_csv(&csv.bsn),
                 place_of_residence: csv.woonplaats,
-                country: csv.landcode,
+                country: country_from_csv(csv.landcode),
             },
             address: DutchAddressForm {
                 locality: csv.correspondentie_plaats,
@@ -203,6 +203,15 @@ impl From<Person> for CandidateRecordCsv {
 impl From<Person> for CandidateRecord {
     fn from(person: Person) -> Self {
         Self::from(CandidateRecordCsv::from(person))
+    }
+}
+
+/// An empty `landcode` column defaults to NL, matching the personal details form.
+fn country_from_csv(landcode: String) -> String {
+    if landcode.trim().is_empty() {
+        "NL".to_string()
+    } else {
+        landcode
     }
 }
 
@@ -296,6 +305,28 @@ mod tests {
             Some("Rotterdam".to_string())
         );
         assert_eq!(person.representative, None);
+    }
+
+    #[test]
+    fn empty_landcode_defaults_to_nl() {
+        let record = CandidateRecord::from(CandidateRecordCsv {
+            voorletters: "J.".to_string(),
+            roepnaam: "Jan".to_string(),
+            achternaam: "Berg".to_string(),
+            woonplaats: "Amsterdam".to_string(),
+            landcode: "  ".to_string(),
+            bsn: NO_BSN.to_string(),
+            geboortedatum: "20-10-2000".to_string(),
+            geslacht: "m".to_string(),
+            ..Default::default()
+        });
+
+        let person = record.validate_create().unwrap();
+
+        assert_eq!(
+            person.personal_data.country.as_ref().map(|v| v.to_string()),
+            Some("NL".to_string())
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #842

# [DOD](/docs/definition-of-done.md) checklist

## For PR maintainer

Perform these checks before marking the PR as ready:

- [x] I have linked the PR to at least one issue.
- [x] I assigned the PR to myself.
- [x] I have added a description how to test this PR (see "Review Instructions").
- [x] I have added documentation where necessary.

## For reviewer

- I have read all code changes.
- I have audited the code quality.
- I have tested the changes either or both:
  - locally
  - on the test environment (preferred)
- I have validated that the PR is functionally correct (use-cases, figma designs, etc.)

### Review instructions

- Import a CSV with incorrect addresses and see the address warning in the interface.
- Import a CSV with a missing country code -> that should default to NL
