### PR TITLE
[#1105] Harden security headers, session handling and redirects

### DIFF
--- a/locales/en/audit_log.yml
+++ b/locales/en/audit_log.yml
@@ -59,6 +59,8 @@ event:
   hide_download_warning: Dismissed download warning
   import: Imported political group
   import_csv: Imported CSV
+  login: Signed in
+  logout: Signed out
   paper_correction: Paper corrections
   remove_candidate_from_list: Removed candidate from list
   set_finished: Set finished state

--- a/locales/en/candidate_list.yml
+++ b/locales/en/candidate_list.yml
@@ -55,6 +55,7 @@ import_errors:
   invalid_headers: Use the same column names as in the exported CSV file.
   missing_file: Please select a CSV file to import.
   parse_error: "The candidate on line {} could not be imported. Please check field '{}': {}"
+  too_many_errors: "The file contains too many errors. Only the first {} are shown here; fix those and try again."
   upload_failed: Your file could not be uploaded. Please try again.
 import_export:
   export_title: Export

--- a/locales/nl/audit_log.yml
+++ b/locales/nl/audit_log.yml
@@ -59,6 +59,8 @@ event:
   hide_download_warning: Download\u00ADwaarschuwing gesloten
   import: Politieke groepering geïmporteerd
   import_csv: CSV geïmporteerd
+  login: Ingelogd
+  logout: Uitgelogd
   paper_correction: Papieren correcties
   remove_candidate_from_list: Kandidaat van lijst verwijderd
   set_finished: Afgerond gezet

--- a/locales/nl/candidate_list.yml
+++ b/locales/nl/candidate_list.yml
@@ -55,6 +55,7 @@ import_errors:
   invalid_headers: Gebruik dezelfde kolomnamen als in het geëxporteerde CSV-bestand.
   missing_file: Selecteer een CSV-bestand om te importeren.
   parse_error: "De kandidaat op regel {} kon niet worden geïmporteerd. Controleer veld '{}': {}"
+  too_many_errors: "Het bestand bevat te veel fouten. Alleen de eerste {} fouten worden hier getoond; herstel deze en probeer het opnieuw."
   upload_failed: Het bestand kon niet worden geüpload. Probeer het opnieuw.
 import_export:
   export_title: Exporteren

--- a/src/app/auth.rs
+++ b/src/app/auth.rs
@@ -7,8 +7,10 @@ use axum::{
 };
 use axum_extra::extract::CookieJar;
 
+use tracing::{error, info, warn};
+
 use crate::{
-    AppError, AppState, Locale, Session, StreamId,
+    AppError, AppState, Locale, PgEvent, PgStore, Session, StreamId,
     auth::session_extractor::{
         SESSION_COOKIE_NAME, build_removal_cookie, build_session_cookie, user_agent_hash,
     },
@@ -32,9 +34,28 @@ impl AppState {
         else {
             return Ok(false);
         };
-        self.store_for_stream(stream_id, election, false).await?;
+        let store = self.store_for_stream(stream_id, election, false).await?;
+        PgStore::own(store).update(PgEvent::Login).await?;
         session.set_current_election(election);
         Ok(true)
+    }
+
+    /// Record `event` on the session's stream, if it has one. Without an election
+    /// there is no partition to write to, and the log is the only record.
+    async fn record_on_session_stream(&self, session: &Session, event: PgEvent) {
+        let (Some(stream_id), Some(election)) = (session.stream_id, session.current_election)
+        else {
+            return;
+        };
+
+        let recorded = match self.store_for_stream(stream_id, election, false).await {
+            Ok(store) => PgStore::own(store).update(event).await,
+            Err(err) => Err(err),
+        };
+
+        if let Err(err) = recorded {
+            error!("failed to record session event on stream: {err}");
+        }
     }
 
     /// Remove the current session (if any) from the store and return a jar with
@@ -79,6 +100,13 @@ impl AuthState for AppState {
         self.sessions.cleanup_expired().await;
         self.sessions.insert(session.clone()).await;
 
+        info!(
+            event = "auth.login",
+            stream_id = %stream_id,
+            scope = session.scope.as_str(),
+            "user authenticated"
+        );
+
         (
             jar.add(build_session_cookie(&session)),
             Redirect::to(&redirect_to),
@@ -90,11 +118,20 @@ impl AuthState for AppState {
         // Drop the session (if any) and always clear the cookie; `Some` means
         // a session was active.
         let name_id = match jar.get(SESSION_COOKIE_NAME).map(|c| c.value().to_string()) {
-            Some(token) => self
-                .sessions
-                .remove(&token)
-                .await
-                .map(|session| session.saml_name_id),
+            Some(token) => match self.sessions.remove(&token).await {
+                Some(session) => {
+                    self.record_on_session_stream(&session, PgEvent::Logout)
+                        .await;
+                    info!(
+                        event = "auth.logout",
+                        stream_id = ?session.stream_id,
+                        scope = session.scope.as_str(),
+                        "user signed out"
+                    );
+                    Some(session.saml_name_id)
+                }
+                None => None,
+            },
             None => None,
         };
         (jar.remove(build_removal_cookie()), name_id)
@@ -107,10 +144,17 @@ impl AuthState for AppState {
         headers: &HeaderMap,
     ) -> Response {
         // TVS L10: end any existing local session before showing the page, so a
-        // failed re-authentication never leaves a stale session behind. The
-        // auth-service already logged the technical detail.
+        // failed re-authentication never leaves a stale session behind.
         let jar = self.clear_session_cookie(jar).await;
         let locale = Locale::from_headers(headers);
+
+        // No session and no stream, so the log is the only place this can land.
+        warn!(
+            event = "auth.failed",
+            reason = ?failure,
+            "authentication failed"
+        );
+
         (jar, auth_failure_response(failure, locale)).into_response()
     }
 

--- a/src/app/router.rs
+++ b/src/app/router.rs
@@ -55,10 +55,13 @@ pub fn create(state: AppState) -> Router<AppState> {
     // These routes need a session but NOT store middleware: select-election runs
     // before a stream_id is chosen, and /language must stay reachable for CSB
     // (committee) sessions that store_middleware redirects off app routes.
-    // The session middleware also verifies the CSRF token of every mutating
+    // `bag::router()` joins them: scanning the embedded BAG database is too
+    // expensive to expose anonymously, and it is only called from a logged-in
+    // form. The session middleware also verifies the CSRF token of every mutating
     // request (see `auth::csrf_guard`), so no handler can forget the check.
     let app_router = app_router
         .merge(common::session_only_router())
+        .merge(bag::router())
         .merge(csb_router)
         .layer(middleware::from_fn_with_state(
             state.clone(),
@@ -72,7 +75,6 @@ pub fn create(state: AppState) -> Router<AppState> {
     let router = app_router;
 
     let router = router
-        .merge(bag::router())
         .merge(auth_service::router())
         .merge(common::public_router());
 
@@ -137,19 +139,43 @@ fn app_feature_router() -> Router<AppState> {
         .merge(substitute_list_submitters::router())
 }
 
+/// Deny every powerful browser feature; the app uses none. Unknown directives
+/// are ignored, so naming retired and proposed features costs nothing.
+const PERMISSIONS_POLICY: &str = concat!(
+    "accelerometer=(), ambient-light-sensor=(), attribution-reporting=(), autoplay=(), ",
+    "battery=(), bluetooth=(), browsing-topics=(), camera=(), captured-surface-control=(), ",
+    "clipboard-read=(), clipboard-write=(), compute-pressure=(), deferred-fetch=(), ",
+    "deferred-fetch-minimal=(), digital-credentials-get=(), display-capture=(), ",
+    "document-domain=(), encrypted-media=(), fullscreen=(), gamepad=(), geolocation=(), ",
+    "gyroscope=(), hid=(), identity-credentials-get=(), idle-detection=(), interest-cohort=(), ",
+    "join-ad-interest-group=(), keyboard-map=(), local-fonts=(), magnetometer=(), microphone=(), ",
+    "midi=(), otp-credentials=(), payment=(), picture-in-picture=(), private-aggregation=(), ",
+    "private-state-token-issuance=(), private-state-token-redemption=(), ",
+    "publickey-credentials-create=(), publickey-credentials-get=(), run-ad-auction=(), ",
+    "screen-wake-lock=(), serial=(), speaker-selection=(), storage-access=(), sync-xhr=(), ",
+    "unload=(), usb=(), web-share=(), window-management=(), xr-spatial-tracking=()",
+);
+
+/// Fetch directives `default-src 'none'` already covers are spelled out anyway,
+/// so a change to a browser's fallback chain cannot widen the policy. Trusted
+/// Types is enforced because the bundle assigns to no injection sink.
+const CONTENT_SECURITY_POLICY: &str = concat!(
+    "default-src 'none'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'; ",
+    "script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; connect-src 'self'; ",
+    "object-src 'none'; media-src 'none'; frame-src 'none'; child-src 'none'; ",
+    "worker-src 'none'; manifest-src 'none'; ",
+    "require-trusted-types-for 'script'; trusted-types 'none'",
+);
+
 /// Static security response headers shared by every response. HSTS is added
 /// separately on the TLS listener (see `core::server`), only over https.
 fn apply_security_headers(mut router: Router<AppState>) -> Router<AppState> {
-    // Deny all powerful browser features by default; the app uses none.
-    const PERMISSIONS_POLICY: &str = "accelerometer=(), autoplay=(), camera=(), display-capture=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(), usb=(), xr-spatial-tracking=()";
-
-    let headers: [(HeaderName, &'static str); 7] = [
-        (
-            header::CONTENT_SECURITY_POLICY,
-            "default-src 'none'; base-uri 'none'; connect-src 'self'; form-action 'self'; script-src 'self'; style-src 'self'; font-src 'self'; img-src 'self'; frame-ancestors 'none';",
-        ),
+    let headers: [(HeaderName, &'static str); 10] = [
+        (header::CONTENT_SECURITY_POLICY, CONTENT_SECURITY_POLICY),
         (header::X_FRAME_OPTIONS, "DENY"),
         (header::X_CONTENT_TYPE_OPTIONS, "nosniff"),
+        // Not `no-referrer`: the language switch and the download-warning
+        // dismissal navigate back to the referring page.
         (header::REFERRER_POLICY, "same-origin"),
         (
             HeaderName::from_static("cross-origin-opener-policy"),
@@ -159,6 +185,17 @@ fn apply_security_headers(mut router: Router<AppState>) -> Router<AppState> {
             HeaderName::from_static("cross-origin-resource-policy"),
             "same-origin",
         ),
+        // Every subresource is same-origin, so requiring an opt-in from
+        // cross-origin ones costs nothing.
+        (
+            HeaderName::from_static("cross-origin-embedder-policy"),
+            "require-corp",
+        ),
+        (
+            HeaderName::from_static("x-permitted-cross-domain-policies"),
+            "none",
+        ),
+        (HeaderName::from_static("origin-agent-cluster"), "?1"),
         (
             HeaderName::from_static("permissions-policy"),
             PERMISSIONS_POLICY,
@@ -166,7 +203,8 @@ fn apply_security_headers(mut router: Router<AppState>) -> Router<AppState> {
     ];
 
     for (name, value) in headers {
-        router = router.layer(SetResponseHeaderLayer::if_not_present(
+        // `overriding`, not `if_not_present`: no handler may weaken these.
+        router = router.layer(SetResponseHeaderLayer::overriding(
             name,
             HeaderValue::from_static(value),
         ));
@@ -174,9 +212,23 @@ fn apply_security_headers(mut router: Router<AppState>) -> Router<AppState> {
     router
 }
 
+/// `Cache-Control: no-store` for every dynamic response: pages carry personal
+/// data and must reach neither a shared cache nor a browser's disk cache.
+/// `if_not_present`, so the download handlers keep their own value.
+fn apply_no_store(router: Router<AppState>) -> Router<AppState> {
+    router.layer(SetResponseHeaderLayer::if_not_present(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("no-store"),
+    ))
+}
+
 /// Mount the cache-busted `/static` asset routes: served from the embedded
 /// bundle in release builds, proxied to the dev asset server otherwise.
+///
+/// [`apply_no_store`] runs first, so these cache-busted assets stay cacheable
+/// while every page above them does not.
 fn mount_static_assets(router: Router<AppState>) -> Router<AppState> {
+    let router = apply_no_store(router);
     let code = crate::filters::cache_buster();
     let index_js = format!("/{code}-index.js");
     let index_css = format!("/{code}-index.css");
@@ -292,16 +344,148 @@ mod tests {
             let response = app.clone().oneshot(request).await.expect("response");
 
             for name in [
-                header::CONTENT_SECURITY_POLICY,
-                header::X_FRAME_OPTIONS,
-                header::X_CONTENT_TYPE_OPTIONS,
+                "content-security-policy",
+                "x-frame-options",
+                "x-content-type-options",
+                "referrer-policy",
+                "cross-origin-opener-policy",
+                "cross-origin-resource-policy",
+                "cross-origin-embedder-policy",
+                "x-permitted-cross-domain-policies",
+                "origin-agent-cluster",
+                "permissions-policy",
             ] {
                 assert!(
-                    response.headers().contains_key(&name),
+                    response.headers().contains_key(name),
                     "{uri} response must carry {name}"
                 );
             }
         }
+    }
+
+    /// Pins the values of the headers that are easy to weaken by accident: the
+    /// CSP must stay closed by default with no inline escape hatch, and the
+    /// cross-origin trio must stay at its strictest setting.
+    #[tokio::test]
+    async fn security_header_values_stay_strict() {
+        let state = AppState::new_for_tests().await;
+        let app: Router = create(state.clone()).with_state(state.clone());
+
+        let request = Request::builder()
+            .uri("/login")
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(request).await.expect("response");
+        let headers = response.headers();
+
+        let csp = headers
+            .get(header::CONTENT_SECURITY_POLICY)
+            .expect("csp")
+            .to_str()
+            .unwrap();
+        for directive in [
+            "default-src 'none'",
+            "base-uri 'none'",
+            "form-action 'self'",
+            "frame-ancestors 'none'",
+            "object-src 'none'",
+            "require-trusted-types-for 'script'",
+        ] {
+            assert!(
+                csp.contains(directive),
+                "CSP must keep `{directive}`: {csp}"
+            );
+        }
+        assert!(
+            !csp.contains("unsafe-inline") && !csp.contains("unsafe-eval"),
+            "CSP must not allow inline or eval: {csp}"
+        );
+
+        for (name, value) in [
+            ("cross-origin-opener-policy", "same-origin"),
+            ("cross-origin-resource-policy", "same-origin"),
+            ("cross-origin-embedder-policy", "require-corp"),
+            ("x-permitted-cross-domain-policies", "none"),
+            ("origin-agent-cluster", "?1"),
+            ("x-frame-options", "DENY"),
+            ("x-content-type-options", "nosniff"),
+        ] {
+            assert_eq!(headers.get(name).unwrap(), value, "{name}");
+        }
+
+        // A missing feature name is a policy that silently allows it, so keep a
+        // sample of the less obvious ones covered.
+        let permissions = headers
+            .get("permissions-policy")
+            .expect("permissions policy")
+            .to_str()
+            .unwrap();
+        for feature in [
+            "browsing-topics=()",
+            "camera=()",
+            "clipboard-read=()",
+            "document-domain=()",
+            "geolocation=()",
+            "microphone=()",
+            "storage-access=()",
+        ] {
+            assert!(
+                permissions.contains(feature),
+                "Permissions-Policy must deny `{feature}`: {permissions}"
+            );
+        }
+    }
+
+    /// Pages hold personal data, so no cache may keep them; the cache-busted
+    /// asset bundle is mounted outside that layer and stays cacheable.
+    #[tokio::test]
+    async fn dynamic_responses_are_not_stored_but_static_assets_stay_cacheable() {
+        let state = AppState::new_for_tests().await;
+        let app: Router = create(state.clone()).with_state(state.clone());
+
+        for uri in ["/login", "/", "/missing"] {
+            let request = Request::builder().uri(uri).body(Body::empty()).unwrap();
+            let response = app.clone().oneshot(request).await.expect("response");
+
+            assert_eq!(
+                response.headers().get(header::CACHE_CONTROL).unwrap(),
+                "no-store",
+                "{uri} must not be stored by any cache"
+            );
+        }
+
+        let request = Request::builder()
+            .uri("/static/index.js")
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(request).await.expect("response");
+        assert_ne!(
+            response
+                .headers()
+                .get(header::CACHE_CONTROL)
+                .map(|v| v.to_str().unwrap().to_string()),
+            Some("no-store".to_string()),
+            "cache-busted assets must stay cacheable"
+        );
+    }
+
+    /// Signing out must also clear what the session left in the browser.
+    #[tokio::test]
+    async fn logged_out_page_clears_site_data() {
+        let state = AppState::new_for_tests().await;
+        let app: Router = create(state.clone()).with_state(state.clone());
+
+        let request = Request::builder()
+            .uri("/logged-out")
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(request).await.expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get("clear-site-data").unwrap(),
+            "\"cache\", \"storage\""
+        );
     }
 
     /// The load balancer has no `x-eks-key`, so its probe must answer from
@@ -384,6 +568,26 @@ mod tests {
         let response = app.oneshot(request).await.expect("response");
 
         assert_ne!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    /// The BAG address lookup is expensive to answer, so it must sit behind the
+    /// session middleware rather than being reachable anonymously.
+    #[tokio::test]
+    async fn bag_lookup_requires_a_session() {
+        let state = AppState::new_for_tests().await;
+        let app: Router = create(state.clone()).with_state(state.clone());
+
+        for uri in ["/lookup?pc=1234AB&n=1", "/suggest?wp=Amsterdam"] {
+            let request = Request::builder().uri(uri).body(Body::empty()).unwrap();
+            let response = app.clone().oneshot(request).await.expect("response");
+
+            assert_eq!(
+                response.status(),
+                StatusCode::SEE_OTHER,
+                "{uri} must not answer without a session"
+            );
+            assert_eq!(response.headers().get(header::LOCATION).unwrap(), "/login");
+        }
     }
 
     /// robots.txt and security.txt must answer requests without a session

--- a/src/auth/session_db.rs
+++ b/src/auth/session_db.rs
@@ -107,6 +107,42 @@ fn session_from_row(row: SessionRow) -> Result<Session, AppError> {
     })
 }
 
+/// Write the mutable fields of an existing session row. Like [`upsert`] but a
+/// plain UPDATE, so it never re-creates a row a concurrent logout deleted.
+/// `created_at`, `user_agent_hash` and `saml_name_id` are fixed at login.
+pub async fn update(pool: &sqlx::PgPool, session: &Session) -> Result<(), AppError> {
+    let current_election_json = session
+        .current_election
+        .map(serde_json::to_value)
+        .transpose()?;
+
+    sqlx::query(
+        r#"
+        UPDATE sessions SET
+            stream_id = $2,
+            paper_correction_stream_id = $3,
+            current_election = $4,
+            locale = $5,
+            last_activity = $6,
+            scope = $7,
+            csrf_token = $8
+        WHERE token = $1
+        "#,
+    )
+    .bind(session.token_hash())
+    .bind(session.stream_id.map(|s| s.uuid()))
+    .bind(session.paper_correction_stream_id.map(|s| s.uuid()))
+    .bind(current_election_json)
+    .bind(session.locale.as_str())
+    .bind(session.last_activity)
+    .bind(session.scope.as_str())
+    .bind(&session.csrf_token().0)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
 /// Refresh `last_activity` of an existing session row. A conditional UPDATE
 /// (not an upsert), so it never re-creates a row a concurrent logout deleted.
 pub async fn touch(

--- a/src/auth/session_store.rs
+++ b/src/auth/session_store.rs
@@ -107,6 +107,32 @@ impl SessionStore {
         }
     }
 
+    /// Persists changes to a stored session. Unlike [`Self::insert`] this never
+    /// re-creates the entry, so an in-flight request holding a clone cannot undo
+    /// a concurrent logout. Use [`Self::insert`] only for a new session.
+    pub async fn update(&self, session: &Session) {
+        match self {
+            SessionStore::InMemory(inner) => {
+                if let Some(existing) = inner.write().get_mut(session.token_hash()) {
+                    // Mutable fields only, mirroring the database backend.
+                    existing.csrf_token = session.csrf_token.clone();
+                    existing.last_activity = session.last_activity;
+                    existing.stream_id = session.stream_id;
+                    existing.paper_correction_stream_id = session.paper_correction_stream_id;
+                    existing.scope = session.scope;
+                    existing.current_election = session.current_election;
+                    existing.locale = session.locale;
+                }
+            }
+            #[cfg(feature = "database")]
+            SessionStore::Database(pool) => {
+                if let Err(err) = session_db::update(pool, session).await {
+                    error!("failed to update session: {err}");
+                }
+            }
+        }
+    }
+
     /// Refreshes `last_activity` of an existing session. Unlike [`Self::insert`]
     /// this never re-creates the row, so a concurrent logout stays terminal.
     pub async fn touch(&self, session: &Session) {
@@ -128,6 +154,8 @@ impl SessionStore {
     }
 
     /// Removes a session by its token. Returns the removed session, if any.
+    /// A failed delete is logged: a session that outlives the request that ended
+    /// it must be visible somewhere.
     pub async fn remove(&self, token: &str) -> Option<Session> {
         let token_hash = hash_token(token);
         match self {
@@ -135,7 +163,9 @@ impl SessionStore {
             #[cfg(feature = "database")]
             SessionStore::Database(pool) => {
                 let session = session_db::load(pool, &token_hash).await.ok().flatten();
-                let _ = session_db::delete(pool, &token_hash).await;
+                if let Err(err) = session_db::delete(pool, &token_hash).await {
+                    error!("failed to remove session, it stays valid until it expires: {err}");
+                }
                 session
             }
         }
@@ -179,7 +209,9 @@ impl SessionStore {
             }
             #[cfg(feature = "database")]
             SessionStore::Database(pool) => {
-                let _ = session_db::delete(pool, token_hash).await;
+                if let Err(err) = session_db::delete(pool, token_hash).await {
+                    error!("failed to drop expired session: {err}");
+                }
             }
         }
     }
@@ -250,6 +282,52 @@ mod tests {
         store.remove(&token).await;
         store.touch(&session).await;
         assert!(store.get(&token).await.expect("load").is_none());
+    }
+
+    /// `update` writes a session's mutable fields but, like `touch`, never
+    /// re-creates a removed one: a request that still holds a clone of a
+    /// logged-out session cannot bring it back.
+    #[tokio::test]
+    async fn update_persists_changes_without_resurrecting_a_removed_session() {
+        let store = SessionStore::default();
+        let mut session = Session::new_test();
+        let token = session.token_string();
+        store.insert(session.clone()).await;
+
+        let old_csrf = session.csrf_token().to_string();
+        session.rotate_csrf_token();
+        session.set_current_election(crate::ElectionConfig::EK27);
+        store.update(&session).await;
+
+        let updated = store.get(&token).await.expect("load").expect("present");
+        assert_eq!(updated.current_election, Some(crate::ElectionConfig::EK27));
+        assert!(!updated.csrf_matches(&old_csrf));
+
+        store.remove(&token).await;
+        store.update(&session).await;
+        assert!(store.get(&token).await.expect("load").is_none());
+    }
+
+    /// The login-time facts of a session are not writable after the fact.
+    #[tokio::test]
+    async fn update_leaves_login_time_fields_alone() {
+        let store = SessionStore::default();
+        let mut session = Session::new_test();
+        session.saml_name_id = "nid-1".to_string();
+        session.set_user_agent_hash("ua-hash".to_string());
+        let token = session.token_string();
+        let created_at = session.created_at;
+        store.insert(session.clone()).await;
+
+        session.created_at = created_at + Duration::hours(1);
+        session.saml_name_id = "attacker".to_string();
+        session.set_user_agent_hash("other-ua".to_string());
+        store.update(&session).await;
+
+        let stored = store.get(&token).await.expect("load").expect("present");
+        assert_eq!(stored.created_at, created_at);
+        assert_eq!(stored.saml_name_id, "nid-1");
+        assert_eq!(stored.user_agent_hash.as_deref(), Some("ua-hash"));
     }
 
     /// Removes expired sessions on lookup.
@@ -346,11 +424,23 @@ mod tests {
             reloaded.created_at,
         );
 
+        // `update` writes the mutable fields and leaves the login-time ones.
+        let mut changed = reloaded.clone();
+        changed.set_current_election(crate::ElectionConfig::EK27);
+        changed.rotate_csrf_token();
+        changed.saml_name_id = "attacker".to_string();
+        store.update(&changed).await;
+        let updated = store.get(&token).await?.expect("still present");
+        assert_eq!(updated.current_election, Some(crate::ElectionConfig::EK27));
+        assert!(updated.csrf_matches(&changed.csrf_token().0));
+        assert_eq!(updated.saml_name_id, "nid-1");
+
         store.remove(&token).await;
         assert!(store.get(&token).await?.is_none());
 
-        // A touch after logout must not resurrect the session row.
+        // A touch or an update after logout must not resurrect the session row.
         store.touch(&reloaded).await;
+        store.update(&reloaded).await;
         assert!(store.get(&token).await?.is_none());
         Ok(())
     }

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -92,6 +92,25 @@ where
     }
 }
 
+/// Secret key material from the environment, refusing a blank value.
+///
+/// `env::var` returns `Ok("")` for a variable set to nothing, which HKDF would
+/// otherwise accept as a key. Refuse to boot instead.
+fn get_secret_with<F>(name: &'static str, lookup: &mut F) -> Result<SecretString, AppError>
+where
+    F: FnMut(&'static str) -> Result<String, env::VarError>,
+{
+    let value = get_env_with(name, lookup)?;
+
+    if value.trim().is_empty() {
+        return Err(AppError::ConfigLoadError(format!(
+            "{name} is set but empty; it must hold secret key material"
+        )));
+    }
+
+    Ok(SecretString::from(value))
+}
+
 /// Offline sanity check; the credentials are bound to their directory, so a
 /// staging account can never be deployed against production (or vice versa).
 fn check_account_credentials(credentials: &str, directory_url: &str) -> Result<(), AppError> {
@@ -174,9 +193,8 @@ impl Config {
         F: FnMut(&'static str) -> Result<String, env::VarError>,
     {
         let storage_url = get_env_with("STORAGE_URL", &mut lookup)?;
-        let id_derivation_key = get_env_with("ID_DERIVATION_KEY", &mut lookup)?;
-
-        let master_encryption_key = get_env_with("MASTER_ENCRYPTION_KEY", &mut lookup)?;
+        let id_derivation_key = get_secret_with("ID_DERIVATION_KEY", &mut lookup)?;
+        let master_encryption_key = get_secret_with("MASTER_ENCRYPTION_KEY", &mut lookup)?;
 
         let tls = tls_from_env(&mut lookup)?;
         let acme = acme_from_env(&mut lookup, tls.is_some())?;
@@ -197,8 +215,8 @@ impl Config {
 
         Ok(Self {
             storage_url: SecretString::from(storage_url),
-            id_derivation_key: SecretString::from(id_derivation_key),
-            master_encryption_key: SecretString::from(master_encryption_key),
+            id_derivation_key,
+            master_encryption_key,
             tls,
             acme,
             server_name,
@@ -259,6 +277,51 @@ mod tests {
         let config = Config::from_env_with(lookup).expect("config");
 
         assert_eq!(config.storage_url.expose_secret(), "memory://test");
+    }
+
+    /// A secret that is set but blank must stop startup, not be accepted as key
+    /// material. Whitespace counts as blank.
+    #[test]
+    fn from_env_rejects_blank_secrets() {
+        for (name, blank) in [
+            ("ID_DERIVATION_KEY", ""),
+            ("ID_DERIVATION_KEY", "   "),
+            ("MASTER_ENCRYPTION_KEY", ""),
+            ("MASTER_ENCRYPTION_KEY", "\t\n"),
+        ] {
+            let map = HashMap::from([
+                ("STORAGE_URL", "memory://test"),
+                ("ID_DERIVATION_KEY", "id-derivation-key-123"),
+                ("MASTER_ENCRYPTION_KEY", "master-encryption-key-123"),
+                (name, blank),
+            ]);
+            let lookup = lookup_from(&map);
+
+            let err = Config::from_env_with(lookup).expect_err("blank secret must be rejected");
+
+            assert!(
+                matches!(err, AppError::ConfigLoadError(ref message) if message.contains(name)),
+                "{name}={blank:?} gave {err:?}"
+            );
+        }
+    }
+
+    /// A secret that holds a value still loads.
+    #[test]
+    fn from_env_accepts_non_blank_secrets() {
+        let map = HashMap::from([
+            ("STORAGE_URL", "memory://test"),
+            ("ID_DERIVATION_KEY", "id-derivation-key-123"),
+            ("MASTER_ENCRYPTION_KEY", "master-encryption-key-123"),
+        ]);
+        let lookup = lookup_from(&map);
+
+        let config = Config::from_env_with(lookup).expect("config");
+
+        assert_eq!(
+            config.master_encryption_key.expose_secret(),
+            "master-encryption-key-123"
+        );
     }
 
     #[cfg(feature = "dev-features")]

--- a/src/core/csv.rs
+++ b/src/core/csv.rs
@@ -10,6 +10,11 @@ use serde::{Serialize, de::DeserializeOwned};
 
 use crate::{AppError, Locale, OptionStringExt, trans, utils::no_cache_headers};
 
+/// Most errors reported for one upload. Every failing row becomes a translated
+/// message held in memory and rendered, so a file of nothing but broken rows
+/// would amplify a few megabytes into hundreds.
+const MAX_ERRORS: usize = 50;
+
 pub enum CsvError {
     FormatError {
         line_number: usize,
@@ -20,6 +25,8 @@ pub enum CsvError {
         field_name: String,
         message: String,
     },
+    /// Parsing stopped after [`MAX_ERRORS`]; more rows may be wrong.
+    TooManyErrors { reported: usize },
 }
 
 impl Display for CsvError {
@@ -50,6 +57,11 @@ impl CsvError {
                 line_number,
                 translated_field_name(field_name, locale),
                 message
+            ),
+            CsvError::TooManyErrors { reported } => trans!(
+                "candidate_list.import_errors.too_many_errors",
+                locale,
+                reported
             ),
         }
     }
@@ -283,20 +295,30 @@ fn detect_delimiter(data: &[u8]) -> u8 {
 }
 
 impl<T: DeserializeOwned> Csv<T> {
+    /// Deserialize every row, or report what went wrong. Reading stops at
+    /// [`MAX_ERRORS`] failures and says so.
     pub fn from_bytes(data: &[u8]) -> Result<Vec<T>, Vec<CsvError>> {
         let mut records = vec![];
         let mut errors = vec![];
 
-        reader_from_bytes(data)
-            .deserialize::<T>()
-            .enumerate()
-            .for_each(|(index, res)| match res {
+        for (index, res) in reader_from_bytes(data).deserialize::<T>().enumerate() {
+            match res {
                 Ok(record) => records.push(record),
-                Err(error) => errors.push(CsvError::FormatError {
-                    line_number: index + 2,
-                    message: error.into_kind(),
-                }),
-            });
+                Err(error) => {
+                    if errors.len() == MAX_ERRORS {
+                        errors.push(CsvError::TooManyErrors {
+                            reported: MAX_ERRORS,
+                        });
+                        break;
+                    }
+                    errors.push(CsvError::FormatError {
+                        line_number: index + 2,
+                        message: error.into_kind(),
+                    });
+                }
+            }
+        }
+
         if errors.is_empty() {
             Ok(records)
         } else {
@@ -477,6 +499,43 @@ mod tests {
                 voorletters: "H.".to_string(),
                 achternaam: "Jansen".to_string(),
             }]
+        );
+    }
+
+    /// A file that fails on every row reports at most `MAX_ERRORS` failures
+    /// plus the marker, however large it is, and stops parsing there.
+    #[test]
+    fn from_bytes_caps_the_error_list() {
+        let mut data = b"value\n".to_vec();
+        for _ in 0..(MAX_ERRORS * 20) {
+            data.extend_from_slice(b"abc\n");
+        }
+
+        let errors = Csv::<TestRecord>::from_bytes(&data).expect_err("every row is invalid");
+
+        assert_eq!(errors.len(), MAX_ERRORS + 1);
+        assert!(matches!(
+            errors.last(),
+            Some(CsvError::TooManyErrors { reported }) if *reported == MAX_ERRORS
+        ));
+        assert!(
+            errors[0..MAX_ERRORS]
+                .iter()
+                .all(|error| matches!(error, CsvError::FormatError { .. }))
+        );
+    }
+
+    /// A file with fewer failures than the cap gets no truncation marker.
+    #[test]
+    fn from_bytes_reports_every_error_below_the_cap() {
+        let errors =
+            Csv::<TestRecord>::from_bytes(b"value\nabc\n1\ndef\n").expect_err("two invalid rows");
+
+        assert_eq!(errors.len(), 2);
+        assert!(
+            errors
+                .iter()
+                .all(|error| matches!(error, CsvError::FormatError { .. }))
         );
     }
 

--- a/src/core/server.rs
+++ b/src/core/server.rs
@@ -78,7 +78,8 @@ mod tls {
         // HSTS: served only over TLS, so the header is meaningful here.
         // 1 year + includeSubDomains matches NCSC HTTPS guidance; preload is
         // intentionally omitted (requires explicit registration).
-        let router = router.layer(SetResponseHeaderLayer::if_not_present(
+        // `overriding`, so no handler can hand out a shorter max-age.
+        let router = router.layer(SetResponseHeaderLayer::overriding(
             header::STRICT_TRANSPORT_SECURITY,
             HeaderValue::from_static("max-age=31536000; includeSubDomains"),
         ));

--- a/src/csb/examination/pages/paper_corrections.rs
+++ b/src/csb/examination/pages/paper_corrections.rs
@@ -22,7 +22,7 @@ pub async fn start_paper_corrections<S: AppRequestState>(
     // Invalidate forms rendered before the switch, so a stale tab cannot
     // submit changes against this stream's data.
     session.rotate_csrf_token();
-    state.sessions().insert(session).await;
+    state.sessions().update(&session).await;
 
     Ok(Redirect::to(&PgIndexPath.to_string()).into_response())
 }
@@ -35,7 +35,7 @@ pub async fn stop_paper_corrections<S: AppRequestState>(
 ) -> Result<Response, AppError> {
     session.paper_correction_stream_id = None;
     session.rotate_csrf_token();
-    state.sessions().insert(session).await;
+    state.sessions().update(&session).await;
 
     Ok(Redirect::to(
         &CsbPoliticalGroupPath {
@@ -82,6 +82,9 @@ mod tests {
         let session = Session::new_test();
         let token = session.token_string();
         let old_csrf = session.csrf_token().to_string();
+        // The session middleware only hands a handler a session that is in the
+        // store; the handler updates it and never re-creates it.
+        state.sessions.insert(session.clone()).await;
 
         let response = start_paper_corrections(
             CsbPaperCorrectionsStartPath { stream_id },
@@ -113,6 +116,7 @@ mod tests {
         session.paper_correction_stream_id = Some(stream_id);
         let token = session.token_string();
         let old_csrf = session.csrf_token().to_string();
+        state.sessions.insert(session.clone()).await;
 
         let response = stop_paper_corrections(
             CsbPaperCorrectionsStopPath { stream_id },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,7 @@ pub(crate) use form::{Form, TokenValue};
 pub(crate) use store::{DbHealth, Event};
 pub(crate) use utils::{
     OptionAsStrExt, OptionStringExt, Overlay, QueryParamState, abbreviate_str, overlay_active,
-    pagination, redirect_success, success_alert_requested, transparent_string,
+    pagination, redirect_success, redirect_to_referer, success_alert_requested, transparent_string,
 };
 // Askama resolves custom filters from the enclosing module scope, so template
 // modules do `use crate::filters`.

--- a/src/pg/audit_log/event_info.rs
+++ b/src/pg/audit_log/event_info.rs
@@ -73,12 +73,12 @@ fn event_description(event: &PgEvent, locale: Locale) -> String {
             trans!("audit_log.event.delete_substitute_submitter", locale)
         }
         PgEvent::DeveloperLogin { .. } => trans!("audit_log.event.developer_login", locale),
+        PgEvent::Login => trans!("audit_log.event.login", locale),
+        PgEvent::Logout => trans!("audit_log.event.logout", locale),
         PgEvent::DownloadFile { .. } => trans!("audit_log.event.download_file", locale),
         PgEvent::HideDownloadWarning => trans!("audit_log.event.hide_download_warning", locale),
         PgEvent::ExportCsv { .. } => trans!("audit_log.event.export_csv", locale),
-        PgEvent::ImportCandidates { .. } => {
-            trans!("audit_log.event.import_csv", locale)
-        }
+        PgEvent::ImportCandidates { .. } => trans!("audit_log.event.import_csv", locale),
         PgEvent::Import { .. } => trans!("audit_log.event.import", locale),
     }
 }
@@ -128,6 +128,8 @@ fn event_details(event: &PgEvent) -> String {
         | PgEvent::DeleteNameAuthorisation(..)
         | PgEvent::DeleteSubstituteSubmitter { .. }
         | PgEvent::DeveloperLogin { .. }
+        | PgEvent::Login
+        | PgEvent::Logout
         | PgEvent::HideDownloadWarning => PgEvent::DEFAULT_DETAILS.to_string(),
     }
 }
@@ -169,6 +171,8 @@ impl PgEvent {
             }
             PgEvent::DownloadFile { .. }
             | PgEvent::HideDownloadWarning
+            | PgEvent::Login
+            | PgEvent::Logout
             | PgEvent::Import { .. } => String::new(),
         }
     }
@@ -238,6 +242,8 @@ impl Event for PgEvent {
             | PgEvent::UpdateSubstituteSubmitter(_)
             | PgEvent::DeleteSubstituteSubmitter { .. } => "substitute_submitter",
             PgEvent::DeveloperLogin { .. }
+            | PgEvent::Login
+            | PgEvent::Logout
             | PgEvent::DownloadFile { .. }
             | PgEvent::HideDownloadWarning
             | PgEvent::ExportCsv { .. }
@@ -271,6 +277,8 @@ impl Event for PgEvent {
             PgEvent::UpdateSubstituteSubmitter(_) => "update_substitute_submitter",
             PgEvent::DeleteSubstituteSubmitter { .. } => "delete_substitute_submitter",
             PgEvent::DeveloperLogin { .. } => "developer_login",
+            PgEvent::Login => "login",
+            PgEvent::Logout => "logout",
             PgEvent::DownloadFile { .. } => "download_file",
             PgEvent::HideDownloadWarning => "hide_download_warning",
             PgEvent::ExportCsv { .. } => "export_csv",

--- a/src/pg/audit_log/structs/event_payload.rs
+++ b/src/pg/audit_log/structs/event_payload.rs
@@ -107,6 +107,8 @@ fn entity_old_new(
         PgEvent::AddCandidateToCandidateList { .. }
         | PgEvent::RemoveCandidateFromCandidateList { .. }
         | PgEvent::DeveloperLogin { .. }
+        | PgEvent::Login
+        | PgEvent::Logout
         | PgEvent::HideDownloadWarning
         | PgEvent::Import { .. }
         | PgEvent::DownloadFile { .. }

--- a/src/pg/common/pages/auth.rs
+++ b/src/pg/common/pages/auth.rs
@@ -6,7 +6,7 @@ use askama::Template;
 use auth_service::{AuthFailure, AuthState, handle_logout};
 use axum::{
     extract::State,
-    http::HeaderMap,
+    http::{HeaderMap, HeaderName, HeaderValue},
     response::{IntoResponse, Response},
 };
 use axum_extra::extract::CookieJar;
@@ -76,14 +76,25 @@ pub async fn logout_submit<S: AppRequestState + AuthState>(
 
 /// GET `/logged-out`: post-logout confirmation page (TVS T7, also the SLO
 /// landing). Public: by definition there is no session left to show it with.
+///
+/// `Clear-Site-Data` drops what the session left on the client. `"cookies"` is
+/// left out: browsers widen it to the whole registrable domain, which would sign
+/// the user out of unrelated `kiesraad.nl` sites.
 pub async fn logged_out(_: LoggedOutPath, headers: HeaderMap) -> Response {
-    HtmlTemplate(
+    let mut response = HtmlTemplate(
         LoggedOutTemplate,
         LocaleValues {
             locale: Locale::from_headers(&headers),
         },
     )
-    .into_response()
+    .into_response();
+
+    response.headers_mut().insert(
+        HeaderName::from_static("clear-site-data"),
+        HeaderValue::from_static("\"cache\", \"storage\""),
+    );
+
+    response
 }
 
 /// Response page for a cancelled (T3), failed (L10), or unavailable auth attempt.
@@ -281,6 +292,54 @@ mod tests {
             .to_str()
             .unwrap();
         assert_eq!(location, PgIndexPath.to_string());
+    }
+
+    /// Signing in and out is recorded on the stream's audit log.
+    #[cfg(feature = "fixtures")]
+    #[tokio::test]
+    async fn login_and_logout_are_recorded_on_the_stream() {
+        use crate::{ElectionConfig, PgEvent, PgStore, store::StoreData};
+
+        let state = crate::AppState::new_for_tests().await;
+        let id_code = SecretString::from("999999990");
+        let stream_id = state.id_deriver().derive_stream_id(&id_code);
+        let store = PgStore::own(
+            state
+                .store_for_stream(stream_id, ElectionConfig::EK27, true)
+                .await
+                .unwrap(),
+        );
+
+        let response = state
+            .on_authenticated(
+                subject("999999990"),
+                "name-id-xyz".to_string(),
+                CookieJar::new(),
+                &HeaderMap::new(),
+            )
+            .await;
+        let cookie = response
+            .headers()
+            .get(header::SET_COOKIE)
+            .expect("session cookie")
+            .to_str()
+            .unwrap();
+        let token = Cookie::parse(cookie).unwrap().value().to_string();
+
+        let recorded = |store: &PgStore, want: fn(&PgEvent) -> bool| {
+            store.data.read().events().iter().any(|e| want(&e.payload))
+        };
+        assert!(
+            recorded(&store, |e| matches!(e, PgEvent::Login)),
+            "login must be recorded"
+        );
+
+        let _ = state.logout_session(jar_with_session_cookie(&token)).await;
+
+        assert!(
+            recorded(&store, |e| matches!(e, PgEvent::Logout)),
+            "logout must be recorded"
+        );
     }
 
     #[tokio::test]

--- a/src/pg/common/pages/hide_download_warning.rs
+++ b/src/pg/common/pages/hide_download_warning.rs
@@ -1,7 +1,11 @@
 use axum::response::Redirect;
 use axum_extra::{TypedHeader, headers};
 
-use crate::{PgEvent, PgStore, common::HideDownloadWarningPath};
+use crate::{
+    PgEvent, PgStore,
+    common::{HideDownloadWarningPath, PgIndexPath},
+    redirect_to_referer,
+};
 
 pub async fn hide_download_warning(
     _: HideDownloadWarningPath,
@@ -9,7 +13,10 @@ pub async fn hide_download_warning(
     store: PgStore,
 ) -> Result<Redirect, crate::AppError> {
     store.update(PgEvent::HideDownloadWarning).await?;
-    Ok(Redirect::to(&referer.to_string()))
+
+    // Back to the page the banner was dismissed on, never off-site (see
+    // [`redirect_to_referer`]).
+    Ok(redirect_to_referer(&referer, PgIndexPath))
 }
 
 #[cfg(test)]
@@ -81,11 +88,12 @@ mod tests {
 
         let response = app.oneshot(request).await.expect("response");
 
-        // we should be redirected and the warning should no longer show
+        // we should be redirected and the warning should no longer show. Only
+        // the referrer's path survives, so the redirect stays on this origin.
         assert_eq!(response.status(), StatusCode::SEE_OTHER);
         assert_eq!(
             response.headers().get(header::LOCATION).unwrap(),
-            "https://example.com/candidate-lists",
+            "/candidate-lists",
         );
         assert!(!store.should_show_download_warning());
     }

--- a/src/pg/common/pages/select_election.rs
+++ b/src/pg/common/pages/select_election.rs
@@ -33,7 +33,7 @@ pub async fn select_election<S: AppRequestState>(
         return Ok(Redirect::to(&PgIndexPath.to_string()).into_response());
     }
 
-    state.sessions().insert(session.clone()).await;
+    state.sessions().update(&session).await;
 
     let template = SelectElectionTemplate {
         elections: crate::ElectionConfig::type_options(),
@@ -85,7 +85,8 @@ pub async fn select_election_submit<S: AppRequestState>(
             crate::csb::import::fixture::import_csb_fixture(&state, election).await?;
         }
 
-        state.sessions().insert(session).await;
+        session.rotate_csrf_token();
+        state.sessions().update(&session).await;
 
         return Ok(Redirect::to(&CsbIndexPath {}.to_string()).into_response());
     }
@@ -100,7 +101,10 @@ pub async fn select_election_submit<S: AppRequestState>(
         .await?;
 
     session.set_current_election(election);
-    state.sessions().insert(session).await;
+    // Invalidate forms rendered before an election was picked, so a stale tab
+    // cannot submit against the election chosen here.
+    session.rotate_csrf_token();
+    state.sessions().update(&session).await;
 
     Ok(Redirect::to(&PgIndexPath.to_string()).into_response())
 }

--- a/src/pg/common/pages/switch_election.rs
+++ b/src/pg/common/pages/switch_election.rs
@@ -5,9 +5,10 @@ use axum::{
 };
 
 use crate::{
-    AnyLocale, AppError, AppRequestState, Context, ElectionConfig, HtmlTemplate, Province, Session,
-    WaterCouncil,
+    AnyLocale, AppError, AppRequestState, Context, ElectionConfig, HtmlTemplate, Province, Scope,
+    Session, WaterCouncil,
     common::{PgIndexPath, SwitchElectionForm},
+    csb::index::CsbIndexPath,
     filters,
 };
 
@@ -65,6 +66,14 @@ pub async fn switch_election_submit<S: AppRequestState>(
     mut session: Session,
     axum::Form(form): axum::Form<SwitchElectionForm>,
 ) -> Result<Response, AppError> {
+    // Committee sessions use CSB stores, not app stores; never create an
+    // `PgStore` in their `(stream_id, election)` partition. Mirrors the guard
+    // in `select_election_submit`, which this route can otherwise bypass while
+    // a committee session is in paper-corrections mode.
+    if session.scope == Scope::CentralElectoralCommittee {
+        return Ok(Redirect::to(&CsbIndexPath {}.to_string()).into_response());
+    }
+
     let Some(election) = form.into_election_config() else {
         return Ok(Redirect::to(&SwitchElectionPath.to_string()).into_response());
     };
@@ -82,7 +91,10 @@ pub async fn switch_election_submit<S: AppRequestState>(
     state.store_for_stream(stream_id, election, false).await?;
 
     session.set_current_election(election);
-    state.sessions().insert(session).await;
+    // Invalidate forms rendered for the previous election, so a stale tab
+    // cannot submit its data against the newly selected one.
+    session.rotate_csrf_token();
+    state.sessions().update(&session).await;
 
     Ok(Redirect::to(&PgIndexPath.to_string()).into_response())
 }

--- a/src/pg/common/pages/switch_locale.rs
+++ b/src/pg/common/pages/switch_locale.rs
@@ -1,4 +1,8 @@
-use crate::{AppRequestState, Locale, Session, common::SwitchLanguagePath};
+use crate::{
+    AppRequestState, Locale, Session,
+    common::{PgIndexPath, SwitchLanguagePath},
+    redirect_to_referer,
+};
 use axum::{extract::State, response::Redirect};
 use axum_extra::{TypedHeader, extract::Form, headers};
 use serde::Deserialize;
@@ -16,9 +20,11 @@ pub async fn switch_language<S: AppRequestState>(
     Form(form): Form<LanguageSwitch>,
 ) -> Redirect {
     session.locale = form.lang;
-    state.sessions().insert(session).await;
+    state.sessions().update(&session).await;
 
-    Redirect::to(&referer.to_string())
+    // Back to the page the switch was made on, never off-site (see
+    // [`redirect_to_referer`]).
+    redirect_to_referer(&referer, PgIndexPath)
 }
 
 #[cfg(test)]
@@ -67,10 +73,9 @@ mod tests {
         let response = app.oneshot(request).await.expect("response");
 
         assert_eq!(response.status(), StatusCode::SEE_OTHER);
-        assert_eq!(
-            response.headers().get(header::LOCATION).unwrap(),
-            "https://example.com/return"
-        );
+        // Only the referrer's path survives, so the redirect stays on this
+        // origin even when the header names another host.
+        assert_eq!(response.headers().get(header::LOCATION).unwrap(), "/return");
 
         let session = state
             .sessions

--- a/src/projection/pg_data/event.rs
+++ b/src/projection/pg_data/event.rs
@@ -75,6 +75,12 @@ pub enum PgEvent {
         stream_id: StreamId,
     },
 
+    /// The user authenticated via TVS / DigiD. Recorded only once the session
+    /// has an election, since that completes the stream's partition key.
+    Login,
+    /// The user signed out.
+    Logout,
+
     DownloadFile {
         file_name: String,
         download_path: String,

--- a/src/projection/pg_data/mod.rs
+++ b/src/projection/pg_data/mod.rs
@@ -84,6 +84,8 @@ impl StoreData for PgStoreData {
 
             // Only the serialized event is relevant for logging.
             PgEvent::DeveloperLogin { .. }
+            | PgEvent::Login
+            | PgEvent::Logout
             | PgEvent::DownloadFile { .. }
             | PgEvent::HideDownloadWarning
             | PgEvent::ExportCsv { .. }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -30,7 +30,7 @@ pub use option_string_ext::{OptionAsStrExt, OptionStringExt};
 pub use overlay::Overlay;
 pub use query_param_state::QueryParamState;
 pub use query_suffix::filter_query_suffix;
-pub use redirect::redirect_success;
+pub use redirect::{redirect_success, redirect_to_referer};
 pub use request_flags::{overlay_active, success_alert_requested};
 pub use sha256_hex::sha256_hex;
 pub use slugify_teletex::slugify_teletex;

--- a/src/utils/query_param_state.rs
+++ b/src/utils/query_param_state.rs
@@ -179,7 +179,7 @@ impl QueryParamState {
 /// Accept only local absolute paths as redirect targets: browsers resolve a
 /// leading `//` (or `/\`) as a protocol-relative URL to another host, and
 /// control characters could split the `Location` header.
-fn is_local_path(url: &str) -> bool {
+pub(crate) fn is_local_path(url: &str) -> bool {
     url.starts_with('/')
         && !url.starts_with("//")
         && !url.contains('\\')

--- a/src/utils/redirect.rs
+++ b/src/utils/redirect.rs
@@ -1,8 +1,11 @@
 //! Redirect helpers for common UI flows.
-use axum::response::{IntoResponse, Redirect, Response};
-use axum_extra::routing::TypedPath;
+use axum::{
+    http::Uri,
+    response::{IntoResponse, Redirect, Response},
+};
+use axum_extra::{headers, routing::TypedPath};
 
-use crate::QueryParamState;
+use crate::{QueryParamState, utils::query_param_state::is_local_path};
 
 /// Helper function to create a redirect response with a success alert query parameter.
 pub fn redirect_success(path: impl TypedPath) -> Response {
@@ -12,4 +15,91 @@ pub fn redirect_success(path: impl TypedPath) -> Response {
             .to_string(),
     )
     .into_response()
+}
+
+/// Redirect back to the page a form was submitted from, named by its `Referer`.
+///
+/// Only the referrer's path and query survive, and only as a safe local path: a
+/// `Referer` is client-chosen, so echoing it into `Location` unchecked is an open
+/// redirect. Anything else falls back to `default`.
+pub fn redirect_to_referer(
+    referer: &headers::Referer,
+    default: impl std::fmt::Display,
+) -> Redirect {
+    match local_path_from_referer(referer) {
+        Some(path) => Redirect::to(&path),
+        None => Redirect::to(&default.to_string()),
+    }
+}
+
+/// The referrer's path and query, if they form a safe local path.
+fn local_path_from_referer(referer: &headers::Referer) -> Option<String> {
+    let uri: Uri = referer.to_string().parse().ok()?;
+    let path = uri.path_and_query()?.as_str();
+
+    is_local_path(path).then(|| path.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::{HeaderValue, header::LOCATION};
+    use axum_extra::headers::{Header, Referer};
+
+    use super::*;
+
+    fn referer(value: &str) -> Referer {
+        let header = HeaderValue::from_str(value).expect("valid header value");
+        Referer::decode(&mut [&header].into_iter()).expect("valid referer")
+    }
+
+    fn location(redirect: Redirect) -> String {
+        redirect
+            .into_response()
+            .headers()
+            .get(LOCATION)
+            .expect("location header")
+            .to_str()
+            .expect("ascii location")
+            .to_string()
+    }
+
+    /// A same-origin referrer sends the user back to where they came from.
+    #[test]
+    fn keeps_path_and_query_of_a_local_referer() {
+        assert_eq!(
+            location(redirect_to_referer(
+                &referer("https://example.com/candidate-lists?highlight=1"),
+                "/fallback"
+            )),
+            "/candidate-lists?highlight=1"
+        );
+    }
+
+    /// Only the path survives, so a foreign host can never become the target.
+    #[test]
+    fn never_redirects_off_site() {
+        for evil in [
+            "https://evil.example",
+            "https://evil.example/",
+            "//evil.example/path",
+        ] {
+            let redirect = redirect_to_referer(&referer(evil), "/fallback");
+            assert!(
+                location(redirect).starts_with('/'),
+                "{evil:?} must stay on this origin"
+            );
+        }
+    }
+
+    /// A referrer that yields no local path falls back to the default target.
+    #[test]
+    fn falls_back_when_referer_has_no_local_path() {
+        for unusable in ["evil.example", "mailto:someone@example.com"] {
+            assert_eq!(
+                location(redirect_to_referer(&referer(unusable), "/fallback")),
+                "/fallback",
+                "{unusable:?} must fall back"
+            );
+        }
+    }
 }


### PR DESCRIPTION
Closes #1105

# [DOD](/docs/definition-of-done.md) checklist

## For PR maintainer

Perform these checks before marking the PR as ready:

- [x] I have linked the PR to at least one issue.
- [x] I assigned the PR to myself.
- [x] I have added a description how to test this PR (see "Review Instructions").
- [x] I have added documentation where necessary.

## For reviewer

- I have read all code changes.
- I have audited the code quality.
- I have tested the changes either or both:
  - locally
  - on the test environment (preferred)
- I have validated that the PR is functionally correct (use-cases, figma designs, etc.)

### Review instructions

- Response headers ([router.rs](vscode-webview://1tencqsiu7htofuo72ua1qeeojorva3r4jhhjhogs5l5ps0f65cp/src/app/router.rs)): stricter CSP (Trusted Types, all fetch directives spelled out), full Permissions-Policy denylist, COEP/X-Permitted-Cross-Domain-Policies/Origin-Agent-Cluster, overriding instead of if_not_present, Cache-Control: no-store on dynamic responses (static assets stay cacheable), Clear-Site-Data on /logged-out.
- Redirects ([redirect.rs](vscode-webview://1tencqsiu7htofuo72ua1qeeojorva3r4jhhjhogs5l5ps0f65cp/src/utils/redirect.rs)): new redirect_to_referer that keeps only a safe local path, closing the open redirect in the language switch and download-warning dismissal.
- Sessions ([session_store.rs](vscode-webview://1tencqsiu7htofuo72ua1qeeojorva3r4jhhjhogs5l5ps0f65cp/src/auth/session_store.rs), [session_db.rs](vscode-webview://1tencqsiu7htofuo72ua1qeeojorva3r4jhhjhogs5l5ps0f65cp/src/auth/session_db.rs), [auth.rs](vscode-webview://1tencqsiu7htofuo72ua1qeeojorva3r4jhhjhogs5l5ps0f65cp/src/app/auth.rs)): update() instead of insert() so handlers can't resurrect a dropped session, plus CSRF-token rotation on election select/switch.
- Routing/auth: BAG lookup moved behind session middleware; switch_election_submit guards against committee sessions; login/logout now recorded as audit events.
- CSV import ([csv.rs](vscode-webview://1tencqsiu7htofuo72ua1qeeojorva3r4jhhjhogs5l5ps0f65cp/src/core/csv.rs)): error list capped at 50 with a truncation message, so a file of broken rows can't amplify into hundreds of MB.