### PR TITLE
[#1043] Add ability to remove political groups from examination

### DIFF
--- a/bin/check
+++ b/bin/check
@@ -45,7 +45,13 @@ echo "==> Typescript checks"
 
 # html
 echo "==> Html checks"
-docker run --rm -v ./src:/work/templates djlint
+# fix for devs that use docker rootless
+if docker info -f '{{.SecurityOptions}}' | grep -q rootless; then
+  DOCKER_USER="0:0"
+else
+  DOCKER_USER="$(id -u):$(id -g)"
+fi
+docker run --rm -v ./src:/work/templates --user "$DOCKER_USER" djlint
 
 # generic
 ./bin/check_newline

--- a/locales/en/audit_log.yml
+++ b/locales/en/audit_log.yml
@@ -37,7 +37,7 @@ detail:
 documents:
   download: Download documents
   no_download: This version was not in a state where downloading documents was possible.
-empty: No events have been recorded yet.
+empty: No events have been recorded yet that meet the filter criteria.
 event:
   add_candidate_to_list: Added candidate to list
   create_candidate_list: Created list of candidates
@@ -46,6 +46,7 @@ event:
   create_omission: Created omission
   create_person: Created person
   create_substitute_submitter: Created substitute submitter of the list
+  delete: Deleted political group
   delete_candidate_list: Deleted list of candidates
   delete_name_authorisation: Deleted statutory name and authorised agent
   delete_omission: Deleted omission
@@ -95,6 +96,7 @@ filter:
     set_finished: Finished state
     substitute_submitter: Substitute submitter
     system: System
+    delete: Deleted
   csb_main_stream: Main CSB stream
   event_type: Event type
   reset: Reset

--- a/locales/en/audit_log.yml
+++ b/locales/en/audit_log.yml
@@ -86,6 +86,7 @@ filter:
   category:
     candidate_list: Candidate list
     correction: Corrections
+    delete: Deleted
     import: Import
     list_submitter: List submitter
     name_authorisation: Statutory name and authorised agent
@@ -96,7 +97,6 @@ filter:
     set_finished: Finished state
     substitute_submitter: Substitute submitter
     system: System
-    delete: Deleted
   csb_main_stream: Main CSB stream
   event_type: Event type
   reset: Reset

--- a/locales/en/csb.yml
+++ b/locales/en/csb.yml
@@ -55,7 +55,7 @@ group:
     plural: "{} BRP errors"
     singular: 1 BRP error
   candidate_count: "<strong>{}</strong> candidates"
-  confirm_delete: "Are you sure you want to delete the political group \"{}\"?"
+  confirm_delete: "Are you sure you want to delete the political group “{}“?"
   delete_note: "It is always possible to re-import a political group but any created (paper) corrections, and omissions will be lost!"
   deleted_label: deleted
   examine_all: Examine all BRP errors

--- a/locales/en/csb.yml
+++ b/locales/en/csb.yml
@@ -55,6 +55,9 @@ group:
     plural: "{} BRP errors"
     singular: 1 BRP error
   candidate_count: "<strong>{}</strong> candidates"
+  confirm_delete: "Are you sure you want to delete the political group \"{}\"?"
+  delete_note: "It is always possible to re-import a political group but any created (paper) corrections, and omissions will be lost!"
+  deleted_label: deleted
   examine_all: Examine all BRP errors
   examine_general: Examine general information
   examine_list: Examine candidate list

--- a/locales/nl/audit_log.yml
+++ b/locales/nl/audit_log.yml
@@ -86,6 +86,7 @@ filter:
   category:
     candidate_list: Kandidatenlijst
     correction: Ambtshalve correcties
+    delete: Verwijderd
     import: Import
     list_submitter: Lijstinleveraar
     name_authorisation: Statutaire naam en gemachtigde
@@ -96,7 +97,6 @@ filter:
     set_finished: Afgerond
     substitute_submitter: Vervanger herstel verzuim
     system: Systeem
-    delete: Verwijderd
   csb_main_stream: Main CSB stream
   event_type: Type gebeurtenis
   reset: Wissen

--- a/locales/nl/audit_log.yml
+++ b/locales/nl/audit_log.yml
@@ -37,7 +37,7 @@ detail:
 documents:
   download: Documenten downloaden
   no_download: In deze versie was het downloaden van documenten niet mogelijk.
-empty: Er zijn nog geen gebeurtenissen vastgelegd.
+empty: Er zijn nog geen gebeurtenissen vastgelegd die voldoen aan de filter criteria.
 event:
   add_candidate_to_list: Kandidaat aan lijst toegevoegd
   create_candidate_list: Kandidatenlijst aangemaakt
@@ -46,6 +46,7 @@ event:
   create_omission: Verzuim aangemaakt
   create_person: Persoon aangemaakt
   create_substitute_submitter: Vervanger herstel verzuim aangemaakt
+  delete: Politieke groepering verwijderd
   delete_candidate_list: Kandidatenlijst verwijderd
   delete_name_authorisation: Statutaire naam en gemachtigde verwijderd
   delete_omission: Verzuim verwijderd
@@ -95,6 +96,7 @@ filter:
     set_finished: Afgerond
     substitute_submitter: Vervanger herstel verzuim
     system: Systeem
+    delete: Verwijderd
   csb_main_stream: Main CSB stream
   event_type: Type gebeurtenis
   reset: Wissen

--- a/locales/nl/csb.yml
+++ b/locales/nl/csb.yml
@@ -55,6 +55,9 @@ group:
     plural: "{} BRP fouten"
     singular: 1 BRP fout
   candidate_count: "<strong>{}</strong> kandidaten"
+  confirm_delete: "Weet u zeker dat u de politieke groepering \"{}\" wilt verwijderen?"
+  delete_note: "Het is altijd mogelijk om een politieke groepering te herimporteren maar aangemaakte papieren- en ambtshalve correcties, en verzuimen zullen verloren gaan!"
+  deleted_label: verwijderd
   examine_all: Alle BRP fouten controleren
   examine_general: Basisgegevens controleren
   examine_list: Kandidatenlijst controleren

--- a/locales/nl/csb.yml
+++ b/locales/nl/csb.yml
@@ -55,7 +55,7 @@ group:
     plural: "{} BRP fouten"
     singular: 1 BRP fout
   candidate_count: "<strong>{}</strong> kandidaten"
-  confirm_delete: "Weet u zeker dat u de politieke groepering \"{}\" wilt verwijderen?"
+  confirm_delete: "Weet u zeker dat u de politieke groepering “{}“ wilt verwijderen?"
   delete_note: "Het is altijd mogelijk om een politieke groepering te herimporteren maar aangemaakte papieren- en ambtshalve correcties, en verzuimen zullen verloren gaan!"
   deleted_label: verwijderd
   examine_all: Alle BRP fouten controleren

--- a/src/csb/audit_log/pages/detail.rs
+++ b/src/csb/audit_log/pages/detail.rs
@@ -79,7 +79,10 @@ pub async fn csb_audit_log_detail<S: AppRequestState>(
         CsbEventDetail::find(
             &data.events,
             event_id,
-            store.get_appellation(crate::projection::WithCorrections::All),
+            store.get_appellation_with_deleted_label(
+                crate::projection::WithCorrections::All,
+                context.session.locale,
+            ),
             locale,
         )?
     };

--- a/src/csb/audit_log/pages/list.rs
+++ b/src/csb/audit_log/pages/list.rs
@@ -23,6 +23,7 @@ const PER_PAGE: usize = 20;
 ///
 /// Category label translations (referenced dynamically in the template):
 /// trans!("audit_log.filter.category.import", _)
+/// trans!("audit_log.filter.category.delete", _)
 /// trans!("audit_log.filter.category.paper_correction", _)
 /// trans!("audit_log.filter.category.correction", _)
 /// trans!("audit_log.filter.category.set_finished", _)
@@ -35,6 +36,10 @@ pub const EVENT_TYPES_BY_CATEGORY: &[EventTypeCategory] = &[
     EventTypeCategory {
         key: "import",
         event_types: &["import", "create_empty"],
+    },
+    EventTypeCategory {
+        key: "delete",
+        event_types: &["delete"],
     },
     EventTypeCategory {
         key: "paper_correction",
@@ -139,7 +144,10 @@ fn collect_entries(
         filter_events(
             store.data.read().events.iter(),
             store.stream_id,
-            store.get_appellation(crate::projection::WithCorrections::All),
+            store.get_appellation_with_deleted_label(
+                crate::projection::WithCorrections::All,
+                locale,
+            ),
             locale,
             active_event_type,
             active_search,
@@ -177,7 +185,10 @@ pub async fn csb_audit_log<S: AppRequestState>(
         .map(|store| {
             (
                 store.stream_id,
-                store.get_appellation(crate::projection::WithCorrections::All),
+                store.get_appellation_with_deleted_label(
+                    crate::projection::WithCorrections::All,
+                    locale,
+                ),
             )
         })
         .collect();

--- a/src/csb/audit_log/pages/list.rs
+++ b/src/csb/audit_log/pages/list.rs
@@ -230,8 +230,13 @@ pub async fn csb_audit_log<S: AppRequestState>(
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
-    use crate::projection::CSB_MAIN_STREAM_ID;
+    use crate::{
+        projection::{CSB_MAIN_STREAM_ID, WithCorrections},
+        structs::common::Appellation,
+    };
     use axum::{
         extract::{Query, State},
         http::StatusCode,
@@ -327,6 +332,39 @@ mod tests {
 
         let body = response_body_string(response).await;
         assert!(body.contains("<td>Set finished state</td>"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn renders_import_stream_events_from_deleted_stream() -> Result<(), AppError> {
+        let state = AppState::new_for_tests().await;
+        let import_stream_id = StreamId::new();
+        let csb_store = state
+            .csb_store_for_stream(import_stream_id, ElectionConfig::EK27)
+            .await?;
+        let mut pg = csb_store.get_political_group(WithCorrections::All);
+        pg.appellation = Appellation::from_str("Test Partij").ok();
+        csb_store.set_political_group(pg);
+        csb_store.update(CsbEvent::Delete).await?;
+
+        let response = call(
+            CsbMainStore::new_for_test(),
+            state,
+            Query(CsbAuditLogFilter {
+                stream: Some(import_stream_id.to_string()),
+                ..Default::default()
+            }),
+        )
+        .await?;
+
+        let body = response_body_string(response).await;
+        assert!(
+            body.chars()
+                .filter(|c| !c.is_whitespace())
+                .collect::<String>()
+                .contains(">TestPartij(deleted)</option>")
+        );
 
         Ok(())
     }

--- a/src/csb/examination/extractors/political_groups.rs
+++ b/src/csb/examination/extractors/political_groups.rs
@@ -9,6 +9,7 @@ pub struct CsbPoliticalGroup {
     pub political_group: PoliticalGroup,
     pub stream_id: StreamId,
     pub is_examination_finished: bool,
+    pub is_deleted: bool,
     pub restoration_count: usize,
     pub omission_count: usize,
     pub first_candidate_name: Option<FullName>,
@@ -16,10 +17,11 @@ pub struct CsbPoliticalGroup {
 
 impl CsbPoliticalGroup {
     pub fn new_from_csb_store(store: &CsbStore) -> Self {
-        CsbPoliticalGroup {
+        Self {
             political_group: store.get_political_group(crate::projection::WithCorrections::All),
             stream_id: store.stream_id,
             is_examination_finished: store.is_examination_finished(),
+            is_deleted: store.is_deleted(),
             restoration_count: store.get_restoration_count(),
             omission_count: store.get_omission_count(),
             first_candidate_name: store
@@ -127,6 +129,7 @@ mod tests {
             },
             stream_id: StreamId::new(),
             is_examination_finished: false,
+            is_deleted: false,
             restoration_count: 0,
             omission_count: 0,
             first_candidate_name: None,
@@ -144,6 +147,7 @@ mod tests {
             },
             stream_id: StreamId::new(),
             is_examination_finished: false,
+            is_deleted: false,
             restoration_count: 0,
             omission_count: 0,
             first_candidate_name: Some(FullName {
@@ -165,6 +169,7 @@ mod tests {
             },
             stream_id: StreamId::new(),
             is_examination_finished: false,
+            is_deleted: false,
             restoration_count: 0,
             omission_count: 0,
             first_candidate_name: None,

--- a/src/csb/examination/pages/delete.html
+++ b/src/csb/examination/pages/delete.html
@@ -1,0 +1,14 @@
+{% extends "csb/components/overlay.html" %}
+{% set submit_label = "csb.omission.form.submit"|trans %}
+{% block overlay_title %}{{ "action.delete"|trans }} {{ political_group.csb_appellation() }}{% endblock %}
+{% block overlay_form %}
+  <fieldset>
+    <p>{{ "csb.group.confirm_delete"|trans(political_group.csb_appellation().as_str()) }}</p>
+    <p>{{  "csb.group.delete_note"|trans }}</p>
+  </fieldset>
+{% endblock %}
+{% block overlay_actions %}
+  <div class="form-actions">
+    <button type="submit" class="button tertiary-destructive icon-trash">{{ "action.delete"|trans }}</button>
+  </div>
+{% endblock %}

--- a/src/csb/examination/pages/delete.rs
+++ b/src/csb/examination/pages/delete.rs
@@ -1,0 +1,89 @@
+use askama::Template;
+use axum::{
+    extract::Query,
+    response::{IntoResponse, Redirect, Response},
+};
+
+use crate::{
+    AppError, Context, CsbContext, CsbEvent, CsbStore, HtmlTemplate, Overlay, QueryParamState,
+    csb::examination::{
+        CsbExaminationOverviewPath, extractors::CsbPoliticalGroup,
+        paths::CsbPoliticalGroupDeletePath,
+    },
+    filters,
+};
+
+#[derive(Template)]
+#[template(path = "csb/examination/pages/delete.html")]
+struct CsbPoliticalGroupDeleteTemplate {
+    political_group: CsbPoliticalGroup,
+    overlay: Overlay,
+    close_action: String,
+}
+
+pub async fn delete(
+    _: CsbPoliticalGroupDeletePath,
+    context: CsbContext,
+    Query(query): Query<QueryParamState>,
+    store: CsbStore,
+) -> Result<Response, AppError> {
+    let political_group = CsbPoliticalGroup::new_from_csb_store(&store);
+    let close_action = political_group.examination_path().to_string();
+    Ok(HtmlTemplate(
+        CsbPoliticalGroupDeleteTemplate {
+            close_action,
+            political_group,
+            overlay: Overlay::new(&query),
+        },
+        context,
+    )
+    .into_response())
+}
+
+pub async fn delete_submit(
+    _: CsbPoliticalGroupDeletePath,
+    store: CsbStore,
+) -> Result<Response, AppError> {
+    store.update(CsbEvent::Delete).await?;
+    Ok(Redirect::to(&CsbExaminationOverviewPath.to_string()).into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use reqwest::StatusCode;
+
+    use crate::{
+        projection::WithCorrections, structs::common::Appellation, test_utils::response_body_string,
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn delete_page_includes_appellation_and_delete_button() -> Result<(), AppError> {
+        let store = CsbStore::new_for_test();
+        let context = CsbContext::new_test();
+
+        let mut pg = store.get_political_group(WithCorrections::All);
+        pg.appellation = Appellation::from_str("Test Partij").ok();
+        store.set_political_group(pg);
+
+        let response = delete(
+            CsbPoliticalGroupDeletePath {
+                stream_id: store.stream_id,
+            },
+            context,
+            Query::default(),
+            store,
+        )
+        .await?;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_body_string(response).await;
+        assert!(body.contains("Delete Test Partij"));
+        assert!(body.contains("<button type=\"submit\" class=\"button tertiary-destructive icon-trash\">Delete</button>"));
+
+        Ok(())
+    }
+}

--- a/src/csb/examination/pages/mod.rs
+++ b/src/csb/examination/pages/mod.rs
@@ -9,6 +9,7 @@ mod all_restorations;
 mod candidate;
 mod candidate_list;
 mod correction;
+mod delete;
 mod general_information;
 mod i1;
 mod i4;
@@ -24,8 +25,8 @@ pub fn router<S: AppRequestState>() -> Router<S> {
         .typed_get(i4::gen_i4::<S>)
         .typed_get(political_group::overview)
         .typed_post(political_group::toggle_examination_finish)
-        .typed_get(political_group::delete)
-        .typed_post(political_group::delete_submit)
+        .typed_get(delete::delete)
+        .typed_post(delete::delete_submit)
         .typed_get(general_information::overview)
         .typed_post(paper_corrections::start_paper_corrections::<S>)
         .typed_post(paper_corrections::stop_paper_corrections::<S>)

--- a/src/csb/examination/pages/mod.rs
+++ b/src/csb/examination/pages/mod.rs
@@ -24,6 +24,8 @@ pub fn router<S: AppRequestState>() -> Router<S> {
         .typed_get(i4::gen_i4::<S>)
         .typed_get(political_group::overview)
         .typed_post(political_group::toggle_examination_finish)
+        .typed_get(political_group::delete)
+        .typed_post(political_group::delete_submit)
         .typed_get(general_information::overview)
         .typed_post(paper_corrections::start_paper_corrections::<S>)
         .typed_post(paper_corrections::stop_paper_corrections::<S>)

--- a/src/csb/examination/pages/overview.rs
+++ b/src/csb/examination/pages/overview.rs
@@ -29,6 +29,9 @@ pub async fn overview(
     let mut unfinished_political_groups = Vec::new();
     let mut finished_political_groups = Vec::new();
     for political_group in political_groups {
+        if political_group.is_deleted {
+            continue;
+        }
         if political_group.is_examination_finished {
             finished_political_groups.push(political_group)
         } else {
@@ -61,6 +64,7 @@ mod tests {
             political_group: sample_political_group(),
             stream_id: StreamId::new(),
             is_examination_finished: false,
+            is_deleted: false,
             restoration_count: 0,
             omission_count: 0,
             first_candidate_name: None,
@@ -87,6 +91,7 @@ mod tests {
             political_group: sample_political_group(),
             stream_id: StreamId::new(),
             is_examination_finished: false,
+            is_deleted: false,
             restoration_count: 0, /* omission count should be used and > 0 */
             omission_count: 3,
             first_candidate_name: None,

--- a/src/csb/examination/pages/overview.rs
+++ b/src/csb/examination/pages/overview.rs
@@ -86,6 +86,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn overview_skips_deleted_political_group_names() {
+        let groups = CsbPoliticalGroups(vec![CsbPoliticalGroup {
+            political_group: sample_political_group(),
+            stream_id: StreamId::new(),
+            is_examination_finished: false,
+            is_deleted: true,
+            restoration_count: 0,
+            omission_count: 0,
+            first_candidate_name: None,
+        }]);
+
+        let response = overview(
+            CsbExaminationOverviewPath {},
+            CsbContext::new_test(),
+            groups,
+        )
+        .await
+        .unwrap()
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        // The seeded group's appellation is not rendered as it is deleted.
+        let body = response_body_string(response).await;
+        assert!(!body.contains("Kiesraad Demo"));
+    }
+
+    #[tokio::test]
     async fn overview_renders_omission_count_badge() {
         let groups = CsbPoliticalGroups(vec![CsbPoliticalGroup {
             political_group: sample_political_group(),

--- a/src/csb/examination/pages/political_group.html
+++ b/src/csb/examination/pages/political_group.html
@@ -6,6 +6,8 @@
 {% endblock %}
 {% block page_title %}
   {{ political_group.csb_appellation() }}
+  <a class="button tertiary-destructive icon-trash"
+     href="{{ political_group.delete_path() }}">{{ "action.delete"|trans }}</a>
 {% endblock %}
 {% block header_action %}
   {% set back_url = crate::csb::examination::CsbExaminationOverviewPath %}

--- a/src/csb/examination/pages/political_group.rs
+++ b/src/csb/examination/pages/political_group.rs
@@ -1,18 +1,16 @@
 use askama::Template;
 use axum::{
     extract::Query,
-    response::{IntoResponse, Redirect, Response},
+    response::{IntoResponse, Response},
 };
 
 use crate::{
     AppError, Context, CsbContext,
     CsbEvent::{self},
-    CsbStore, HtmlTemplate, Overlay, QueryParamState,
+    CsbStore, HtmlTemplate, QueryParamState,
     csb::examination::{
-        CsbExaminationOverviewPath,
         extractors::CsbPoliticalGroup,
         pages::{CsbPoliticalGroupPath, CsbPoliticalGroupToggleFinishPath},
-        paths::CsbPoliticalGroupDeletePath,
         structs::{CsbCandidateList, RestorationStatus},
     },
     filters,
@@ -27,14 +25,6 @@ struct CsbPoliticalGroupTemplate {
     political_group_status: RestorationStatus,
     declarations_of_support_status: RestorationStatus,
     declarations_of_support_card_path: String,
-}
-
-#[derive(Template)]
-#[template(path = "csb/examination/pages/delete.html")]
-struct CsbPoliticalGroupDeleteTemplate {
-    political_group: CsbPoliticalGroup,
-    overlay: Overlay,
-    close_action: String,
 }
 
 /// Render the placeholder political group overview page.
@@ -98,33 +88,6 @@ pub async fn toggle_examination_finish(
     let finished = store.is_examination_finished();
     store.update(CsbEvent::SetFinished(!finished)).await?;
     Ok(query.redirect_or(CsbPoliticalGroup::new_from_csb_store(&store).examination_path()))
-}
-
-pub async fn delete(
-    _: CsbPoliticalGroupDeletePath,
-    context: CsbContext,
-    Query(query): Query<QueryParamState>,
-    store: CsbStore,
-) -> Result<Response, AppError> {
-    let political_group = CsbPoliticalGroup::new_from_csb_store(&store);
-    let close_action = political_group.examination_path().to_string();
-    Ok(HtmlTemplate(
-        CsbPoliticalGroupDeleteTemplate {
-            close_action,
-            political_group,
-            overlay: Overlay::new(&query),
-        },
-        context,
-    )
-    .into_response())
-}
-
-pub async fn delete_submit(
-    _: CsbPoliticalGroupDeletePath,
-    store: CsbStore,
-) -> Result<Response, AppError> {
-    store.update(CsbEvent::Delete).await?;
-    Ok(Redirect::to(&CsbExaminationOverviewPath.to_string()).into_response())
 }
 
 #[cfg(test)]

--- a/src/csb/examination/pages/political_group.rs
+++ b/src/csb/examination/pages/political_group.rs
@@ -1,16 +1,18 @@
 use askama::Template;
 use axum::{
     extract::Query,
-    response::{IntoResponse, Response},
+    response::{IntoResponse, Redirect, Response},
 };
 
 use crate::{
     AppError, Context, CsbContext,
     CsbEvent::{self},
-    CsbStore, HtmlTemplate, QueryParamState,
+    CsbStore, HtmlTemplate, Overlay, QueryParamState,
     csb::examination::{
+        CsbExaminationOverviewPath,
         extractors::CsbPoliticalGroup,
         pages::{CsbPoliticalGroupPath, CsbPoliticalGroupToggleFinishPath},
+        paths::CsbPoliticalGroupDeletePath,
         structs::{CsbCandidateList, RestorationStatus},
     },
     filters,
@@ -25,6 +27,14 @@ struct CsbPoliticalGroupTemplate {
     political_group_status: RestorationStatus,
     declarations_of_support_status: RestorationStatus,
     declarations_of_support_card_path: String,
+}
+
+#[derive(Template)]
+#[template(path = "csb/examination/pages/delete.html")]
+struct CsbPoliticalGroupDeleteTemplate {
+    political_group: CsbPoliticalGroup,
+    overlay: Overlay,
+    close_action: String,
 }
 
 /// Render the placeholder political group overview page.
@@ -88,6 +98,33 @@ pub async fn toggle_examination_finish(
     let finished = store.is_examination_finished();
     store.update(CsbEvent::SetFinished(!finished)).await?;
     Ok(query.redirect_or(CsbPoliticalGroup::new_from_csb_store(&store).examination_path()))
+}
+
+pub async fn delete(
+    _: CsbPoliticalGroupDeletePath,
+    context: CsbContext,
+    Query(query): Query<QueryParamState>,
+    store: CsbStore,
+) -> Result<Response, AppError> {
+    let political_group = CsbPoliticalGroup::new_from_csb_store(&store);
+    let close_action = political_group.examination_path().to_string();
+    Ok(HtmlTemplate(
+        CsbPoliticalGroupDeleteTemplate {
+            close_action,
+            political_group,
+            overlay: Overlay::new(&query),
+        },
+        context,
+    )
+    .into_response())
+}
+
+pub async fn delete_submit(
+    _: CsbPoliticalGroupDeletePath,
+    store: CsbStore,
+) -> Result<Response, AppError> {
+    store.update(CsbEvent::Delete).await?;
+    Ok(Redirect::to(&CsbExaminationOverviewPath.to_string()).into_response())
 }
 
 #[cfg(test)]

--- a/src/csb/examination/paths.rs
+++ b/src/csb/examination/paths.rs
@@ -44,6 +44,12 @@ pub struct CsbPoliticalGroupToggleFinishPath {
 }
 
 #[derive(TypedPath, Deserialize)]
+#[typed_path("/csb/examination/{stream_id}/delete", rejection(AppError))]
+pub struct CsbPoliticalGroupDeletePath {
+    pub stream_id: StreamId,
+}
+
+#[derive(TypedPath, Deserialize)]
 #[typed_path(
     "/csb/examination/{stream_id}/general-information",
     rejection(AppError)
@@ -155,6 +161,12 @@ pub struct OmissionListQuery {
 impl CsbPoliticalGroup {
     pub fn examination_path(&self) -> impl TypedPath {
         CsbPoliticalGroupPath {
+            stream_id: self.stream_id,
+        }
+    }
+
+    pub fn delete_path(&self) -> impl TypedPath {
+        CsbPoliticalGroupDeletePath {
             stream_id: self.stream_id,
         }
     }

--- a/src/csb/examination/structs/restoration_status.rs
+++ b/src/csb/examination/structs/restoration_status.rs
@@ -60,7 +60,7 @@ mod tests {
     use crate::{
         CsbEvent, ElectoralDistrict,
         structs::{
-            common::{DisplayName, Initials},
+            common::{Appellation, Initials},
             csb::{Correction, OmissionCategory, PersonCorrection, sample_omission},
         },
         test_utils::{sample_candidate_list, sample_person},
@@ -88,8 +88,8 @@ mod tests {
             )))
             .await?;
         store
-            .update(CsbEvent::UpdateCorrection(Correction::DisplayName(
-                DisplayName::from_str("Correction Party").unwrap(),
+            .update(CsbEvent::UpdateCorrection(Correction::Appellation(
+                Appellation::from_str("Correction Party").unwrap(),
             )))
             .await?;
 

--- a/src/csb/import/pages/import.rs
+++ b/src/csb/import/pages/import.rs
@@ -81,10 +81,11 @@ async fn do_import<S: AppRequestState>(
 
     // Reject if this source stream has already been imported.
     for store in state.csb_store_registry().stores_by_scope().await? {
-        let already_imported = store.data.read().events.first().is_some_and(|e| {
-            matches!(&e.payload, CsbEvent::Import { source_stream_id: sid, .. } if *sid == source_stream_id)
+        let already_imported_and_not_deleted = store.data.read().events.first().is_some_and(|e| {
+            matches!(&e.payload, CsbEvent::Import { source_stream_id: sid, .. } if *sid == source_stream_id) &&
+            !store.is_deleted()
         });
-        if already_imported {
+        if already_imported_and_not_deleted {
             return Err(AppError::UserError(trans!(
                 "csb.import.error.already_imported",
                 locale

--- a/src/csb/import/pages/import.rs
+++ b/src/csb/import/pages/import.rs
@@ -148,8 +148,8 @@ mod tests {
     use axum::http::StatusCode;
 
     use crate::{
-        AppState, CsbContext, ElectionConfig, PgEvent, test_utils::response_body_string,
-        utils::format_hash,
+        AppState, CsbContext, CsbEvent::Delete, ElectionConfig, PgEvent,
+        test_utils::response_body_string, utils::format_hash,
     };
 
     /// Populate a political-group stream with a single event in the (in-memory)
@@ -314,6 +314,63 @@ mod tests {
             CsbEvent::CreateEmpty
         ));
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn reimport_deleted_allowed() -> Result<(), AppError> {
+        let state = AppState::new_for_tests().await;
+        let (_, hash) = seed_source_event(&state).await?;
+
+        let context = CsbContext::new_test();
+        let response = import_submit(
+            CsbImportPath {},
+            State(state.clone()),
+            context,
+            Form(ImportForm { hash: hash.clone() }),
+        )
+        .await?
+        .into_response();
+        // First import succeeds (redirects away from import page)
+        assert_eq!(response.status(), StatusCode::SEE_OTHER);
+
+        let csb_stores = state.csb_store_registry().stores_by_scope().await?;
+        assert_eq!(csb_stores.len(), 1);
+
+        // mark imported store as deleted
+        csb_stores[0].update(Delete).await?;
+
+        // Re-importing the same source stream is rejected against the cached CSB
+        // store (the in-memory backend persists nothing, so the duplicate check
+        // must consult the live registry).
+        let context = CsbContext::new_test();
+        let response = import_submit(
+            CsbImportPath {},
+            State(state.clone()),
+            context,
+            Form(ImportForm { hash: hash.clone() }),
+        )
+        .await?
+        .into_response();
+
+        dbg!(&response);
+
+        // second import succeeds too as first import got deleted
+        assert_eq!(response.status(), StatusCode::SEE_OTHER);
+
+        let csb_stores = state.csb_store_registry().stores_by_scope().await?;
+        assert_eq!(csb_stores.iter().filter(|s| s.is_deleted()).count(), 1);
+        assert_eq!(csb_stores.iter().filter(|s| !s.is_deleted()).count(), 1);
+        for store in csb_stores {
+            if let CsbEvent::Import {
+                hash: import_hash, ..
+            } = store.data.read().events.first().unwrap().payload
+            {
+                assert_eq!(hash.clone(), format_hash(&import_hash, false));
+            } else {
+                panic!("No import")
+            }
+        }
         Ok(())
     }
 }

--- a/src/pg/candidate_lists/pages/delete.html
+++ b/src/pg/candidate_lists/pages/delete.html
@@ -14,6 +14,6 @@
 {% endblock %}
 {% block overlay_actions %}
   <div class="form-actions">
-    <button type="submit" class="button tertiary-destructive">{{ "candidate_list.actions.delete_list"|trans }}</button>
+    <button type="submit" class="button tertiary-destructive icon-trash">{{ "candidate_list.actions.delete_list"|trans }}</button>
   </div>
 {% endblock %}

--- a/src/pg/name_authorisations/pages/delete.html
+++ b/src/pg/name_authorisations/pages/delete.html
@@ -14,7 +14,7 @@
 {% endblock %}
 {% block overlay_actions %}
   <div class="form-actions">
-    <button type="submit" class="button tertiary-destructive">
+    <button type="submit" class="button tertiary-destructive icon-trash">
       {{ "political_group.actions.delete_name_authorisation"|trans }}
     </button>
   </div>

--- a/src/pg/substitute_list_submitters/pages/delete.html
+++ b/src/pg/substitute_list_submitters/pages/delete.html
@@ -14,7 +14,7 @@
 {% endblock %}
 {% block overlay_actions %}
   <div class="form-actions">
-    <button type="submit" class="button tertiary-destructive">
+    <button type="submit" class="button tertiary-destructive icon-trash">
       {{ "political_group.actions.delete_substitute_submitter"|trans }}
     </button>
   </div>

--- a/src/projection/csb_data/event.rs
+++ b/src/projection/csb_data/event.rs
@@ -31,6 +31,8 @@ pub enum CsbEvent {
     },
     /// Create an empty political-group store without importing from a PG stream.
     CreateEmpty,
+    /// Delete a political-group stream
+    Delete,
     /// An app event applied to the paper-corrected projection instead of a
     /// political group's own stream. Boxed to keep the event enum small.
     PaperCorrectedUpdate(Box<PgEvent>),
@@ -48,6 +50,7 @@ impl Event for CsbEvent {
         match self {
             CsbEvent::Import { .. } => "import",
             CsbEvent::CreateEmpty => "import",
+            CsbEvent::Delete => "delete",
             CsbEvent::PaperCorrectedUpdate(_) => "paper_correction",
             CsbEvent::SetFinished(_) => "set_finished",
             CsbEvent::CreateOmission(_)
@@ -61,6 +64,7 @@ impl Event for CsbEvent {
         match self {
             CsbEvent::Import { .. } => "import",
             CsbEvent::CreateEmpty => "create_empty",
+            CsbEvent::Delete => "delete",
             CsbEvent::PaperCorrectedUpdate(event) => event.key(),
             CsbEvent::SetFinished(_) => "set_finished",
             CsbEvent::CreateOmission(_) => "create_omission",
@@ -73,6 +77,7 @@ impl Event for CsbEvent {
     fn description(&self, locale: crate::Locale) -> String {
         match self {
             CsbEvent::Import { .. } => trans!("audit_log.event.import", locale),
+            CsbEvent::Delete => trans!("audit_log.event.delete", locale),
             CsbEvent::CreateEmpty => trans!("audit_log.event.create_empty", locale),
             CsbEvent::PaperCorrectedUpdate(event) => event.description(locale),
             CsbEvent::SetFinished(_) => trans!("audit_log.event.set_finished", locale),
@@ -97,6 +102,7 @@ impl Event for CsbEvent {
                     format_hash(hash, true)
                 )
             }
+            CsbEvent::Delete => String::new(),
             CsbEvent::CreateEmpty => String::new(),
             CsbEvent::PaperCorrectedUpdate(event) => event.details(),
             CsbEvent::SetFinished(value) => value.to_string(),

--- a/src/projection/csb_data/extractor.rs
+++ b/src/projection/csb_data/extractor.rs
@@ -27,7 +27,16 @@ impl<S: AppRequestState> FromRequestParts<S> for CsbStore {
             .await?
             .require_current_election()?;
 
-        registry.get_store(stream_id, election).await
+        match registry.get_store(stream_id, election).await {
+            Ok(store) => {
+                if store.is_deleted() {
+                    Err(AppError::GenericNotFound)
+                } else {
+                    Ok(store)
+                }
+            }
+            Err(e) => Err(e),
+        }
     }
 }
 

--- a/src/projection/csb_data/extractor.rs
+++ b/src/projection/csb_data/extractor.rs
@@ -27,16 +27,14 @@ impl<S: AppRequestState> FromRequestParts<S> for CsbStore {
             .await?
             .require_current_election()?;
 
-        match registry.get_store(stream_id, election).await {
-            Ok(store) => {
-                if store.is_deleted() {
-                    Err(AppError::GenericNotFound)
-                } else {
-                    Ok(store)
-                }
-            }
-            Err(e) => Err(e),
+        let result = registry.get_store(stream_id, election).await;
+
+        if let Ok(store) = &result
+            && store.is_deleted()
+        {
+            return Err(AppError::NotFound("Stream deleted".to_string()));
         }
+        result
     }
 }
 
@@ -147,5 +145,40 @@ mod tests {
             <CsbStoreData as crate::store::StoreData>::scope(),
             crate::Scope::ImportedByCsb
         );
+    }
+
+    #[tokio::test]
+    async fn returns_not_found_for_a_deleted_stream() -> Result<(), AppError> {
+        let state = AppState::new_for_tests().await;
+        let stream_id = StreamId::new();
+        // create a new store
+        let csb_store = state
+            .csb_store_for_stream(stream_id, ElectionConfig::EK27)
+            .await?;
+
+        let response = request_store(
+            state.clone(),
+            format!("/csb/examination/{stream_id}"),
+            ElectionConfig::EK27,
+        )
+        .await;
+
+        // store exists && !deleted => OK
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // delete the store
+        csb_store.update(CsbEvent::Delete).await?;
+
+        let response = request_store(
+            state,
+            format!("/csb/examination/{stream_id}"),
+            ElectionConfig::EK27,
+        )
+        .await;
+
+        // store exists && deleted => Not Found
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+        Ok(())
     }
 }

--- a/src/projection/csb_data/getters.rs
+++ b/src/projection/csb_data/getters.rs
@@ -6,7 +6,7 @@ use parking_lot::{
 };
 
 use crate::{
-    AppError, CsbStore, PgStoreData,
+    AppError, CsbStore, Locale, PgStoreData,
     structs::{
         candidate_lists::{CandidateList, CandidateListId},
         csb::{Omission, OmissionCategory, OmissionId},
@@ -15,6 +15,7 @@ use crate::{
         persons::{Person, PersonId},
         political_groups::PoliticalGroup,
     },
+    trans,
 };
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -47,6 +48,12 @@ impl CsbStore {
         let data = self.data.read();
 
         data.is_examination_finished
+    }
+
+    pub fn is_deleted(&self) -> bool {
+        let data = self.data.read();
+
+        data.is_deleted
     }
 
     pub fn get_omission(&self, omission_id: OmissionId) -> Result<Omission, AppError> {
@@ -103,7 +110,7 @@ impl CsbStore {
     pub fn get_political_group_csb_corrections_count(&self) -> usize {
         let data = self.data.read();
 
-        match data.csb_corrected_display_name {
+        match data.csb_corrected_appellation {
             Some(_) => 1,
             None => 0,
         }
@@ -288,6 +295,26 @@ impl CsbStore {
     pub fn get_appellation(&self, corrections: WithCorrections) -> String {
         let political_group = self.get_political_group(corrections);
         political_group.csb_appellation(self.get_first_candidate_name(corrections).as_ref())
+    }
+
+    /// Short-hand to get the appellation of the political group (including special names for blank lists).
+    /// Additionally includes a deleted label when the political group has been deleted
+    pub fn get_appellation_with_deleted_label(
+        &self,
+        corrections: WithCorrections,
+        locale: Locale,
+    ) -> String {
+        let political_group = self.get_political_group(corrections);
+        let appellation =
+            political_group.csb_appellation(self.get_first_candidate_name(corrections).as_ref());
+        if self.is_deleted() {
+            format!(
+                "{appellation} ({})",
+                trans!("csb.group.deleted_label", locale)
+            )
+        } else {
+            appellation
+        }
     }
 
     /// One-based position of the candidate on the given list

--- a/src/projection/csb_data/mod.rs
+++ b/src/projection/csb_data/mod.rs
@@ -32,6 +32,7 @@ pub struct CsbStoreData {
     pub(crate) omissions: HashMap<OmissionId, Omission>,
     pub(crate) csb_corrected_persons: HashMap<PersonId, PersonCorrectionDelta>,
     pub(crate) csb_corrected_appellation: Option<Appellation>,
+    pub(crate) is_deleted: bool,
 }
 
 impl StoreData for CsbStoreData {
@@ -67,6 +68,7 @@ impl StoreData for CsbStoreData {
                 });
             }
             CsbEvent::CreateEmpty => {}
+            CsbEvent::Delete => self.is_deleted = true,
             CsbEvent::PaperCorrectedUpdate(payload) => {
                 // Replay the wrapped app event onto the corrected projection,
                 // keeping the CSB stream's event metadata.


### PR DESCRIPTION
Closes #1043

# [DOD](/docs/definition-of-done.md) checklist

## For PR maintainer

Perform these checks before marking the PR as ready:

- [x] I have linked the PR to at least one issue.
- [x] I assigned the PR to myself.
- [x] I have added a description how to test this PR (see "Review Instructions").
- [x] ~~[For bug fixes only] I have added a regression test for the fixed bug.~~
- [x] I have added documentation where necessary.

## For reviewer

- I have read all code changes.
- I have audited the code quality.
- I have tested the changes either or both:
  - locally
  - on the test environment (preferred)
- I have validated that the PR is functionally correct (use-cases, figma designs, etc.)

### Review instructions
Confirm the following behviors:
- import, delete, and import same hash works 
- Audit log contains deleted streams/pg's but are labeled as deleted
- Deleted pg's don't appear in the examination overview
- Navigating to a deleted pg gives 404
