### PR TITLE
[#1079] Only allow adding candidate omissions for lists that a candidate is on

### DIFF
--- a/src/csb/examination/pages/omission/mod.rs
+++ b/src/csb/examination/pages/omission/mod.rs
@@ -76,21 +76,19 @@ impl OmissionTarget {
             .then(|| views::available_electoral_districts(store))
             .filter(|options| options.len() > 1)
             .unwrap_or_default();
-        let available_candidate_lists = match self.omission_type {
-            OmissionType::CandidateList => Some(views::candidate_list_options(
-                store,
-                context.session.locale,
-                None,
-            )),
-            OmissionType::Candidate => Some(views::candidate_list_options(
-                store,
-                context.session.locale,
-                Some(PersonId::from(self.reference)),
-            )),
-            OmissionType::PoliticalGroup | OmissionType::DeclarationsOfSupport => None,
-        }
-        .filter(|options| options.len() > 1)
-        .unwrap_or_default();
+        let available_candidate_lists = self
+            .omission_type
+            .needs_candidate_lists()
+            .then(|| {
+                views::candidate_list_options(
+                    store,
+                    context.session.locale,
+                    (self.omission_type == OmissionType::Candidate)
+                        .then(|| PersonId::from(self.reference)),
+                )
+            })
+            .filter(|options| options.len() > 1)
+            .unwrap_or_default();
 
         let political_group = CsbPoliticalGroup::new_from_csb_store(store);
         Ok(HtmlTemplate(

--- a/src/csb/examination/pages/omission/mod.rs
+++ b/src/csb/examination/pages/omission/mod.rs
@@ -76,12 +76,22 @@ impl OmissionTarget {
             .then(|| views::available_electoral_districts(store))
             .filter(|options| options.len() > 1)
             .unwrap_or_default();
-        let available_candidate_lists = self
-            .omission_type
-            .needs_candidate_lists()
-            .then(|| views::candidate_list_options(store, context.session.locale))
-            .filter(|options| options.len() > 1)
-            .unwrap_or_default();
+        let available_candidate_lists = match self.omission_type {
+            OmissionType::CandidateList => Some(views::candidate_list_options(
+                store,
+                context.session.locale,
+                None,
+            )),
+            OmissionType::Candidate => Some(views::candidate_list_options(
+                store,
+                context.session.locale,
+                Some(PersonId::from(self.reference)),
+            )),
+            OmissionType::PoliticalGroup | OmissionType::DeclarationsOfSupport => None,
+        }
+        .filter(|options| options.len() > 1)
+        .unwrap_or_default();
+
         let political_group = CsbPoliticalGroup::new_from_csb_store(store);
         Ok(HtmlTemplate(
             CsbAddOmissionTemplate {
@@ -231,7 +241,7 @@ pub async fn add_omission_submit(
         target.omission_type.needs_candidate_lists(),
         &form.candidate_lists,
         || {
-            views::candidate_list_options(&store, context.session.locale)
+            views::candidate_list_options(&store, context.session.locale, None)
                 .into_iter()
                 .map(|o| o.id)
                 .collect()
@@ -487,10 +497,54 @@ mod tests {
         // With only one list the selector is hidden
         let body = render(store.clone()).await;
         assert!(!body.contains(&format!("omission_candidate_list_{list_id}")));
-        // A second list shows the selector
-        store.set_paper_corrected_candidate_list(sample_candidate_list(CandidateListId::new()));
+        // A second list this candidate is also on shows the selector
+        let second_list_id = CandidateListId::new();
+        let mut second_list = sample_candidate_list(second_list_id);
+        second_list.candidates = vec![person_id];
+        store.set_paper_corrected_candidate_list(second_list);
         let body = render(store.clone()).await;
         assert!(body.contains(&format!("omission_candidate_list_{list_id}")));
+        assert!(body.contains(&format!("omission_candidate_list_{second_list_id}")));
+    }
+
+    #[tokio::test]
+    async fn candidate_dialog_excludes_lists_the_candidate_is_not_on() {
+        use crate::test_utils::{sample_candidate_list, sample_person};
+
+        let store = CsbStore::new_for_test();
+        let stream_id = store.stream_id;
+        let person = sample_person(PersonId::new());
+        let person_id = person.id;
+        store.add_person(person);
+        let list_id = CandidateListId::new();
+        let mut list = sample_candidate_list(list_id);
+        list.candidates = vec![person_id];
+        store.add_candidate_list(list);
+        // A second list this candidate does not appear on.
+        let other_list_id = CandidateListId::new();
+        store.add_candidate_list(sample_candidate_list(other_list_id));
+
+        let response = add_omission(
+            CsbAddOmissionPath {
+                stream_id,
+                omission_type: OmissionType::Candidate,
+                reference: person_id.into(),
+            },
+            CsbContext::new_test(),
+            store,
+            Query(QueryParamState::default()),
+            Query(OmissionListQuery::default()),
+        )
+        .await
+        .unwrap()
+        .into_response();
+        let body = response_body_string(response).await;
+
+        // Only one list actually has this candidate, so the selector stays
+        // hidden (nothing to choose between) and the other list is never
+        // offered as an option.
+        assert!(!body.contains(&format!("omission_candidate_list_{list_id}")));
+        assert!(!body.contains(&format!("omission_candidate_list_{other_list_id}")));
     }
 
     #[tokio::test]

--- a/src/csb/examination/pages/omission/views.rs
+++ b/src/csb/examination/pages/omission/views.rs
@@ -113,12 +113,18 @@ fn placeholders_for(target: &OmissionTarget, store: &CsbStore) -> OmissionPlaceh
     }
 }
 
-/// All paper-corrected candidate lists of the political group for the
-/// candidate omission form
-pub(super) fn candidate_list_options(store: &CsbStore, locale: Locale) -> Vec<CandidateListOption> {
+/// Candidate lists of the political group, optionally filtered to those
+/// containing a specific candidate. When `person_id` is `None`, returns all
+/// lists; when `Some`, returns only lists this candidate appears on.
+pub(super) fn candidate_list_options(
+    store: &CsbStore,
+    locale: Locale,
+    person_id: Option<PersonId>,
+) -> Vec<CandidateListOption> {
     store
         .get_candidate_lists(WithCorrections::All)
         .into_iter()
+        .filter(|l| person_id.is_none_or(|id| l.candidates.contains(&id)))
         .map(|l| CandidateListOption {
             id: l.id,
             label: l.districts_name(locale.into()),

--- a/src/csb/examination/pages/omission/views.rs
+++ b/src/csb/examination/pages/omission/views.rs
@@ -119,12 +119,12 @@ fn placeholders_for(target: &OmissionTarget, store: &CsbStore) -> OmissionPlaceh
 pub(super) fn candidate_list_options(
     store: &CsbStore,
     locale: Locale,
-    person_id: Option<PersonId>,
+    person_filter: Option<PersonId>,
 ) -> Vec<CandidateListOption> {
     store
         .get_candidate_lists(WithCorrections::All)
         .into_iter()
-        .filter(|l| person_id.is_none_or(|id| l.candidates.contains(&id)))
+        .filter(|l| person_filter.is_none_or(|id| l.candidates.contains(&id)))
         .map(|l| CandidateListOption {
             id: l.id,
             label: l.districts_name(locale.into()),


### PR DESCRIPTION
Closes #1079

Rather than greying out the checkboxes, I opted for not showing lists that a candidate isn't on.

# [DOD](/docs/definition-of-done.md) checklist

## For PR maintainer

Perform these checks before marking the PR as ready:

- [x] I have linked the PR to at least one issue.
- [x] I assigned the PR to myself.
- [x] I have added a description how to test this PR (see "Review Instructions").
- [x] I have added documentation where necessary.

## For reviewer

- I have read all code changes.
- I have audited the code quality.
- I have tested the changes either or both:
  - locally
  - on the test environment (preferred)
- I have validated that the PR is functionally correct (use-cases, figma designs, etc.)

### Review instructions

Login as PP and add three lists. Add candidate X to one of the lists, add candidate Y to two of the lists and Z to all lists.

Now log in CSB and load this Political group. When adding a candidate omission:
- Candidate X has no Candidate list selection available (there is nothing to choose; this was already the behavior previously, but then only when there was only 1 list)
- Candidate Y can only choose the lists that they are actually on
- Candidate Z can choose all lists