### PR TITLE
[#1035] Fix redirects in omission overlays 

### DIFF
--- a/src/csb/examination/pages/omission/mod.rs
+++ b/src/csb/examination/pages/omission/mod.rs
@@ -266,9 +266,9 @@ pub async fn add_omission_submit(
     }
 }
 
-/// Remove a single omission and return to the overview it was removed from (the
-/// `redirect_to` carried by the button, falling back to the overview derived
-/// from the omission's category).
+/// Remove a single omission and return to the overview it was listed on,
+/// keeping the dialog's `redirect_to` (where the close button returns to) and
+/// the overlay marker across the redirect.
 pub async fn delete_omission(
     path: CsbDeleteOmissionPath,
     _context: CsbContext,
@@ -282,16 +282,14 @@ pub async fn delete_omission(
     let omission = store.get_omission(omission_id)?;
     let overview = overview_url_for(&omission.category, stream_id);
     omission.delete(&store).await?;
-    if let Some(redirect_url) = query.redirect_url() {
-        Ok(Redirect::to(
-            &overview
-                .with_query_params(QueryParamState::redirect_to(redirect_url.to_owned()))
-                .to_string(),
-        )
-        .into_response())
-    } else {
-        Ok(Redirect::to(&overview.to_string()).into_response())
-    }
+    Ok(Redirect::to(
+        &overview
+            .with_query_params(QueryParamState::overlay(
+                query.redirect_url().map(str::to_owned),
+            ))
+            .to_string(),
+    )
+    .into_response())
 }
 
 #[cfg(test)]
@@ -645,7 +643,8 @@ mod tests {
         assert_eq!(response.status(), StatusCode::SEE_OTHER);
         // The omission is gone...
         assert!(store.get_candidate_list_omissions(list).unwrap().is_empty());
-        // ...and without an explicit redirect we fall back to the political group overview
+        // ...and we return to the overview it was listed on, without replaying
+        // the overlay open animation
         let location = response
             .headers()
             .get("Location")
@@ -653,8 +652,9 @@ mod tests {
             .to_str()
             .unwrap();
         assert!(location.contains(&format!(
-            "/csb/examination/{stream_id}/omission/political-group/{stream_id}/overview"
+            "/csb/examination/{stream_id}/omission/candidate-list/{list}/overview"
         )));
+        assert!(location.contains("overlay=true"));
     }
 
     #[tokio::test]
@@ -693,6 +693,7 @@ mod tests {
             .to_str()
             .unwrap();
         assert!(location.contains("redirect_to=%2Fback%2Fhere"));
+        assert!(location.contains("overlay=true"));
     }
 
     #[tokio::test]

--- a/src/csb/examination/pages/omission/mod.rs
+++ b/src/csb/examination/pages/omission/mod.rs
@@ -1,7 +1,8 @@
 use axum::{
     extract::Query,
-    response::{IntoResponse, Response},
+    response::{IntoResponse, Redirect, Response},
 };
+use axum_extra::routing::TypedPath;
 use uuid::Uuid;
 
 use crate::{
@@ -27,7 +28,7 @@ use crate::{
 mod urls;
 mod views;
 
-use urls::{add_url, overview_url, overview_url_for, return_path};
+use urls::{overview_url_for, return_path};
 use views::{CsbAddOmissionTemplate, CsbOmissionOverviewTemplate, omission_views, preset_views};
 
 /// The entity an omission dialog operates on, together with the list context
@@ -89,8 +90,7 @@ impl OmissionTarget {
                 overlay: Overlay::new(query),
                 close_action: return_path(self, &political_group),
                 presets: preset_views(self, store),
-                add_tab_url: add_url(self),
-                overview_tab_url: overview_url(self),
+                omission_target: self.to_owned(),
                 available_districts,
                 available_candidate_lists,
                 title_suffix: self.generate_title_suffix(store, context.session.locale)?,
@@ -159,18 +159,16 @@ pub async fn overview(
     Query(query): Query<QueryParamState>,
     Query(list_query): Query<OmissionListQuery>,
 ) -> Result<Response, AppError> {
-    let target = OmissionTarget::from_overview_path(path, list_query);
+    let omission_target = OmissionTarget::from_overview_path(path, list_query);
     let political_group = CsbPoliticalGroup::new_from_csb_store(&store);
-    let overview_tab_url = overview_url(&target);
 
     Ok(HtmlTemplate(
         CsbOmissionOverviewTemplate {
             overlay: Overlay::new(&query),
-            close_action: return_path(&target, &political_group),
-            omissions: omission_views(&target, &store, &overview_tab_url)?,
-            add_tab_url: add_url(&target),
-            overview_tab_url,
-            title_suffix: target.generate_title_suffix(&store, context.session.locale)?,
+            close_action: return_path(&omission_target, &political_group),
+            omissions: omission_views(&omission_target, &store)?,
+            title_suffix: omission_target.generate_title_suffix(&store, context.session.locale)?,
+            omission_target,
         },
         context,
     )
@@ -282,10 +280,18 @@ pub async fn delete_omission(
         omission_id,
     } = path;
     let omission = store.get_omission(omission_id)?;
-    let fallback = overview_url_for(&omission.category, stream_id);
+    let overview = overview_url_for(&omission.category, stream_id);
     omission.delete(&store).await?;
-
-    Ok(query.redirect_or(fallback))
+    if let Some(redirect_url) = query.redirect_url() {
+        Ok(Redirect::to(
+            &overview
+                .with_query_params(QueryParamState::redirect_to(redirect_url.to_owned()))
+                .to_string(),
+        )
+        .into_response())
+    } else {
+        Ok(Redirect::to(&overview.to_string()).into_response())
+    }
 }
 
 #[cfg(test)]
@@ -652,7 +658,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delete_omission_honours_the_redirect_to() {
+    async fn delete_omission_preserves_the_redirect_to() {
         let store = CsbStore::new_for_test();
         let stream_id = store.stream_id;
 
@@ -686,7 +692,7 @@ mod tests {
             .unwrap()
             .to_str()
             .unwrap();
-        assert!(location.starts_with("/back/here"));
+        assert!(location.contains("redirect_to=%2Fback%2Fhere"));
     }
 
     #[tokio::test]

--- a/src/csb/examination/pages/omission/urls.rs
+++ b/src/csb/examination/pages/omission/urls.rs
@@ -35,17 +35,16 @@ pub(super) fn return_path(target: &OmissionTarget, political_group: &CsbPolitica
     }
 }
 
-/// Query string for links within the dialog: the list context plus the
-/// `overlay=true` marker that suppresses the overlay open animation.
+/// Query string for links within the dialog: the list context. The overlay
+/// marker and `redirect_to` are appended by `Overlay::forward` where the
+/// templates render these links.
 #[derive(serde::Serialize)]
 struct DialogQuery {
     #[serde(skip_serializing_if = "Option::is_none")]
     list: Option<CandidateListId>,
 }
 
-/// Append the list context and the overlay marker as a query string. These
-/// URLs are only linked from within the already-open dialog (the sidebar tabs
-/// and the remove buttons), so the target should not replay the animation.
+/// Append the list context as a query string.
 fn with_context(path: impl TypedPath, list: Option<CandidateListId>) -> impl TypedPath {
     path.with_query_params(DialogQuery { list })
 }
@@ -77,8 +76,9 @@ impl OmissionTarget {
         )
     }
 }
-/// Fallback overview URL to return to after removing an omission, derived from
-/// its category. Used only when the request carries no explicit `redirect_to`.
+
+/// The overview URL to return to after removing an omission, derived from its
+/// category so the redirect lands on the overview the omission was listed on.
 pub(super) fn overview_url_for(category: &OmissionCategory, stream_id: StreamId) -> impl TypedPath {
     let target = match category {
         OmissionCategory::Candidate { person, lists } => OmissionTarget {
@@ -86,6 +86,18 @@ pub(super) fn overview_url_for(category: &OmissionCategory, stream_id: StreamId)
             omission_type: OmissionType::Candidate,
             reference: (*person).into(),
             list: lists.first().copied(),
+        },
+        OmissionCategory::CandidateList(lists) if !lists.is_empty() => OmissionTarget {
+            stream_id,
+            omission_type: OmissionType::CandidateList,
+            reference: lists[0].into(),
+            list: None,
+        },
+        OmissionCategory::DeclarationsOfSupport(_) => OmissionTarget {
+            stream_id,
+            omission_type: OmissionType::DeclarationsOfSupport,
+            reference: stream_id.into(),
+            list: None,
         },
         _ => OmissionTarget {
             stream_id,

--- a/src/csb/examination/pages/omission/urls.rs
+++ b/src/csb/examination/pages/omission/urls.rs
@@ -41,49 +41,45 @@ pub(super) fn return_path(target: &OmissionTarget, political_group: &CsbPolitica
 struct DialogQuery {
     #[serde(skip_serializing_if = "Option::is_none")]
     list: Option<CandidateListId>,
-    overlay: bool,
 }
 
 /// Append the list context and the overlay marker as a query string. These
 /// URLs are only linked from within the already-open dialog (the sidebar tabs
 /// and the remove buttons), so the target should not replay the animation.
-fn with_context(path: impl TypedPath, list: Option<CandidateListId>) -> String {
-    path.with_query_params(DialogQuery {
-        list,
-        overlay: true,
-    })
-    .to_string()
+fn with_context(path: impl TypedPath, list: Option<CandidateListId>) -> impl TypedPath {
+    path.with_query_params(DialogQuery { list })
 }
 
-/// The URL of the add-omission form for this entity, keeping the list context
-/// (the sidebar links here from the overview page).
-pub(super) fn add_url(target: &OmissionTarget) -> String {
-    with_context(
-        CsbAddOmissionPath {
-            stream_id: target.stream_id,
-            omission_type: target.omission_type,
-            reference: target.reference,
-        },
-        target.list,
-    )
-}
+impl OmissionTarget {
+    /// The URL of the add-omission form for this entity, keeping the list context
+    /// (the sidebar links here from the overview page).
+    pub(super) fn add_url(&self) -> impl TypedPath {
+        with_context(
+            CsbAddOmissionPath {
+                stream_id: self.stream_id,
+                omission_type: self.omission_type,
+                reference: self.reference,
+            },
+            self.list,
+        )
+    }
 
-/// The URL of the overview page for this entity, keeping the list context
-/// (the sidebar links here from the add form).
-pub(super) fn overview_url(target: &OmissionTarget) -> String {
-    with_context(
-        CsbOmissionOverviewPath {
-            stream_id: target.stream_id,
-            omission_type: target.omission_type,
-            reference: target.reference,
-        },
-        target.list,
-    )
+    /// The URL of the overview page for this entity, keeping the list context
+    /// (the sidebar links here from the add form).
+    pub(super) fn overview_url(&self) -> impl TypedPath + use<> {
+        with_context(
+            CsbOmissionOverviewPath {
+                stream_id: self.stream_id,
+                omission_type: self.omission_type,
+                reference: self.reference,
+            },
+            self.list,
+        )
+    }
 }
-
 /// Fallback overview URL to return to after removing an omission, derived from
 /// its category. Used only when the request carries no explicit `redirect_to`.
-pub(super) fn overview_url_for(category: &OmissionCategory, stream_id: StreamId) -> String {
+pub(super) fn overview_url_for(category: &OmissionCategory, stream_id: StreamId) -> impl TypedPath {
     let target = match category {
         OmissionCategory::Candidate { person, lists } => OmissionTarget {
             stream_id,
@@ -98,5 +94,5 @@ pub(super) fn overview_url_for(category: &OmissionCategory, stream_id: StreamId)
             list: None,
         },
     };
-    overview_url(&target)
+    target.overview_url()
 }

--- a/src/csb/examination/pages/omission/views.rs
+++ b/src/csb/examination/pages/omission/views.rs
@@ -2,7 +2,7 @@ use askama::Template;
 use axum_extra::routing::TypedPath;
 
 use crate::{
-    AppError, Context, CsbStore, ElectoralDistrict, Locale, Overlay, QueryParamState,
+    AppError, Context, CsbStore, ElectoralDistrict, Locale, Overlay,
     candidate_lists::CandidateListId,
     csb::{
         WithCorrections,
@@ -33,9 +33,8 @@ pub(super) struct CsbAddOmissionTemplate {
     pub(super) close_action: String,
     /// Quick-fill suggestions for this type, with placeholders interpolated.
     pub(super) presets: Vec<PresetView>,
-    /// The dialog opened on its two tabs, for the steps sidebar.
-    pub(super) add_tab_url: String,
-    pub(super) overview_tab_url: String,
+    /// target to generate urls from, for the steps sidebar.
+    pub(super) omission_target: OmissionTarget,
     /// Districts that appear on at least one paper-corrected candidate list of
     /// this political group. The districts section is hidden when this is
     /// empty. Districts absent from all lists are shown disabled so the user
@@ -55,9 +54,8 @@ pub(super) struct CsbOmissionOverviewTemplate {
     pub(super) close_action: String,
     /// The omissions already added to this entity, each with a remove action.
     pub(super) omissions: Vec<OmissionView>,
-    /// The dialog opened on its two tabs, for the steps sidebar.
-    pub(super) add_tab_url: String,
-    pub(super) overview_tab_url: String,
+    /// target to generate urls from, for the steps sidebar.
+    pub(super) omission_target: OmissionTarget,
     pub(super) title_suffix: String,
 }
 
@@ -65,9 +63,17 @@ pub(super) struct CsbOmissionOverviewTemplate {
 /// (which returns to this same overview afterwards).
 pub(super) struct OmissionView {
     omission: Omission,
-    remove_url: String,
     /// Formatted district string for display (e.g. "1. Groningen, 2. Friesland").
     districts: String,
+}
+
+impl OmissionView {
+    fn remove_url(&self, omission_target: &OmissionTarget) -> impl TypedPath {
+        CsbDeleteOmissionPath {
+            stream_id: omission_target.stream_id,
+            omission_id: self.omission.id,
+        }
+    }
 }
 
 /// A preset shown in the dialog, with `{token}` placeholders in its description
@@ -157,7 +163,6 @@ pub(super) fn preset_views(target: &OmissionTarget, store: &CsbStore) -> Vec<Pre
 pub(super) fn omission_views(
     target: &OmissionTarget,
     store: &CsbStore,
-    overview_url: &str,
 ) -> Result<Vec<OmissionView>, AppError> {
     let omissions = match target.omission_type {
         OmissionType::PoliticalGroup => store.get_political_group_omissions(),
@@ -174,12 +179,6 @@ pub(super) fn omission_views(
             .category
             .electoral_district(store, &store.election)?;
         views.push(OmissionView {
-            remove_url: CsbDeleteOmissionPath {
-                stream_id: target.stream_id,
-                omission_id: omission.id,
-            }
-            .with_query_params(QueryParamState::redirect_to(overview_url.to_string()))
-            .to_string(),
             omission,
             districts,
         });

--- a/src/csb/examination/pages/omission/views.rs
+++ b/src/csb/examination/pages/omission/views.rs
@@ -59,8 +59,8 @@ pub(super) struct CsbOmissionOverviewTemplate {
     pub(super) title_suffix: String,
 }
 
-/// An omission in the overview tab, paired with the URL of its remove action
-/// (which returns to this same overview afterwards).
+/// An omission in the overview tab; the URL of its remove action is derived
+/// from the dialog's target via `remove_url`.
 pub(super) struct OmissionView {
     omission: Omission,
     /// Formatted district string for display (e.g. "1. Groningen, 2. Friesland").
@@ -158,8 +158,7 @@ pub(super) fn preset_views(target: &OmissionTarget, store: &CsbStore) -> Vec<Pre
 
 /// The omissions already added to the entity the dialog was opened for, shown
 /// on the overview tab. A candidate lists every omission for the person, both
-/// list-scoped and general. Each is paired with a remove action that returns to
-/// `overview_url` afterwards.
+/// list-scoped and general.
 pub(super) fn omission_views(
     target: &OmissionTarget,
     store: &CsbStore,

--- a/src/csb/examination/pages/omission_overview.html
+++ b/src/csb/examination/pages/omission_overview.html
@@ -34,7 +34,7 @@
               </div>
               <button type="submit"
                       class="button xs tertiary-destructive"
-                      formaction="{{ view.remove_url }}"
+                      formaction="{{ overlay.forward(view.remove_url(omission_target) ) }}"
                       formnovalidate>{{ "action.remove"|trans }}</button>
             </div>
           </li>

--- a/src/csb/examination/pages/omission_steps.html
+++ b/src/csb/examination/pages/omission_steps.html
@@ -1,11 +1,11 @@
 <div class="steps-nav">
   <ul>
     <li>
-      <a href="{{ add_tab_url }}"
+      <a href="{{ overlay.forward(omission_target.add_url() ) }}"
          class="{% if !is_overview %}active{% endif %}">{{ "csb.omission.form.title"|trans }}</a>
     </li>
     <li>
-      <a href="{{ overview_tab_url }}"
+      <a href="{{ overlay.forward(omission_target.overview_url() ) }}"
          class="{% if is_overview %}active{% endif %}">{{ "csb.omission.overview.title"|trans }}</a>
     </li>
   </ul>


### PR DESCRIPTION
Closes #1035

# [DOD](/docs/definition-of-done.md) checklist

## For PR maintainer

Perform these checks before marking the PR as ready:

- [x] I have linked the PR to at least one issue.
- [x] I assigned the PR to myself.
- [x] I have added a description how to test this PR (see "Review Instructions").
- [x] [For bug fixes only] I have added a regression test for the fixed bug.
  - edited the existing test for redirect after remove (`delete_omission_preserves_the_redirect_to`)
- [x] I have added documentation where necessary.

## For reviewer

- I have read all code changes.
- I have audited the code quality.
- I have tested the changes either or both:
  - locally
  - on the test environment (preferred)
- I have validated that the PR is functionally correct (use-cases, figma designs, etc.)

### Review instructions
- Add 2 omissions (e.g. for a candidate)
- Go to overview from the candidate view
- Remove 1 omission
- Click close on the dialog
  - Candidate view shows
- Go to "alle verzuimen"
- Click on the omission that is still left
- Remove it
- Close dialog
  - Alle verzuimen view shows 
