### PR TITLE
[#1060] Use Cargo `--locked` option in correct position

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -61,7 +61,7 @@ jobs:
           rustup component add --toolchain nightly rustfmt
 
       - name: Check rustfmt
-        run: cargo --locked fmt --all -- --check
+        run: cargo fmt --all -- --check
 
   frontend:
     name: Frontend lint
@@ -133,16 +133,16 @@ jobs:
       - *setup-project
 
       - name: Check Clippy with all features
-        run: cargo --locked clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --locked --all-targets --all-features -- -D warnings
 
       - name: Check Clippy without default features
-        run: cargo --locked clippy --all-targets --no-default-features -- -D warnings
+        run: cargo clippy --locked --all-targets --no-default-features -- -D warnings
 
       - name: Run tests
-        run: cargo --locked test -- --nocapture
+        run: cargo test --locked -- --nocapture
 
       - name: Build docs
-        run: cargo doc --workspace --no-deps --all-features --document-private-items
+        run: cargo doc --locked --workspace --no-deps --all-features --document-private-items
 
       - name: Add redirect to main crate docs
         if: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
Closes #1060

Use Cargo `--locked` option in correct position: the option was not passed to Clippy, silently updating the `Cargo.lock` file if it was out of date. rustfmt does not accept a `--locked` flag at all. Fixed in Abacus in https://github.com/kiesraad/abacus/pull/3794. Also see https://github.com/rust-lang/cargo/issues/11390.