### PR TITLE
[#824] Fix line numbers being off by one in CSV import errors

### DIFF
--- a/src/core/csv.rs
+++ b/src/core/csv.rs
@@ -12,11 +12,11 @@ use crate::{AppError, Locale, OptionStringExt, trans, utils::no_cache_headers};
 
 pub enum CsvError {
     FormatError {
-        candidate_number: usize,
+        line_number: usize,
         message: csv::ErrorKind,
     },
     ParseError {
-        candidate_number: usize,
+        line_number: usize,
         field_name: String,
         message: String,
     },
@@ -32,22 +32,22 @@ impl CsvError {
     pub fn message(&self, locale: Locale) -> String {
         match self {
             CsvError::FormatError {
-                candidate_number,
+                line_number,
                 message,
             } => trans!(
                 "candidate_list.import_errors.format_error",
                 locale,
-                candidate_number,
+                line_number,
                 format_error_kind(message, locale)
             ),
             CsvError::ParseError {
-                candidate_number,
+                line_number,
                 field_name,
                 message,
             } => trans!(
                 "candidate_list.import_errors.parse_error",
                 locale,
-                candidate_number,
+                line_number,
                 translated_field_name(field_name, locale),
                 message
             ),
@@ -270,10 +270,10 @@ impl<T: DeserializeOwned> Csv<T> {
         reader_from_bytes(data)
             .deserialize::<T>()
             .enumerate()
-            .for_each(|(count, res)| match res {
+            .for_each(|(index, res)| match res {
                 Ok(record) => records.push(record),
                 Err(error) => errors.push(CsvError::FormatError {
-                    candidate_number: count + 1,
+                    line_number: index + 2,
                     message: error.into_kind(),
                 }),
             });
@@ -328,7 +328,7 @@ mod tests {
     fn formats_error_kind_messages_in_english() {
         assert_eq!(
             CsvError::FormatError {
-                candidate_number: 3,
+                line_number: 3,
                 message: csv::ErrorKind::Io(std::io::Error::other("disk failed")),
             }
             .message(Locale::En),
@@ -336,7 +336,7 @@ mod tests {
         );
         assert_eq!(
             CsvError::FormatError {
-                candidate_number: 3,
+                line_number: 3,
                 message: csv::ErrorKind::Utf8 {
                     pos: None,
                     err: utf8_error(),
@@ -347,7 +347,7 @@ mod tests {
         );
         assert_eq!(
             CsvError::FormatError {
-                candidate_number: 3,
+                line_number: 3,
                 message: csv::ErrorKind::Utf8 {
                     pos: Some(position(2, 4, 18)),
                     err: utf8_error(),
@@ -358,7 +358,7 @@ mod tests {
         );
         assert_eq!(
             CsvError::FormatError {
-                candidate_number: 3,
+                line_number: 3,
                 message: csv::ErrorKind::UnequalLengths {
                     pos: None,
                     expected_len: 4,
@@ -370,7 +370,7 @@ mod tests {
         );
         assert_eq!(
             CsvError::FormatError {
-                candidate_number: 3,
+                line_number: 3,
                 message: csv::ErrorKind::UnequalLengths {
                     pos: Some(position(2, 4, 18)),
                     expected_len: 4,
@@ -382,7 +382,7 @@ mod tests {
         );
         assert_eq!(
             CsvError::FormatError {
-                candidate_number: 3,
+                line_number: 3,
                 message: csv::ErrorKind::Seek,
             }
             .message(Locale::En),
@@ -390,7 +390,7 @@ mod tests {
         );
         assert_eq!(
             CsvError::FormatError {
-                candidate_number: 3,
+                line_number: 3,
                 message: csv::ErrorKind::Serialize("unsupported value".to_string()),
             }
             .message(Locale::En),
@@ -398,7 +398,7 @@ mod tests {
         );
         assert_eq!(
             CsvError::FormatError {
-                candidate_number: 3,
+                line_number: 3,
                 message: csv::ErrorKind::Deserialize {
                     pos: None,
                     err: deserialize_error(),
@@ -409,7 +409,7 @@ mod tests {
         );
         assert_eq!(
             CsvError::FormatError {
-                candidate_number: 3,
+                line_number: 3,
                 message: csv::ErrorKind::Deserialize {
                     pos: Some(position(1, 2, 6)),
                     err: deserialize_error(),
@@ -420,7 +420,7 @@ mod tests {
         );
         assert_eq!(
             CsvError::ParseError {
-                candidate_number: 4,
+                line_number: 4,
                 field_name: "postal_code".to_string(),
                 message: "invalid value".to_string(),
             }
@@ -433,7 +433,7 @@ mod tests {
     fn formats_error_kind_messages_in_dutch() {
         assert_eq!(
             CsvError::FormatError {
-                candidate_number: 3,
+                line_number: 3,
                 message: csv::ErrorKind::Io(std::io::Error::other("disk failed")),
             }
             .message(Locale::Nl),
@@ -441,7 +441,7 @@ mod tests {
         );
         assert_eq!(
             CsvError::FormatError {
-                candidate_number: 3,
+                line_number: 3,
                 message: csv::ErrorKind::Utf8 {
                     pos: None,
                     err: utf8_error(),
@@ -452,7 +452,7 @@ mod tests {
         );
         assert_eq!(
             CsvError::FormatError {
-                candidate_number: 3,
+                line_number: 3,
                 message: csv::ErrorKind::Utf8 {
                     pos: Some(position(2, 4, 18)),
                     err: utf8_error(),
@@ -463,7 +463,7 @@ mod tests {
         );
         assert_eq!(
             CsvError::FormatError {
-                candidate_number: 3,
+                line_number: 3,
                 message: csv::ErrorKind::UnequalLengths {
                     pos: None,
                     expected_len: 4,
@@ -475,7 +475,7 @@ mod tests {
         );
         assert_eq!(
             CsvError::FormatError {
-                candidate_number: 3,
+                line_number: 3,
                 message: csv::ErrorKind::UnequalLengths {
                     pos: Some(position(2, 4, 18)),
                     expected_len: 4,
@@ -487,7 +487,7 @@ mod tests {
         );
         assert_eq!(
             CsvError::FormatError {
-                candidate_number: 3,
+                line_number: 3,
                 message: csv::ErrorKind::Seek,
             }
             .message(Locale::Nl),
@@ -495,7 +495,7 @@ mod tests {
         );
         assert_eq!(
             CsvError::FormatError {
-                candidate_number: 3,
+                line_number: 3,
                 message: csv::ErrorKind::Serialize("unsupported value".to_string()),
             }
             .message(Locale::Nl),
@@ -503,7 +503,7 @@ mod tests {
         );
         assert_eq!(
             CsvError::FormatError {
-                candidate_number: 3,
+                line_number: 3,
                 message: csv::ErrorKind::Deserialize {
                     pos: None,
                     err: deserialize_error(),
@@ -514,7 +514,7 @@ mod tests {
         );
         assert_eq!(
             CsvError::FormatError {
-                candidate_number: 3,
+                line_number: 3,
                 message: csv::ErrorKind::Deserialize {
                     pos: Some(position(1, 2, 6)),
                     err: deserialize_error(),
@@ -525,7 +525,7 @@ mod tests {
         );
         assert_eq!(
             CsvError::ParseError {
-                candidate_number: 4,
+                line_number: 4,
                 field_name: "postal_code".to_string(),
                 message: "invalid value".to_string(),
             }
@@ -537,7 +537,7 @@ mod tests {
     #[test]
     fn display_uses_default_locale() {
         let message = CsvError::FormatError {
-            candidate_number: 1,
+            line_number: 1,
             message: csv::ErrorKind::Serialize("invalid record".to_string()),
         }
         .to_string();

--- a/src/pg/candidate_lists/importer.rs
+++ b/src/pg/candidate_lists/importer.rs
@@ -217,7 +217,7 @@ fn field_error_messages(
         .into_iter()
         .map(|(field_name, error)| {
             CsvError::ParseError {
-                candidate_number,
+                line_number: candidate_number + 1,
                 field_name,
                 message: error.message(locale),
             }
@@ -632,8 +632,8 @@ mod tests {
         match result {
             Err(ImportCandidateListError::Messages(messages)) => {
                 assert_eq!(messages.len(), 2);
-                assert!(messages.iter().any(|message| message.contains("line 1")));
                 assert!(messages.iter().any(|message| message.contains("line 2")));
+                assert!(messages.iter().any(|message| message.contains("line 3")));
             }
             other => panic!("expected validation messages, got {other:?}"),
         }

--- a/src/pg/candidate_lists/pages/import.rs
+++ b/src/pg/candidate_lists/pages/import.rs
@@ -284,7 +284,7 @@ mod tests {
 
         let body = response_body_string(response).await;
         assert!(body.contains("Import failed"));
-        assert!(body.contains("The candidate on line 1 could not be imported:"));
+        assert!(body.contains("The candidate on line 2 could not be imported:"));
         assert!(body.contains("has 2 columns, but earlier rows have 23"));
         assert_eq!(body.matches("alert alert-warning").count(), 1);
 
@@ -315,7 +315,7 @@ mod tests {
         let body = response_body_string(response).await;
         assert!(body.contains("Import failed"));
         assert_eq!(
-            body.matches("The candidate on line 1 could not be imported.")
+            body.matches("The candidate on line 2 could not be imported.")
                 .count(),
             2
         );


### PR DESCRIPTION
Closes #824

# [DOD](/docs/definition-of-done.md) checklist

## For PR maintainer

Perform these checks before marking the PR as ready:

- [x] I have linked the PR to at least one issue.
- [x] I assigned the PR to myself.
- [x] I have added a description how to test this PR (see "Review Instructions").
- [x] [For bug fixes only] I have added a regression test for the fixed bug.
  - edited existing unit tests (that were also wrong)
- [x] ~~I have added documentation where necessary.~~

## For reviewer

- I have read all code changes.
- I have audited the code quality.
- I have tested the changes either or both:
  - locally
  - on the test environment (preferred)
- I have validated that the PR is functionally correct (use-cases, figma designs, etc.)


### Review instructions
- import a CSV with errors and observe line numbers being correct
